### PR TITLE
test/cypress/e2e: fix ResizeObserver loop completed with undelivered notifications error

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -105,7 +105,7 @@ export default defineComponent({
               color="white"
               outline
               round
-              data-cy="footer-top-button"
+              data-cy="footer-top-button-mobile"
               @click.prevent="scrollToTop"
             >
               <q-icon name="arrow_upward" size="18px" />

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -275,7 +275,11 @@ describe('Home page', () => {
       cy.dataCy('footer-top-button')
         .should('be.visible')
         .click()
-        .click(); // second click helps to overcome a ResizeObserver loop bug.
+        .click();
+        /**
+         * Second click helps to overcome a ResizeObserver loop completed
+         * with undelivered notifications error
+         */
       cy.window().its('scrollY').should('equal', 0);
     });
   });
@@ -539,7 +543,11 @@ describe('Home page', () => {
       cy.dataCy('footer-top-button-mobile')
         .should('be.visible')
         .click()
-        .click(); // second click helps to overcome a ResizeObserver loop bug.
+        .click();
+        /**
+         * Second click helps to overcome a ResizeObserver loop completed
+         * with undelivered notifications error
+         */
       cy.window().its('scrollY').should('equal', 0);
     });
 

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -272,9 +272,10 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
-      cy.window().scrollTo('bottom');
       cy.dataCy('footer-top-button')
-        .should('be.visible').click();
+        .should('be.visible')
+        .click()
+        .click(); // second click helps to overcome a ResizeObserver loop bug.
       cy.window().its('scrollY').should('equal', 0);
     });
   });
@@ -535,9 +536,10 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
-      cy.window().scrollTo('bottom');
       cy.dataCy('footer-top-button-mobile')
-        .should('be.visible').click();
+        .should('be.visible')
+        .click()
+        .click(); // second click helps to overcome a ResizeObserver loop bug.
       cy.window().its('scrollY').should('equal', 0);
     });
 

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -272,10 +272,9 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
+      cy.window().scrollTo('bottom');
       cy.dataCy('footer-top-button')
-        .should('be.visible')
-        .click()
-        .click(); // second click helps to overcome a ResizeObserver loop bug.
+        .should('be.visible').click();
       cy.window().its('scrollY').should('equal', 0);
     });
   });
@@ -536,10 +535,9 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
+      cy.window().scrollTo('bottom');
       cy.dataCy('footer-top-button-mobile')
-        .should('be.visible')
-        .click()
-        .click(); // second click helps to overcome a ResizeObserver loop bug.
+        .should('be.visible').click();
       cy.window().its('scrollY').should('equal', 0);
     });
 

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -272,8 +272,10 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
-      cy.dataCy('footer-top-button').first().should('be.visible').click();
-
+      cy.dataCy('footer-top-button')
+        .should('be.visible')
+        .click()
+        .click(); // second click helps to overcome a ResizeObserver loop bug.
       cy.window().its('scrollY').should('equal', 0);
     });
   });
@@ -534,8 +536,10 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
-      cy.dataCy('footer-top-button').last().should('be.visible').click();
-
+      cy.dataCy('footer-top-button-mobile')
+        .should('be.visible')
+        .click()
+        .click(); // second click helps to overcome a ResizeObserver loop bug.
       cy.window().its('scrollY').should('equal', 0);
     });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -32,8 +32,9 @@ registerCommands();
 // Fix for ResizeObserver loop issue in Firefox
 // see https://stackoverflow.com/questions/74947338/i-keep-getting-error-resizeobserver-loop-limit-exceeded-in-cypress
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+const resizeObserverLoopCompletedRe = /^[^(ResizeObserver loop completed with undelivered notifications)]/;
 Cypress.on('uncaught:exception', (err) => {
-  if (resizeObserverLoopErrRe.test(err.message)) {
+  if (resizeObserverLoopErrRe.test(err.message) || resizeObserverLoopCompletedRe.test(err.message)) {
     return false;
   }
 });


### PR DESCRIPTION
* Provide unique identifiers for the two footer buttons in Cypress E2E test
* Double-up on .click() simulation - workaround for Resize Observer bug

Similar problem mentioned in another repo:
https://github.com/benetech/VideoDeduplication/issues/442

Screenshot: Example case where second click triggers the desired action after Error.

![Screenshot 2023-10-10 at 08 07 52](https://github.com/auto-mat/ride-to-work-by-bike-frontend/assets/42778183/45cf330d-af74-41ab-b3bb-e09327ae39a2)
