### PR TITLE
Enable CI Renovate bot instead of Dependency bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base",
+        ":semanticCommitTypeAll(CI)"
+    ]
+}


### PR DESCRIPTION
Enable CI Renovate bot instead of Dependency bot.

[https://github.com/apps/renovate
https://developer.mend.io/](https://developer.mend.io/)