### PR TITLE
src/components: fix showing deployed frontend app version info into mobile viewport

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -136,7 +136,19 @@ export default defineComponent({
                 :key="message"
                 class="text-white flex items-center gap-12"
               >
-                <span v-html="$t('index.footer.' + message)"></span>
+                <span
+                  v-if="message !== 'deployedAppVersion'"
+                  v-html="$t('index.footer.' + message)"
+                ></span>
+                <!-- Deployed app version -->
+                <span
+                  v-else-if="rideToWorkByBikeDeployedAppVersion.version"
+                  v-html="
+                    `${$t('index.footer.' + message)}: ${
+                      rideToWorkByBikeDeployedAppVersion.version
+                    }`
+                  "
+                ></span>
                 <span v-if="index < copyrightList.length - 1" class="gt-sm"
                   >|</span
                 >


### PR DESCRIPTION
Fix showing deployed frontend app version info into mobile viewport.


**Screenshots**

<img src="https://github.com/auto-mat/ride-to-work-by-bike-frontend/assets/50632337/aeeb2d49-17ca-47ec-bfed-c178b4455558" alt="Mobile viewport showing footer deployed app version" height="450">

