### PR TITLE
src/components: rename component file name/name  plus fix icon alignment

### DIFF
--- a/src/components/FooterBar.vue
+++ b/src/components/FooterBar.vue
@@ -170,7 +170,12 @@ export default defineComponent({
                       :key="link.icon"
                       :title="link.title"
                     >
-                      <a :href="link.url" class="flex column justify-center text-white" target="_blank" style="text-decoration: none;">
+                      <a
+                        :href="link.url"
+                        class="flex column justify-center text-white"
+                        target="_blank"
+                        style="text-decoration: none"
+                      >
                         <q-icon :name="link.icon" size="18px" />
                       </a>
                     </q-btn>

--- a/src/components/FooterBar.vue
+++ b/src/components/FooterBar.vue
@@ -170,7 +170,7 @@ export default defineComponent({
                       :key="link.icon"
                       :title="link.title"
                     >
-                      <a :href="link.url" class="text-white" target="_blank">
+                      <a :href="link.url" class="flex column justify-center text-white" target="_blank" style="text-decoration: none;">
                         <q-icon :name="link.icon" size="18px" />
                       </a>
                     </q-btn>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -19,7 +19,7 @@ const rideToWorkByBikeDeployedAppVersion: object = JSON.parse(
 );
 
 export default defineComponent({
-  name: 'TheFooter',
+  name: 'FooterBar',
   components: {
     LanguageSwitcher,
   },

--- a/src/components/__tests__/FooterBar.cy.js
+++ b/src/components/__tests__/FooterBar.cy.js
@@ -1,14 +1,14 @@
-import TheFooter from 'components/TheFooter.vue';
+import FooterBar from 'components/FooterBar.vue';
 import { i18n } from '../../boot/i18n';
 
-describe('<TheFooter>', () => {
+describe('<FooterBar>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext([], 'index.component', i18n);
   });
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.mount(TheFooter, {
+      cy.mount(FooterBar, {
         props: {
           copyright: [
             'Tato aplikace je svobodný software.',
@@ -82,7 +82,7 @@ describe('<TheFooter>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.mount(TheFooter, {
+      cy.mount(FooterBar, {
         props: {},
       });
       cy.viewport('iphone-6');

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,7 +8,7 @@ import { i18n } from 'src/boot/i18n';
 import DrawerHeader from 'components/DrawerHeader.vue';
 import UserSelect from 'components/UserSelect.vue';
 import DrawerMenu from 'components/DrawerMenu.vue';
-import TheFooter from 'components/TheFooter.vue';
+import FooterBar from 'components/FooterBar.vue';
 import MobileBottomPanel from 'src/components/MobileBottomPanel.vue';
 
 // import types
@@ -31,7 +31,7 @@ export default defineComponent({
     DrawerHeader,
     UserSelect,
     DrawerMenu,
-    TheFooter,
+    FooterBar,
     MobileBottomPanel,
   },
 });
@@ -74,7 +74,7 @@ export default defineComponent({
     <q-footer class="position-static md-position-absolute bg-transparent">
       <!-- footer content -->
       <mobile-bottom-panel></mobile-bottom-panel>
-      <the-footer />
+      <footer-bar />
     </q-footer>
   </q-layout>
 </template>


### PR DESCRIPTION
* Rename component `TheFooter` to `FooterBar` (Footer is a reserved HTML keyword)
* Fix alignment of social-link icons by adding `display: flex`
* Remove icon underline with `style` override (button has default hover behaviour)