### PR TITLE
src/components/__tests__: split command chaining to fix eslint cypress plugin error

### DIFF
--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -206,16 +206,6 @@ describe('<CardEvent>', () => {
         .should('have.css', 'font-weight', '400');
     });
 
-    it('renders dialog content', () => {
-      cy.dataCy('card-link').click();
-
-      cy.dataCy('dialog-content')
-        .should('be.visible')
-        .should('contain', 'We want to reward you for your support')
-        .should('have.css', 'font-size', '14px')
-        .should('have.css', 'font-weight', '400');
-    });
-
     it('renders dialog image', () => {
       cy.dataCy('card-link').click();
 

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -54,7 +54,6 @@ describe('<CardEvent>', () => {
           .then(($title) => {
             expect($title.text()).to.equal(title);
           });
-
         cy.dataCy('card-link')
           .should('be.visible')
           .should('have.attr', 'href', '#');
@@ -90,7 +89,6 @@ describe('<CardEvent>', () => {
           .should('contain', '1.')
           .should('contain', '2023')
           .should('contain', '12:00');
-
         cy.dataCy('card-dates')
           .find('i')
           .should('be.visible')
@@ -106,7 +104,6 @@ describe('<CardEvent>', () => {
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
           .should('contain', location);
-
         cy.dataCy('card-location')
           .find('i')
           .should('be.visible')
@@ -121,7 +118,6 @@ describe('<CardEvent>', () => {
           .should('be.visible')
           .should('have.css', 'height', '42px')
           .should('have.css', 'width', '42px');
-
         cy.dataCy('calendar-button')
           .find('i')
           .should('be.visible')
@@ -156,7 +152,6 @@ describe('<CardEvent>', () => {
           .then(($title) => {
             expect($title.text()).to.equal(title);
           });
-
         cy.dataCy('dialog-meta')
           .should('be.visible')
           .should('have.css', 'font-size', '14px')

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -206,6 +206,16 @@ describe('<CardEvent>', () => {
         .should('have.css', 'font-weight', '400');
     });
 
+    it('renders dialog content', () => {
+      cy.dataCy('card-link').click();
+
+      cy.dataCy('dialog-content')
+        .should('be.visible')
+        .should('contain', 'We want to reward you for your support')
+        .should('have.css', 'font-size', '14px')
+        .should('have.css', 'font-weight', '400');
+    });
+
     it('renders dialog image', () => {
       cy.dataCy('card-link').click();
 

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -138,58 +138,62 @@ describe('<CardEvent>', () => {
     });
 
     it('renders modal dialog on click', () => {
-      cy.dataCy('card-link').click();
+      cy.window().then(() => {
+        cy.dataCy('card-link').click();
 
-      cy.dataCy('dialog-card-event').should('be.visible');
+        cy.dataCy('dialog-card-event').should('be.visible');
+      });
     });
 
     it('renders modal title, location and date', () => {
-      cy.dataCy('card-link').click();
+      cy.window().then(() => {
+        cy.dataCy('card-link').click();
 
-      cy.dataCy('dialog-header')
-        .find('h3')
-        .should('be.visible')
-        .should('have.css', 'font-size', '20px')
-        .should('have.css', 'font-weight', '500')
-        .should('contain', title)
-        .then(($title) => {
-          expect($title.text()).to.equal(title);
-        });
+        cy.dataCy('dialog-header')
+          .find('h3')
+          .should('be.visible')
+          .should('have.css', 'font-size', '20px')
+          .should('have.css', 'font-weight', '500')
+          .should('contain', title)
+          .then(($title) => {
+            expect($title.text()).to.equal(title);
+          });
 
-      cy.dataCy('dialog-meta')
-        .should('be.visible')
-        .should('have.css', 'font-size', '14px')
-        .should('have.css', 'font-weight', '400')
-        .should('have.color', '#546e7a')
-        .each(($el, index) => {
-          if (index === 0) {
-            cy.wrap($el)
-              .should('contain', '1.')
-              .should('contain', '2023')
-              .should('contain', '12:00');
+        cy.dataCy('dialog-meta')
+          .should('be.visible')
+          .should('have.css', 'font-size', '14px')
+          .should('have.css', 'font-weight', '400')
+          .should('have.color', '#546e7a')
+          .each(($el, index) => {
+            if (index === 0) {
+              cy.wrap($el)
+                .should('contain', '1.')
+                .should('contain', '2023')
+                .should('contain', '12:00');
 
-            const $icon = $el.find('i');
-            if ($icon.length) {
-              cy.wrap($icon)
-                .should('be.visible')
-                .should('have.color', '#b0bec5')
-                .should('have.css', 'width', '18px')
-                .should('have.css', 'height', '18px');
+              const $icon = $el.find('i');
+              if ($icon.length) {
+                cy.wrap($icon)
+                  .should('be.visible')
+                  .should('have.color', '#b0bec5')
+                  .should('have.css', 'width', '18px')
+                  .should('have.css', 'height', '18px');
+              }
             }
-          }
-          if (index === 1) {
-            cy.wrap($el).should('contain', location);
+            if (index === 1) {
+              cy.wrap($el).should('contain', location);
 
-            const $icon = $el.find('i');
-            if ($icon.length) {
-              cy.wrap($icon)
-                .should('be.visible')
-                .should('have.color', '#b0bec5')
-                .should('have.css', 'width', '18px')
-                .should('have.css', 'height', '18px');
+              const $icon = $el.find('i');
+              if ($icon.length) {
+                cy.wrap($icon)
+                  .should('be.visible')
+                  .should('have.color', '#b0bec5')
+                  .should('have.css', 'width', '18px')
+                  .should('have.css', 'height', '18px');
+              }
             }
-          }
-        });
+          });
+      });
     });
 
     it('renders dialog content', () => {

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -140,7 +140,6 @@ describe('<CardEvent>', () => {
     it('renders modal dialog on click', () => {
       cy.window().then(() => {
         cy.dataCy('card-link').click();
-
         cy.dataCy('dialog-card-event').should('be.visible');
       });
     });
@@ -148,7 +147,6 @@ describe('<CardEvent>', () => {
     it('renders modal title, location and date', () => {
       cy.window().then(() => {
         cy.dataCy('card-link').click();
-
         cy.dataCy('dialog-header')
           .find('h3')
           .should('be.visible')
@@ -198,7 +196,6 @@ describe('<CardEvent>', () => {
 
     it('renders dialog content', () => {
       cy.dataCy('card-link').click();
-
       cy.dataCy('dialog-content')
         .should('be.visible')
         .should('contain', 'We want to reward you for your support')
@@ -208,7 +205,6 @@ describe('<CardEvent>', () => {
 
     it('renders dialog image', () => {
       cy.dataCy('card-link').click();
-
       cy.dataCy('dialog-image')
         .should('be.visible')
         .find('img')
@@ -221,7 +217,6 @@ describe('<CardEvent>', () => {
 
     it('shows modal with two columns', () => {
       cy.dataCy('card-link').click();
-
       cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
       cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
     });
@@ -247,7 +242,6 @@ describe('<CardEvent>', () => {
 
     it('shows modal with one column', () => {
       cy.dataCy('card-link').click();
-
       cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
       cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
     });

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -138,102 +138,88 @@ describe('<CardEvent>', () => {
     });
 
     it('renders modal dialog on click', () => {
-      cy.window().then(() => {
-        cy.dataCy('card-link')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-card-event').should('be.visible');
-          });
-      });
+      cy.dataCy('card-link').click();
+
+      cy.dataCy('dialog-card-event').should('be.visible');
     });
 
     it('renders modal title, location and date', () => {
-      cy.window().then(() => {
-        cy.dataCy('card-link')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-header')
-              .find('h3')
-              .should('be.visible')
-              .should('have.css', 'font-size', '20px')
-              .should('have.css', 'font-weight', '500')
-              .should('contain', title)
-              .then(($title) => {
-                expect($title.text()).to.equal(title);
-              });
+      cy.dataCy('card-link').click();
 
-            cy.dataCy('dialog-meta')
-              .should('be.visible')
-              .should('have.css', 'font-size', '14px')
-              .should('have.css', 'font-weight', '400')
-              .should('have.color', '#546e7a')
-              .each(($el, index) => {
-                if (index === 0) {
-                  cy.wrap($el)
-                    .should('contain', '1.')
-                    .should('contain', '2023')
-                    .should('contain', '12:00');
+      cy.dataCy('dialog-header')
+        .find('h3')
+        .should('be.visible')
+        .should('have.css', 'font-size', '20px')
+        .should('have.css', 'font-weight', '500')
+        .should('contain', title)
+        .then(($title) => {
+          expect($title.text()).to.equal(title);
+        });
 
-                  const $icon = $el.find('i');
-                  if ($icon.length) {
-                    cy.wrap($icon)
-                      .should('be.visible')
-                      .should('have.color', '#b0bec5')
-                      .should('have.css', 'width', '18px')
-                      .should('have.css', 'height', '18px');
-                  }
-                }
-                if (index === 1) {
-                  cy.wrap($el).should('contain', location);
+      cy.dataCy('dialog-meta')
+        .should('be.visible')
+        .should('have.css', 'font-size', '14px')
+        .should('have.css', 'font-weight', '400')
+        .should('have.color', '#546e7a')
+        .each(($el, index) => {
+          if (index === 0) {
+            cy.wrap($el)
+              .should('contain', '1.')
+              .should('contain', '2023')
+              .should('contain', '12:00');
 
-                  const $icon = $el.find('i');
-                  if ($icon.length) {
-                    cy.wrap($icon)
-                      .should('be.visible')
-                      .should('have.color', '#b0bec5')
-                      .should('have.css', 'width', '18px')
-                      .should('have.css', 'height', '18px');
-                  }
-                }
-              });
-          });
-      });
-    });
+            const $icon = $el.find('i');
+            if ($icon.length) {
+              cy.wrap($icon)
+                .should('be.visible')
+                .should('have.color', '#b0bec5')
+                .should('have.css', 'width', '18px')
+                .should('have.css', 'height', '18px');
+            }
+          }
+          if (index === 1) {
+            cy.wrap($el).should('contain', location);
 
-    it('renders dialog content', () => {
-      cy.dataCy('card-link')
-        .click()
-        .then(() => {
-          cy.dataCy('dialog-content')
-            .should('be.visible')
-            .should('contain', 'We want to reward you for your support')
-            .should('have.css', 'font-size', '14px')
-            .should('have.css', 'font-weight', '400');
+            const $icon = $el.find('i');
+            if ($icon.length) {
+              cy.wrap($icon)
+                .should('be.visible')
+                .should('have.color', '#b0bec5')
+                .should('have.css', 'width', '18px')
+                .should('have.css', 'height', '18px');
+            }
+          }
         });
     });
 
+    it('renders dialog content', () => {
+      cy.dataCy('card-link').click();
+
+      cy.dataCy('dialog-content')
+        .should('be.visible')
+        .should('contain', 'We want to reward you for your support')
+        .should('have.css', 'font-size', '14px')
+        .should('have.css', 'font-weight', '400');
+    });
+
     it('renders dialog image', () => {
-      cy.dataCy('card-link')
-        .click()
-        .then(() => {
-          cy.dataCy('dialog-image')
-            .should('be.visible')
-            .find('img')
-            .then(($img) => {
-              // Updated version of the test valid for Firefox
-              cy.testImageHeight($img);
-              expect($img.attr('src')).to.equal(image.src);
-            });
+      cy.dataCy('card-link').click();
+
+      cy.dataCy('dialog-image')
+        .should('be.visible')
+        .find('img')
+        .then(($img) => {
+          // Updated version of the test valid for Firefox
+          cy.testImageHeight($img);
+          expect($img.attr('src')).to.equal(image.src);
         });
     });
 
     it('shows modal with two columns', () => {
-      cy.dataCy('card-link')
-        .click()
-        .then(() => {
-          cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
-          cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
-        });
+      cy.dataCy('card-link').click();
+
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
     });
   });
 
@@ -256,12 +242,10 @@ describe('<CardEvent>', () => {
     });
 
     it('shows modal with one column', () => {
-      cy.dataCy('card-link')
-        .click()
-        .then(() => {
-          cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
-          cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
-        });
+      cy.dataCy('card-link').click();
+
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
     });
   });
 });

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -43,40 +43,34 @@ describe('<CardOffer>', () => {
 
     it('shows modal dialog on click', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-offer').should('be.visible');
-          });
+        cy.dataCy('card-offer').click();
+
+        cy.dataCy('dialog-offer').should('be.visible');
       });
     });
 
     it('shows modal with title', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-header')
-              .find('h3')
-              .should('be.visible')
-              .should('have.css', 'font-size', '20px')
-              .should('have.css', 'font-weight', '500')
-              .should('contain', card.title)
-              .then(($title) => {
-                expect($title.text()).to.equal(card.title);
-              });
+        cy.dataCy('card-offer').click();
+
+        cy.dataCy('dialog-header')
+          .find('h3')
+          .should('be.visible')
+          .should('have.css', 'font-size', '20px')
+          .should('have.css', 'font-weight', '500')
+          .should('contain', card.title)
+          .then(($title) => {
+            expect($title.text()).to.equal(card.title);
           });
       });
     });
 
     it('shows modal with two columns', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
-            cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
-          });
+        cy.dataCy('card-offer').click();
+
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
       });
     });
   });
@@ -149,78 +143,68 @@ describe('<CardOffer>', () => {
 
     it('shows modal dialog on click', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-offer').should('be.visible');
-          });
+        cy.dataCy('card-offer').click();
+
+        cy.dataCy('dialog-offer').should('be.visible');
       });
     });
 
     it('shows modal with title', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-header')
-              .find('h3')
-              .should('be.visible')
-              .should('have.css', 'font-size', '20px')
-              .should('have.css', 'font-weight', '500')
-              .should('contain', card.title)
-              .then(($title) => {
-                expect($title.text()).to.equal(card.title);
-              });
+        cy.dataCy('card-offer').click();
+
+        cy.dataCy('dialog-header')
+          .find('h3')
+          .should('be.visible')
+          .should('have.css', 'font-size', '20px')
+          .should('have.css', 'font-weight', '500')
+          .should('contain', card.title)
+          .then(($title) => {
+            expect($title.text()).to.equal(card.title);
           });
       });
     });
 
     it('shows modal content', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-body')
-              .should('be.visible')
-              .should('have.css', 'font-size', '14px')
-              .should('have.css', 'font-weight', '400')
-              .should('have.color', '#000000')
-              .should('contain', card.content);
-          });
+        cy.dataCy('card-offer').click();
+
+        cy.dataCy('dialog-body')
+          .should('be.visible')
+          .should('have.css', 'font-size', '14px')
+          .should('have.css', 'font-weight', '400')
+          .should('have.color', '#000000')
+          .should('contain', card.content);
       });
     });
 
     it('shows modal image', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.dataCy('dialog-body')
-              .scrollTo('bottom')
-              .find('img')
-              .should('be.visible')
-              .then(($img) => {
-                cy.testImageHeight($img);
-                expect($img.attr('src')).to.equal(card.image.src);
-              });
+        cy.dataCy('card-offer').click();
 
-            cy.matchImageSnapshotWithHiddenScrollbars(
-              'dialog-body',
-              0.5,
-              'percent'
-            );
+        cy.dataCy('dialog-body')
+          .scrollTo('bottom')
+          .find('img')
+          .should('be.visible')
+          .then(($img) => {
+            cy.testImageHeight($img);
+            expect($img.attr('src')).to.equal(card.image.src);
           });
+
+        cy.matchImageSnapshotWithHiddenScrollbars(
+          'dialog-body',
+          0.5,
+          'percent'
+        );
       });
     });
 
     it('shows modal with one column', () => {
       cy.window().then(() => {
-        cy.dataCy('card-offer')
-          .click()
-          .then(() => {
-            cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
-            cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
-          });
+        cy.dataCy('card-offer').click();
+
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
       });
     });
   });

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -44,7 +44,6 @@ describe('<CardOffer>', () => {
     it('shows modal dialog on click', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.dataCy('dialog-offer').should('be.visible');
       });
     });
@@ -52,7 +51,6 @@ describe('<CardOffer>', () => {
     it('shows modal with title', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.dataCy('dialog-header')
           .find('h3')
           .should('be.visible')
@@ -68,7 +66,6 @@ describe('<CardOffer>', () => {
     it('shows modal with two columns', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 50);
         cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 50);
       });
@@ -144,7 +141,6 @@ describe('<CardOffer>', () => {
     it('shows modal dialog on click', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.dataCy('dialog-offer').should('be.visible');
       });
     });
@@ -152,7 +148,6 @@ describe('<CardOffer>', () => {
     it('shows modal with title', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.dataCy('dialog-header')
           .find('h3')
           .should('be.visible')
@@ -168,7 +163,6 @@ describe('<CardOffer>', () => {
     it('shows modal content', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.dataCy('dialog-body')
           .should('be.visible')
           .should('have.css', 'font-size', '14px')
@@ -181,16 +175,13 @@ describe('<CardOffer>', () => {
     it('shows modal image', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
-        cy.dataCy('dialog-body')
-          .scrollTo('bottom')
-          .find('img')
+        cy.dataCy('dialog-body').scrollTo('bottom')
+        cy.dataCy('dialog-body').find('img')
           .should('be.visible')
           .then(($img) => {
             cy.testImageHeight($img);
             expect($img.attr('src')).to.equal(card.image.src);
           });
-
         cy.matchImageSnapshotWithHiddenScrollbars(
           'dialog-body',
           0.5,
@@ -202,7 +193,6 @@ describe('<CardOffer>', () => {
     it('shows modal with one column', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-
         cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
         cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
       });

--- a/src/components/__tests__/DrawerHeader.cy.js
+++ b/src/components/__tests__/DrawerHeader.cy.js
@@ -72,7 +72,6 @@ describe('<DrawerHeader>', () => {
   it('shows modal dialog on click', () => {
     cy.window().then(() => {
       cy.dataCy('link-help').click();
-
       cy.dataCy('dialog-help').should('be.visible');
     });
   });
@@ -80,7 +79,6 @@ describe('<DrawerHeader>', () => {
   it('renders modal title', () => {
     cy.window().then(() => {
       cy.dataCy('link-help').click();
-
       cy.dataCy('dialog-header')
         .find('h3')
         .should('be.visible')
@@ -98,10 +96,8 @@ describe('<DrawerHeader>', () => {
   it('renders guide section with title and button', () => {
     cy.window().then(() => {
       cy.dataCy('link-help').click();
-
       // TODO: Find if you can calculate height exact height of the sections
       cy.dataCy('dialog-content').scrollTo(0, 1060);
-
       cy.dataCy('title-guide')
         .should('be.visible')
         .should('have.css', 'font-size', '24px')
@@ -112,7 +108,6 @@ describe('<DrawerHeader>', () => {
             i18n.global.t('index.help.titleGuide')
           );
         });
-
       cy.dataCy('button-guide')
         .should('be.visible')
         .should('contain.text', i18n.global.t('index.help.buttonGuide'))

--- a/src/components/__tests__/DrawerHeader.cy.js
+++ b/src/components/__tests__/DrawerHeader.cy.js
@@ -71,61 +71,55 @@ describe('<DrawerHeader>', () => {
 
   it('shows modal dialog on click', () => {
     cy.window().then(() => {
-      cy.dataCy('link-help')
-        .click()
-        .then(() => {
-          cy.dataCy('dialog-help').should('be.visible');
-        });
+      cy.dataCy('link-help').click();
+
+      cy.dataCy('dialog-help').should('be.visible');
     });
   });
 
   it('renders modal title', () => {
     cy.window().then(() => {
-      cy.dataCy('link-help')
-        .click()
-        .then(() => {
-          cy.dataCy('dialog-header')
-            .find('h3')
-            .should('be.visible')
-            .should('have.css', 'font-size', '20px')
-            .should('have.css', 'font-weight', '500')
-            .should('contain', i18n.global.t('index.help.titleStateDefault'))
-            .then(($title) => {
-              expect($title.text()).to.equal(
-                i18n.global.t('index.help.titleStateDefault')
-              );
-            });
+      cy.dataCy('link-help').click();
+
+      cy.dataCy('dialog-header')
+        .find('h3')
+        .should('be.visible')
+        .should('have.css', 'font-size', '20px')
+        .should('have.css', 'font-weight', '500')
+        .should('contain', i18n.global.t('index.help.titleStateDefault'))
+        .then(($title) => {
+          expect($title.text()).to.equal(
+            i18n.global.t('index.help.titleStateDefault')
+          );
         });
     });
   });
 
   it('renders guide section with title and button', () => {
     cy.window().then(() => {
-      cy.dataCy('link-help')
-        .click()
-        .then(() => {
-          // TODO: Find if you can calculate height exact height of the sections
-          cy.dataCy('dialog-content').scrollTo(0, 1060);
+      cy.dataCy('link-help').click();
 
-          cy.dataCy('title-guide')
-            .should('be.visible')
-            .should('have.css', 'font-size', '24px')
-            .should('have.css', 'font-weight', '700')
-            .should('contain', i18n.global.t('index.help.titleGuide'))
-            .then(($title) => {
-              expect($title.text()).to.equal(
-                i18n.global.t('index.help.titleGuide')
-              );
-            });
+      // TODO: Find if you can calculate height exact height of the sections
+      cy.dataCy('dialog-content').scrollTo(0, 1060);
 
-          cy.dataCy('button-guide')
-            .should('be.visible')
-            .should('contain.text', i18n.global.t('index.help.buttonGuide'))
-            .then(($button) => {
-              expect($button.text()).to.equal(
-                i18n.global.t('index.help.buttonGuide')
-              );
-            });
+      cy.dataCy('title-guide')
+        .should('be.visible')
+        .should('have.css', 'font-size', '24px')
+        .should('have.css', 'font-weight', '700')
+        .should('contain', i18n.global.t('index.help.titleGuide'))
+        .then(($title) => {
+          expect($title.text()).to.equal(
+            i18n.global.t('index.help.titleGuide')
+          );
+        });
+
+      cy.dataCy('button-guide')
+        .should('be.visible')
+        .should('contain.text', i18n.global.t('index.help.buttonGuide'))
+        .then(($button) => {
+          expect($button.text()).to.equal(
+            i18n.global.t('index.help.buttonGuide')
+          );
         });
     });
   });

--- a/src/components/__tests__/ListFaq.cy.js
+++ b/src/components/__tests__/ListFaq.cy.js
@@ -38,15 +38,14 @@ describe('<ListFaq>', () => {
         .find('.q-item')
         .first()
         .should('be.visible')
-        .click()
-        .then(() => {
-          cy.dataCy('list-faq-list')
-            .find('.q-card')
-            .first()
-            .should('be.visible')
-            .then(($element) => {
-              expect($element.height()).to.be.greaterThan(0);
-            });
+        .click();
+
+      cy.dataCy('list-faq-list')
+        .find('.q-card')
+        .first()
+        .should('be.visible')
+        .then(($element) => {
+          expect($element.height()).to.be.greaterThan(0);
         });
     });
   });
@@ -79,15 +78,14 @@ describe('<ListFaq>', () => {
         .find('.q-item')
         .first()
         .should('be.visible')
-        .click()
-        .then(() => {
-          cy.dataCy('list-faq-list')
-            .find('.q-card')
-            .first()
-            .should('be.visible')
-            .then(($element) => {
-              expect($element.height()).to.be.greaterThan(0);
-            });
+        .click();
+
+      cy.dataCy('list-faq-list')
+        .find('.q-card')
+        .first()
+        .should('be.visible')
+        .then(($element) => {
+          expect($element.height()).to.be.greaterThan(0);
         });
     });
   });

--- a/src/components/__tests__/ListFaq.cy.js
+++ b/src/components/__tests__/ListFaq.cy.js
@@ -28,18 +28,15 @@ describe('<ListFaq>', () => {
         .first()
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400');
-
       cy.dataCy('list-faq-list')
         .find('.q-card')
         .first()
         .should('not.be.visible');
-
       cy.dataCy('list-faq-list')
         .find('.q-item')
         .first()
         .should('be.visible')
         .click();
-
       cy.dataCy('list-faq-list')
         .find('.q-card')
         .first()
@@ -68,18 +65,15 @@ describe('<ListFaq>', () => {
         .first()
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400');
-
       cy.dataCy('list-faq-list')
         .find('.q-card')
         .first()
         .should('not.be.visible');
-
       cy.dataCy('list-faq-list')
         .find('.q-item')
         .first()
         .should('be.visible')
         .click();
-
       cy.dataCy('list-faq-list')
         .find('.q-card')
         .first()

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -42,11 +42,9 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input').click()
+      cy.dataCy('user-select-input').click();
 
-      cy.get('.q-item__label')
-        .should('be.visible')
-        .should('have.length', 6);
+      cy.get('.q-item__label').should('be.visible').should('have.length', 6);
     });
   });
 
@@ -86,11 +84,9 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input').click()
+      cy.dataCy('user-select-input').click();
 
-      cy.get('.q-item__label')
-        .should('be.visible')
-        .should('have.length', 6);
+      cy.get('.q-item__label').should('be.visible').should('have.length', 6);
     });
   });
 });

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -84,11 +84,9 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input').click()
+      cy.dataCy('user-select-input').click();
 
-      cy.get('.q-item__label')
-        .should('be.visible')
-        .should('have.length', 6);
+      cy.get('.q-item__label').should('be.visible').should('have.length', 6);
     });
   });
 });

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -42,13 +42,11 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input')
-        .click()
-        .then(() => {
-          cy.get('.q-item__label')
-            .should('be.visible')
-            .should('have.length', 6);
-        });
+      cy.dataCy('user-select-input').click()
+
+      cy.get('.q-item__label')
+        .should('be.visible')
+        .should('have.length', 6);
     });
   });
 

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -84,9 +84,11 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input').click();
+      cy.dataCy('user-select-input').click()
 
-      cy.get('.q-item__label').should('be.visible').should('have.length', 6);
+      cy.get('.q-item__label')
+        .should('be.visible')
+        .should('have.length', 6);
     });
   });
 });

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -32,7 +32,6 @@ describe('<UserSelect>', () => {
           cy.testImageHeight($img);
           expect($img.attr('src')).to.equal(user.image.src);
         });
-
       cy.dataCy('avatar')
         .find('.q-img')
         .should('be.visible')
@@ -43,7 +42,6 @@ describe('<UserSelect>', () => {
 
     it('shows dropdown on click', () => {
       cy.dataCy('user-select-input').click();
-
       cy.get('.q-item__label').should('be.visible').should('have.length', 6);
     });
   });
@@ -74,7 +72,6 @@ describe('<UserSelect>', () => {
           cy.testImageHeight($img);
           expect($img.attr('src')).to.equal(user.image.src);
         });
-
       cy.dataCy('avatar')
         .find('.q-img')
         .should('be.visible')
@@ -85,7 +82,6 @@ describe('<UserSelect>', () => {
 
     it('shows dropdown on click', () => {
       cy.dataCy('user-select-input').click();
-
       cy.get('.q-item__label').should('be.visible').should('have.length', 6);
     });
   });

--- a/src/components/__tests__/UserSelect.cy.js
+++ b/src/components/__tests__/UserSelect.cy.js
@@ -86,13 +86,11 @@ describe('<UserSelect>', () => {
     });
 
     it('shows dropdown on click', () => {
-      cy.dataCy('user-select-input')
-        .click()
-        .then(() => {
-          cy.get('.q-item__label')
-            .should('be.visible')
-            .should('have.length', 6);
-        });
+      cy.dataCy('user-select-input').click()
+
+      cy.get('.q-item__label')
+        .should('be.visible')
+        .should('have.length', 6);
     });
   });
 });


### PR DESCRIPTION
* For selected components remove chaining `click().then(() => {...})`

See error: `It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from "cy." in a next command line.`