### PR TITLE
test/cypress/e2e: fix Cypress e2e tests unsafe to chain command error message

### DIFF
--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -272,7 +272,8 @@ describe('Home page', () => {
     });
 
     it('allows user to scroll to top using the footer button', () => {
-      cy.dataCy('footer-top-button').should('be.visible').click().click();
+      cy.dataCy('footer-top-button').should('be.visible').click();
+      cy.dataCy('footer-top-button').should('be.visible').click();
       /**
        * Second click helps to overcome a ResizeObserver loop completed
        * with undelivered notifications error
@@ -539,7 +540,9 @@ describe('Home page', () => {
     it('allows user to scroll to top using the footer button', () => {
       cy.dataCy('footer-top-button-mobile')
         .should('be.visible')
-        .click()
+        .click();
+      cy.dataCy('footer-top-button-mobile')
+        .should('be.visible')
         .click();
       /**
        * Second click helps to overcome a ResizeObserver loop completed


### PR DESCRIPTION
Error message:

```
test@test:/tmp/ride-to-work-by-bike-frontend$ yarn lint
yarn run v1.22.19
$ eslint --ext .js,.ts,.vue ./

/tmp/ride-to-work-by-bike-frontend/test/cypress/e2e/home.spec.cy.js
  275:7   error  It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from `cy.` in a next command line  cypress/unsafe-to-chain-command @typescript-eslint/no-unused-vars                                                                                                                
  540:7   error  It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from `cy.` in a next command line  cypress/unsafe-to-chain-command @typescript-eslint/no-unused-vars
```