### PR TITLE
ts: fix run Cypress e2e unit tests with TypeScript version 5.0.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "sourceMap": false
   }
 }


### PR DESCRIPTION
Error message:

`TS5053: Option 'sourceMap' cannot be specified with option 'inlineSourceMap'.`

**Additional context**

Check the tests result of PR #40.