### PR TITLE
src/components: add SectionColumns component

### DIFF
--- a/src/components/SectionColumns.vue
+++ b/src/components/SectionColumns.vue
@@ -27,7 +27,7 @@
  */
 
 // libraries
-import { h } from 'vue';
+import { h, VNode, RendererNode, RendererElement } from 'vue';
 
 export default {
   name: 'SectionColumns',
@@ -46,34 +46,36 @@ export default {
     }
 
     // Map over each child in the default slot
-    const childrenWithClass = defaultSlot.map((slot) => {
-      // If children are VNodes
-      if (Array.isArray(slot.children)) {
-        return slot.children.map((child) => {
-          // Render each child with the appropriate column classes
-          return h(
-            'div',
-            {
-              'class': [`col-12 col-sm-6 col-lg-${12 / this.columns}`],
-              'data-cy': 'section-columns-column',
-            },
-            [child]
-          );
-        });
-      }
+    const childrenWithClass = defaultSlot.map(
+      (slot): VNode<RendererNode, RendererElement>[] => {
+        // If children are VNodes
+        if (Array.isArray(slot.children)) {
+          return slot.children.map((child) => {
+            // Render each child with the appropriate column classes
+            return h(
+              'div',
+              {
+                class: [`col-12 col-sm-6 col-lg-${12 / this.columns}`],
+                'data-cy': 'section-columns-column',
+              },
+              [child],
+            );
+          });
+        }
 
-      // Render content
-      return h('div', {}, slot);
-    });
+        // Render content
+        return [h('div', {}, slot)];
+      },
+    );
 
     // Return the component VNode
     return h(
       'div',
       {
-        'class': ['row'],
+        class: ['row'],
         'data-cy': 'section-columns-row',
       },
-      childrenWithClass
+      childrenWithClass,
     );
   },
 };

--- a/src/components/SectionColumns.vue
+++ b/src/components/SectionColumns.vue
@@ -27,7 +27,7 @@
  */
 
 // libraries
-import { h, VNode, RendererNode, RendererElement } from 'vue';
+import { h, VNode, RendererNode, RendererElement, VNodeChild } from 'vue';
 
 export default {
   name: 'SectionColumns',
@@ -47,11 +47,13 @@ export default {
 
     // Map over each child in the default slot
     const childrenWithClass = defaultSlot.map(
-      (slot): VNode<RendererNode, RendererElement>[] => {
+      (
+        slot: VNode<RendererNode, RendererElement>,
+      ): VNode<RendererNode, RendererElement>[] => {
         // If children are VNodes
         if (Array.isArray(slot.children)) {
           return slot.children.map(
-            (child): VNode<RendererNode, RendererElement> => {
+            (child: VNodeChild): VNode<RendererNode, RendererElement> => {
               // Render each child with the appropriate column classes
               return h(
                 'div',

--- a/src/components/SectionColumns.vue
+++ b/src/components/SectionColumns.vue
@@ -50,17 +50,19 @@ export default {
       (slot): VNode<RendererNode, RendererElement>[] => {
         // If children are VNodes
         if (Array.isArray(slot.children)) {
-          return slot.children.map((child) => {
-            // Render each child with the appropriate column classes
-            return h(
-              'div',
-              {
-                class: [`col-12 col-sm-6 col-lg-${12 / this.columns}`],
-                'data-cy': 'section-columns-column',
-              },
-              [child],
-            );
-          });
+          return slot.children.map(
+            (child): VNode<RendererNode, RendererElement> => {
+              // Render each child with the appropriate column classes
+              return h(
+                'div',
+                {
+                  class: [`col-12 col-sm-6 col-lg-${12 / this.columns}`],
+                  'data-cy': 'section-columns-column',
+                },
+                [child],
+              );
+            },
+          );
         }
 
         // Render content

--- a/src/components/SectionColumns.vue
+++ b/src/components/SectionColumns.vue
@@ -1,0 +1,80 @@
+<script lang="ts">
+/**
+ * SectionColumns Component
+ *
+ * The `SectionColumns`
+ *
+ * @description * Use this component to render content in columns.
+ * You can adjust its appearance by passing the `columns` prop.
+ *
+ * Note: This component is commonly used with Card-type components.
+ *
+ * @props
+ * - `columns` (Number, required): The number of columns.
+ *   It should be one of these options: 2 | 3 | 4 | 6.
+ *
+ * @slots
+ * - `default`: For displaying content.
+ *
+ * Note: each element in content slot takes up one grid column.
+ *
+ * @example
+ * <section-columns :columns="4">
+ *   <card-stats v-for="card in cardsStats" :key="card.title" :card="card" />
+ * </section-columns>
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=4858%3A106374&mode=dev)
+ */
+
+// libraries
+import { h } from 'vue';
+
+export default {
+  name: 'SectionColumns',
+  props: {
+    columns: {
+      type: Number as () => 2 | 3 | 4 | 6,
+      required: true,
+    },
+  },
+  render() {
+    // Access the default slot
+    const defaultSlot = this.$slots.default && this.$slots.default();
+    if (!defaultSlot) {
+      // Render empty wrapper
+      return h('div', {}, defaultSlot);
+    }
+
+    // Map over each child in the default slot
+    const childrenWithClass = defaultSlot.map((slot) => {
+      // If children are VNodes
+      if (Array.isArray(slot.children)) {
+        return slot.children.map((child) => {
+          // Render each child with the appropriate column classes
+          return h(
+            'div',
+            {
+              'class': [`col-12 col-sm-6 col-lg-${12 / this.columns}`],
+              'data-cy': 'section-columns-column',
+            },
+            [child]
+          );
+        });
+      }
+
+      // Render content
+      return h('div', {}, slot);
+    });
+
+    // Return the component VNode
+    return h(
+      'div',
+      {
+        'class': ['row'],
+        'data-cy': 'section-columns-row',
+      },
+      childrenWithClass
+    );
+  },
+};
+</script>

--- a/src/components/SectionColumnsTest.vue
+++ b/src/components/SectionColumnsTest.vue
@@ -1,0 +1,55 @@
+<script lang='ts'>
+/**
+* SectionColumnsTest Component
+*
+* The `SectionColumnsTest`
+*
+* @description * Use this component to test the SectionColumns component.
+*
+* @props
+* - `columns` (Number, required): The number of columns.
+*   It should be one of these options: 2 | 3 | 4 | 6.
+*
+* @components
+* - `SectionColumns`: Component to render content in columns.
+* - `CardStats`: Card which provides content for the component.
+*
+* @example
+* <SectionColumnsTest />
+*/
+
+// libraries
+import { defineComponent } from 'vue';
+
+// components
+import SectionColumns from 'src/components/SectionColumns.vue';
+import CardStats from 'src/components/CardStats.vue';
+
+// mocks
+import { cardsStats } from 'src/mocks/homepage';
+
+export default defineComponent({
+  name: 'SectionColumnsTest',
+  components: {
+    SectionColumns,
+    CardStats,
+  },
+  props: {
+    columns: {
+      type: Number as () => 2 | 3 | 4 | 6,
+      required: true,
+    }
+  },
+  setup() {
+    return {
+      cardsStats,
+    }
+  }
+})
+</script>
+
+<template>
+  <section-columns :columns="columns" class="q-col-gutter-lg q-pt-xl q-pb-xl">
+    <card-stats v-for="card in cardsStats" :key="card.title" :card="card" />
+  </section-columns>
+</template>

--- a/src/components/__tests__/SectionColumns.cy.js
+++ b/src/components/__tests__/SectionColumns.cy.js
@@ -1,0 +1,104 @@
+import SectionColumnsTest from 'components/SectionColumnsTest.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<SectionColumnsTest>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop 2 columns', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 2,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders 2 columns', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 50);
+    })
+  });
+
+  context('desktop 3 columns', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 3,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders 3 columns', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 33);
+    })
+  });
+
+  context('desktop 4 columns', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 4,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders 4 columns', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 25);
+    })
+  });
+
+  context('desktop 6 columns', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 6,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders 6 columns', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 17);
+    })
+  });
+
+  context('tablet', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 4,
+        },
+      });
+      cy.viewport('ipad-2');
+    });
+
+    it('renders 2 columns', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 50);
+    })
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(SectionColumnsTest, {
+        props: {
+          columns: 4,
+        },
+      });
+      cy.viewport('iphone-6');
+    });
+
+    it('renders 1 column', () => {
+      cy.dataCy('section-columns-row').should('be.visible')
+      cy.testElementPercentageWidth(cy.dataCy('section-columns-column'), 100);
+    })
+  });
+});

--- a/src/mocks/homepage.ts
+++ b/src/mocks/homepage.ts
@@ -494,4 +494,30 @@ export const cardsStats: CardStats[] = [
       },
     ],
   },
+  {
+    title: 'Vy',
+    icon: 'people',
+    stats: [
+      {
+        id: 'regularity',
+        icon: 'lens',
+        text: '80% pravidelnost',
+      },
+      {
+        id: 'routes',
+        icon: 'route',
+        text: '18 cest',
+      },
+      {
+        id: 'distance',
+        icon: 'sync_alt',
+        text: '312,25 km',
+      },
+      {
+        id: 'emissions',
+        icon: 'eco',
+        text: '420 g CO2 ušetřeno',
+      },
+    ],
+  },
 ];

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -48,6 +48,9 @@
         class="q-pt-xl q-pb-xl"
         data-cy="list-badges"
       ></list-badge-achievement>
+      <section-columns :columns="3" class="q-col-gutter-lg q-pt-xl q-pb-xl">
+        <card-stats v-for="card in cardsStats" :key="card.title" :card="card" />
+      </section-columns>
     </div>
     <heading-background
       :title="headingBgTitle"
@@ -103,6 +106,8 @@ import ListCardPost from 'src/components/ListCardPost.vue';
 import ListCardProgress from 'src/components/ListCardProgress.vue';
 import NewsletterFeature from 'src/components/NewsletterFeature.vue';
 import SliderProgress from 'src/components/SliderProgress.vue';
+import SectionColumns from 'src/components/SectionColumns.vue';
+import CardStats from 'src/components/CardStats.vue';
 
 // mocks
 import * as homepage from '../mocks/homepage';
@@ -124,6 +129,8 @@ export default defineComponent({
     SliderProgress,
     ListCardPost,
     NewsletterFeature,
+    SectionColumns,
+    CardStats,
   },
   setup() {
     return {
@@ -140,6 +147,7 @@ export default defineComponent({
       cardsProgressSlider: homepage.cardsProgressSlider,
       progressStats: homepage.progressStats,
       cardsProgress: homepage.cardsProgress,
+      cardsStats: homepage.cardsStats,
     };
   },
 });


### PR DESCRIPTION
* Implements flexible grid component which allows to list component cards on homepage without the need to create separate `List` element.
* Uses slot and render functions to apply correct classes.
* In future it can replace several components such as `ListBadgeAchievement`, `ListCardChallenge`, or `ListCardEvent`.
* `SectionColumnsTest` component is created to easily render the content of slots within the standard Cypress component test.
* Component is used on `IndexPage` with `CardStats` as content.