### PR TITLE
docker: upgrade Node.js version to the last LTS Iron 20.x version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL authors="Auto*Mat, z. s. auto-mat@auto-mat.cz"
 LABEL maintainer="Auto*Mat, z. s. auto-mat@auto-mat.cz"
 
 ENV APP_PATH=/tmp/nginx/ride-to-work-by-bike-app
-RUN apk add --update --no-cache nginx nodejs yarn
+RUN apk add --update --no-cache nginx nodejs-current yarn
 
 # Create the directories we will need
 RUN mkdir -p $APP_PATH /var/log/nginx /var/www/html

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Auto*Mat, z. s. auto-mat@auto-mat.cz"
 ARG UID
 ENV APP_USER=dev
 ENV APP_PATH=/home/$APP_USER/ride-to-work-by-bike-app
-RUN apk add --update --no-cache nodejs yarn \
+RUN apk add --update --no-cache nodejs-current yarn \
     && yarn global add @quasar/cli npx \
     && adduser $APP_USER -u $UID -S
 # Create the directories we will need


### PR DESCRIPTION
Upgrade Docker Alpine GNU/Linux base image Node.js version to the last LTS Iron 20.x version.