### PR TITLE
Fix run Cypress test framework from dev Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ App is automatically deployed into k8 repository.
 Open web app URL https://rtwbb-test.dopracenakole.net/ with your default browser.
 
 ```bash
-# Open default web browser with URL https://rtwbb-test.dopracenakole.net/ from emulator terminal
+# Open default web browser with URL https://rtwbb-test.dopracenakole.net/ from the emulator terminal
 test@test:~$ xdg-open https://rtwbb-test.dopracenakole.net
 ```
 
@@ -174,13 +174,51 @@ APP_DIR=/home/dev/$APP_NAME
 docker buildx build --build-arg="UID=$(id -u)" -f ./docker/dev/Dockerfile .
 
 # Run Docker app container
-docker run -it --rm -e "PS1=\u@\h:\w$ " -p 9000:9000 -v $(pwd):$APP_DIR --name $APP_NAME <YOUR_BUILDED_DOCKER_IMAGE_ID>
+xhost local:$(id -u)
+
+docker run -it --rm \
+--env "PS1=\u@\h:\w$ " \
+--env "DISPLAY=$DISPLAY" \
+--publish 9000:9000 \
+--volume $(pwd):$APP_DIR \
+--volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+--device="/dev/dri/card0:/dev/dri/card0" \
+--name $APP_NAME \
+<YOUR_BUILDED_DOCKER_IMAGE_ID>
 
 # Or if you want override some Docker app container ENV variables (-e flag)
-docker run -it --rm -e "PS1=\u@\h:\w$ " -e "PRIMARY_COLOR=red" -p 9000:9000 -v $(pwd):$APP_DIR --name $APP_NAME <YOUR_BUILDED_DOCKER_IMAGE_ID>
+xhost local:$(id -u)
+
+docker run -it --rm  \
+--env "PS1=\u@\h:\w$ " \
+--env "PRIMARY_COLOR=red" \
+--env "DISPLAY=$DISPLAY" \
+--publish 9000:9000 \
+--volume $(pwd):$APP_DIR
+--volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+--device="/dev/dri/card0:/dev/dri/card0" \
+--name $APP_NAME
+<YOUR_BUILDED_DOCKER_IMAGE_ID>
+
+# Install app JS dependencies
+dev@61b150727994:~/ride-to-work-by-bike-app$ ./docker/dev/install_app_dependencies.sh
 
 # Run quasar app dev server from emulator terminal
-dev@61b150727994:~/ride-to-work-by-bike-app$ npx quasar dev
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn dev
+
+# Run app component/e2e tests, see Run app tests section
+#
+# Run quasar app dev server on the background from emulator terminal
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn dev &
+# Run component tests
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn test:component:firefox
+# Open component tests
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn test:component:open:firefox
+# Run e2e tests
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn test:e2e:firefox
+# Open e2e tests
+dev@61b150727994:~/ride-to-work-by-bike-app$ yarn test:e2e:open:firefox
+
 
 # Check web app from your host OS via web browser
 # Open default web browser with URL http://localhost:9000 from host OS emulator terminal

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM ubuntu:jammy
 
 LABEL authors="Auto*Mat, z. s. auto-mat@auto-mat.cz"
 LABEL maintainer="Auto*Mat, z. s. auto-mat@auto-mat.cz"
@@ -6,9 +6,37 @@ LABEL maintainer="Auto*Mat, z. s. auto-mat@auto-mat.cz"
 ARG UID
 ENV APP_USER=dev
 ENV APP_PATH=/home/$APP_USER/ride-to-work-by-bike-app
-RUN apk add --update --no-cache nodejs-current yarn \
+ENV ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_NAME=install_custom_packages.sh
+ENV ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_PATH=\
+/usr/local/bin/$ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_NAME
+ENV NODEJS_MAJOR_VERSION=20
+
+COPY ./docker/dev/$ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_NAME \
+     $ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_PATH
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    --no-install-suggests \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    git \
+    gpg-agent \
+    psmisc \
+    software-properties-common \
+    wget \
+    xvfb \
+    # Add custom packages repositories
+    && chmod +x $ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_PATH \
+    && $ADD_CUSTOM_PACKAGES_REPOSITORIES_SCRIPT_PATH \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+    nodejs \
+    yarn \
+    firefox \
+    google-chrome-stable \
+    microsoft-edge-stable \
+    && apt clean \
     && yarn global add @quasar/cli npx \
-    && adduser $APP_USER -u $UID -S
+    && adduser $APP_USER --uid $UID --system
 # Create the directories we will need
 RUN mkdir $APP_PATH
 WORKDIR $APP_PATH

--- a/docker/dev/install_app_dependencies.sh
+++ b/docker/dev/install_app_dependencies.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+# Install app JS lib dependencies
+
+
+if [ -d "./node_modules" ]; then
+    npx husky install
+    npx cypress install
+else
+    yarn
+fi

--- a/docker/dev/install_custom_packages.sh
+++ b/docker/dev/install_custom_packages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+#
+# Install custom packages
+#
+# Node.js  major 20.x version
+# Yarn JS package manager
+# Last Mozilla Firefox web browser version
+# Last Google Chrome web browser version
+# Last Microsoft Edge web browser version
+
+
+# Add Node.js major version 20.x repository
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+sh -c '''
+echo \
+"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
+https://deb.nodesource.com/node_$NODEJS_MAJOR_VERSION.x nodistro main" \
+| tee /etc/apt/sources.list.d/nodesource.list
+'''
+
+# Add yarn repository
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/yarn-archive-keyring.gpg
+sh -c '''
+echo \
+"deb [signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] \
+https://dl.yarnpkg.com/debian/ stable main" \
+| tee /etc/apt/sources.list.d/yarn.list
+'''
+
+# Add Google Chrome browser repository
+wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+    | gpg --dearmour -o /usr/share/keyrings/google_linux_signing_key.gpg
+sh -c '''
+echo \
+"deb [arch=amd64 signed-by=/usr/share/keyrings/google_linux_signing_key.gpg] \
+http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+'''
+
+# Add MS Edge browser repository
+wget -q -O - https://packages.microsoft.com/keys/microsoft.asc \
+    | gpg --dearmour -o /usr/share/keyrings/microsoft_linux_signing_key.gpg
+sh -c '''
+echo \
+"deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft_linux_signing_key.gpg] \
+https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list
+'''
+
+# Add Mozilla Firefox repository
+add-apt-repository ppa:mozillateam/ppa
+sh -c '''
+echo \
+"Package: firefox*
+Pin: release o=LP-PPA-mozillateam
+Pin-Priority: 501" > /etc/apt/preferences.d/mozillateamppa
+'''


### PR DESCRIPTION
Use Ubuntu GNU/Linux Jammy Jellyfish 22.04 LTS version as Docker base image with latest Node.js LTS Iron 20.x version and lastest Mozilla Firefox, Google Chrome, Microsoft Edge web browser.