### PR TITLE
src/components/__tests__: replace hex color definitions with getPaletteColor func

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -15,6 +15,7 @@ const {
   getDeployedAppVersion,
 } = require('./src/utils/get_deployed_app_version');
 
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports = configure(function (ctx) {
   return {

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -15,7 +15,6 @@ const {
   getDeployedAppVersion,
 } = require('./src/utils/get_deployed_app_version');
 
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports = configure(function (ctx) {
   return {

--- a/src/components/__tests__/BadgeAchievement.cy.js
+++ b/src/components/__tests__/BadgeAchievement.cy.js
@@ -5,6 +5,8 @@ import { i18n } from '../../boot/i18n';
 import { badgeList } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const grey9 = getPaletteColor('grey-9');
+const blueGrey7 = getPaletteColor('blue-grey-7');
 
 const badge = badgeList[0];
 const badgeDark = badgeList[1];
@@ -30,7 +32,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', getPaletteColor('grey-9'))
+          .should('have.color', grey9)
           .should('contain', badge.title)
           .then(($title) => {
             expect($title.text()).to.equal(badge.title);
@@ -62,7 +64,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '12px')
           .should('have.css', 'font-weight', '400')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', getPaletteColor('grey-9'))
+          .should('have.color', grey9)
           .should('contain', badge.description)
           .then(($description) => {
             expect($description.text()).to.equal(badge.description);
@@ -82,10 +84,7 @@ describe('<BadgeAchievement>', () => {
     });
 
     it('has dark background', () => {
-      cy.dataCy('badge-card').should(
-        'have.backgroundColor',
-        getPaletteColor('blue-grey-7'),
-      );
+      cy.dataCy('badge-card').should('have.backgroundColor', blueGrey7);
     });
 
     it('renders title', () => {

--- a/src/components/__tests__/BadgeAchievement.cy.js
+++ b/src/components/__tests__/BadgeAchievement.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import BadgeAchievement from '../BadgeAchievement.vue';
 import { i18n } from '../../boot/i18n';
 import { badgeList } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const badge = badgeList[0];
 const badgeDark = badgeList[1];
@@ -26,7 +30,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', '#424242') // bg-grey-9
+          .should('have.color', getPaletteColor('grey-9'))
           .should('contain', badge.title)
           .then(($title) => {
             expect($title.text()).to.equal(badge.title);
@@ -58,7 +62,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '12px')
           .should('have.css', 'font-weight', '400')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', '#424242') // bg-grey-9
+          .should('have.color', getPaletteColor('grey-9'))
           .should('contain', badge.description)
           .then(($description) => {
             expect($description.text()).to.equal(badge.description);

--- a/src/components/__tests__/BadgeAchievement.cy.js
+++ b/src/components/__tests__/BadgeAchievement.cy.js
@@ -82,7 +82,10 @@ describe('<BadgeAchievement>', () => {
     });
 
     it('has dark background', () => {
-      cy.dataCy('badge-card').should('have.backgroundColor', '#546e7a'); // bg-blue-grey-7
+      cy.dataCy('badge-card').should(
+        'have.backgroundColor',
+        getPaletteColor('blue-grey-7'),
+      );
     });
 
     it('renders title', () => {
@@ -91,7 +94,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', '#fff') // bg-grey-9
+          .should('have.color', '#fff')
           .should('contain', badgeDark.title)
           .then(($title) => {
             expect($title.text()).to.equal(badgeDark.title);
@@ -105,7 +108,7 @@ describe('<BadgeAchievement>', () => {
           .should('have.css', 'font-size', '12px')
           .should('have.css', 'font-weight', '400')
           .should('have.css', 'text-align', 'center')
-          .should('have.color', '#fff') // bg-grey-9
+          .should('have.color', '#fff')
           .should('contain', badgeDark.description)
           .then(($description) => {
             expect($description.text()).to.equal(badgeDark.description);

--- a/src/components/__tests__/BannerApp.cy.js
+++ b/src/components/__tests__/BannerApp.cy.js
@@ -4,6 +4,7 @@ import BannerApp from '../BannerApp.vue';
 import { bannerApp } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const blueGrey8 = getPaletteColor('blue-grey-8');
 
 const config = JSON.parse(process.env.RIDE_TO_WORK_BY_BIKE_CONFIG);
 
@@ -80,7 +81,7 @@ describe('<BannerApp>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-app')
           .should('be.visible')
-          .should('have.backgroundColor', getPaletteColor('blue-grey-8'));
+          .should('have.backgroundColor', blueGrey8);
       });
     });
 
@@ -166,7 +167,7 @@ describe('<BannerApp>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-app')
           .should('be.visible')
-          .should('have.backgroundColor', getPaletteColor('blue-grey-8'));
+          .should('have.backgroundColor', blueGrey8);
       });
     });
 

--- a/src/components/__tests__/BannerApp.cy.js
+++ b/src/components/__tests__/BannerApp.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import BannerApp from '../BannerApp.vue';
 import { bannerApp } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const config = JSON.parse(process.env.RIDE_TO_WORK_BY_BIKE_CONFIG);
 
@@ -76,7 +80,7 @@ describe('<BannerApp>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-app')
           .should('be.visible')
-          .should('have.backgroundColor', '#455a64'); // blue-grey-8
+          .should('have.backgroundColor', getPaletteColor('blue-grey-8'));
       });
     });
 
@@ -162,7 +166,7 @@ describe('<BannerApp>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-app')
           .should('be.visible')
-          .should('have.backgroundColor', '#455a64'); // blue-grey-8
+          .should('have.backgroundColor', getPaletteColor('blue-grey-8'));
       });
     });
 

--- a/src/components/__tests__/BannerImage.cy.js
+++ b/src/components/__tests__/BannerImage.cy.js
@@ -33,7 +33,7 @@ describe('<BannerImage>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain.text', bannerImage.title)
           .then(($title) => {
             expect($title.text()).to.equal(bannerImage.title);
@@ -47,7 +47,7 @@ describe('<BannerImage>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '12px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain.text', bannerImage.perex)
           .then(($perex) => {
             expect($perex.text()).to.equal(bannerImage.perex);
@@ -134,7 +134,7 @@ describe('<BannerImage>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain.text', bannerImage.title)
           .then(($title) => {
             expect($title.text()).to.equal(bannerImage.title);
@@ -148,7 +148,7 @@ describe('<BannerImage>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '12px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain.text', bannerImage.perex)
           .then(($perex) => {
             expect($perex.text()).to.equal(bannerImage.perex);

--- a/src/components/__tests__/BannerRoutes.cy.js
+++ b/src/components/__tests__/BannerRoutes.cy.js
@@ -4,6 +4,7 @@ import BannerRoutes from '../BannerRoutes.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey1 = getPaletteColor('grey-1');
 
 const routesCount = 3;
 
@@ -73,7 +74,7 @@ describe('<BannerRoutes>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-routes-card')
           .should('be.visible')
-          .should('have.backgroundColor', getPaletteColor('grey-1'));
+          .should('have.backgroundColor', grey1);
       });
     });
 
@@ -157,7 +158,7 @@ describe('<BannerRoutes>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-routes-card')
           .should('be.visible')
-          .should('have.backgroundColor', getPaletteColor('grey-1'));
+          .should('have.backgroundColor', grey1);
       });
     });
 
@@ -235,7 +236,7 @@ describe('<BannerRoutes>', () => {
       cy.window().then(() => {
         cy.dataCy('banner-routes-card')
           .should('be.visible')
-          .should('have.backgroundColor', getPaletteColor('grey-1'));
+          .should('have.backgroundColor', grey1);
       });
     });
 

--- a/src/components/__tests__/BannerRoutes.cy.js
+++ b/src/components/__tests__/BannerRoutes.cy.js
@@ -37,7 +37,7 @@ describe('<BannerRoutes>', () => {
       cy.dataCy('banner-routes-title')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '700')
-        .should('have.color', '#000000');
+        .should('have.color', '#000');
     });
 
     it('renders button', () => {
@@ -121,7 +121,7 @@ describe('<BannerRoutes>', () => {
       cy.dataCy('banner-routes-title')
         .should('have.css', 'font-size', '20px')
         .should('have.css', 'font-weight', '700')
-        .should('have.color', '#000000');
+        .should('have.color', '#000');
     });
 
     it('renders button', () => {
@@ -197,7 +197,7 @@ describe('<BannerRoutes>', () => {
         cy.dataCy('banner-routes-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', routesCount);
       });
     });

--- a/src/components/__tests__/CardChallenge.cy.js
+++ b/src/components/__tests__/CardChallenge.cy.js
@@ -80,7 +80,7 @@ describe('<CardChallenge>', () => {
     cy.window().then(() => {
       cy.dataCy('card-dates')
         .should('be.visible')
-        .should('have.color', '#ffffff')
+        .should('have.color', '#fff')
         .should('have.css', 'font-size', '14px')
         .should('contain', dates);
     });
@@ -98,7 +98,7 @@ describe('<CardChallenge>', () => {
         .should('have.css', 'border-radius', '12px')
         .should('have.css', 'font-size', '12px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', '#ffffff')
+        .should('have.color', '#fff')
         .should('have.css', 'height', '24px')
         .should('contain.text', i18n.global.t('index.cardChallenge.company'));
     });

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -80,7 +80,7 @@ describe('<CardEvent>', () => {
       cy.window().then(() => {
         cy.dataCy('card')
           .should('be.visible')
-          .should('have.backgroundColor', '#ffffff');
+          .should('have.backgroundColor', '#fff');
       });
     });
 
@@ -125,7 +125,7 @@ describe('<CardEvent>', () => {
         cy.dataCy('calendar-button')
           .find('i')
           .should('be.visible')
-          .should('have.color', '#000000');
+          .should('have.color', '#000');
       });
     });
 

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import CardEvent from '../CardEvent.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 const title = 'Opening Ceremony Bike to Work 2022';
 const thumbnail = {
@@ -92,7 +96,7 @@ describe('<CardEvent>', () => {
         cy.dataCy('card-dates')
           .find('i')
           .should('be.visible')
-          .should('have.color', '#cfd8dc')
+          .should('have.color', getPaletteColor('blue-grey-2'))
           .should('contain', 'event');
       });
     });
@@ -107,7 +111,7 @@ describe('<CardEvent>', () => {
         cy.dataCy('card-location')
           .find('i')
           .should('be.visible')
-          .should('have.color', '#cfd8dc')
+          .should('have.color', getPaletteColor('blue-grey-2'))
           .should('contain', 'place');
       });
     });
@@ -156,7 +160,7 @@ describe('<CardEvent>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#546e7a')
+          .should('have.color', getPaletteColor('blue-grey-7'))
           .each(($el, index) => {
             if (index === 0) {
               cy.wrap($el)
@@ -168,7 +172,7 @@ describe('<CardEvent>', () => {
               if ($icon.length) {
                 cy.wrap($icon)
                   .should('be.visible')
-                  .should('have.color', '#b0bec5')
+                  .should('have.color', getPaletteColor('blue-grey-3'))
                   .should('have.css', 'width', '18px')
                   .should('have.css', 'height', '18px');
               }
@@ -180,7 +184,7 @@ describe('<CardEvent>', () => {
               if ($icon.length) {
                 cy.wrap($icon)
                   .should('be.visible')
-                  .should('have.color', '#b0bec5')
+                  .should('have.color', getPaletteColor('blue-grey-3'))
                   .should('have.css', 'width', '18px')
                   .should('have.css', 'height', '18px');
               }

--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -4,6 +4,9 @@ import CardEvent from '../CardEvent.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const blueGrey2 = getPaletteColor('blue-grey-2');
+const blueGrey3 = getPaletteColor('blue-grey-3');
+const blueGrey7 = getPaletteColor('blue-grey-7');
 
 const title = 'Opening Ceremony Bike to Work 2022';
 const thumbnail = {
@@ -96,7 +99,7 @@ describe('<CardEvent>', () => {
         cy.dataCy('card-dates')
           .find('i')
           .should('be.visible')
-          .should('have.color', getPaletteColor('blue-grey-2'))
+          .should('have.color', blueGrey2)
           .should('contain', 'event');
       });
     });
@@ -111,7 +114,7 @@ describe('<CardEvent>', () => {
         cy.dataCy('card-location')
           .find('i')
           .should('be.visible')
-          .should('have.color', getPaletteColor('blue-grey-2'))
+          .should('have.color', blueGrey2)
           .should('contain', 'place');
       });
     });
@@ -160,7 +163,7 @@ describe('<CardEvent>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', getPaletteColor('blue-grey-7'))
+          .should('have.color', blueGrey7)
           .each(($el, index) => {
             if (index === 0) {
               cy.wrap($el)
@@ -172,7 +175,7 @@ describe('<CardEvent>', () => {
               if ($icon.length) {
                 cy.wrap($icon)
                   .should('be.visible')
-                  .should('have.color', getPaletteColor('blue-grey-3'))
+                  .should('have.color', blueGrey3)
                   .should('have.css', 'width', '18px')
                   .should('have.css', 'height', '18px');
               }
@@ -184,7 +187,7 @@ describe('<CardEvent>', () => {
               if ($icon.length) {
                 cy.wrap($icon)
                   .should('be.visible')
-                  .should('have.color', getPaletteColor('blue-grey-3'))
+                  .should('have.color', blueGrey3)
                   .should('have.css', 'width', '18px')
                   .should('have.css', 'height', '18px');
               }

--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -4,6 +4,8 @@ import CardFollow from '../CardFollow.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey7 = getPaletteColor('blue-grey-7');
 
 // mocks
 import { cardsFollow } from 'src/mocks/homepage';
@@ -73,7 +75,7 @@ describe('<CardFollow>', () => {
         cy.dataCy('card-follow-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);
@@ -86,7 +88,7 @@ describe('<CardFollow>', () => {
         cy.dataCy('card-follow-handle')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', getPaletteColor('blue-grey-7'))
+          .should('have.color', blueGrey7)
           .should('contain', card.handle)
           .then(($title) => {
             expect($title.text()).to.equal(card.handle);

--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import CardFollow from '../CardFollow.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 // mocks
 import { cardsFollow } from 'src/mocks/homepage';
@@ -69,7 +73,7 @@ describe('<CardFollow>', () => {
         cy.dataCy('card-follow-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);

--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -26,7 +26,7 @@ describe('<CardFollow>', () => {
 
     it('has white background', () => {
       cy.window().then(() => {
-        cy.dataCy('card-follow').should('have.backgroundColor', '#ffffff'); // blue-grey-2
+        cy.dataCy('card-follow').should('have.backgroundColor', '#fff');
       });
     });
 
@@ -86,7 +86,7 @@ describe('<CardFollow>', () => {
         cy.dataCy('card-follow-handle')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#546e7a') // blue-grey-7
+          .should('have.color', getPaletteColor('blue-grey-7'))
           .should('contain', card.handle)
           .then(($title) => {
             expect($title.text()).to.equal(card.handle);

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -5,6 +5,7 @@ import { i18n } from '../../boot/i18n';
 import { cardsOffer } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
 
 const card = cardsOffer[0];
 
@@ -115,7 +116,7 @@ describe('<CardOffer>', () => {
         cy.dataCy('card-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -138,7 +138,7 @@ describe('<CardOffer>', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer')
           .should('be.visible')
-          .should('have.backgroundColor', '#ffffff');
+          .should('have.backgroundColor', '#fff');
       });
     });
 
@@ -171,7 +171,7 @@ describe('<CardOffer>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', card.content);
       });
     });

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import CardOffer from '../CardOffer.vue';
 import { i18n } from '../../boot/i18n';
 import { cardsOffer } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const card = cardsOffer[0];
 
@@ -111,7 +115,7 @@ describe('<CardOffer>', () => {
         cy.dataCy('card-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);

--- a/src/components/__tests__/CardPost.cy.js
+++ b/src/components/__tests__/CardPost.cy.js
@@ -72,7 +72,7 @@ describe('<CardPost>', () => {
       cy.dataCy('card-post-date')
         .should('have.css', 'font-size', '12px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', '#78909c')
+        .should('have.color', getPaletteColor('blue-grey-5'))
         .should('contain', '1. Sep. 2023')
         .then(($date) => {
           // manual workaround to avoid having to calculate dynamic date

--- a/src/components/__tests__/CardPost.cy.js
+++ b/src/components/__tests__/CardPost.cy.js
@@ -4,6 +4,8 @@ import CardPost from '../CardPost.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey5 = getPaletteColor('blue-grey-5');
 
 // mocks
 import { cardsPost } from 'src/mocks/homepage';
@@ -59,7 +61,7 @@ describe('<CardPost>', () => {
       cy.dataCy('card-post-title')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('contain', card.title)
         .then(($title) => {
           expect($title.text()).to.equal(card.title);
@@ -72,7 +74,7 @@ describe('<CardPost>', () => {
       cy.dataCy('card-post-date')
         .should('have.css', 'font-size', '12px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', getPaletteColor('blue-grey-5'))
+        .should('have.color', blueGrey5)
         .should('contain', '1. Sep. 2023')
         .then(($date) => {
           // manual workaround to avoid having to calculate dynamic date

--- a/src/components/__tests__/CardPost.cy.js
+++ b/src/components/__tests__/CardPost.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import CardPost from '../CardPost.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 // mocks
 import { cardsPost } from 'src/mocks/homepage';
@@ -55,7 +59,7 @@ describe('<CardPost>', () => {
       cy.dataCy('card-post-title')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', '#212121')
+        .should('have.color', getPaletteColor('grey-10'))
         .should('contain', card.title)
         .then(($title) => {
           expect($title.text()).to.equal(card.title);

--- a/src/components/__tests__/CardPost.cy.js
+++ b/src/components/__tests__/CardPost.cy.js
@@ -26,7 +26,7 @@ describe('<CardPost>', () => {
     cy.window().then(() => {
       cy.dataCy('card-post')
         .should('be.visible')
-        .should('have.backgroundColor', '#ffffff');
+        .should('have.backgroundColor', '#fff');
     });
   });
 

--- a/src/components/__tests__/CardProgress.cy.js
+++ b/src/components/__tests__/CardProgress.cy.js
@@ -5,6 +5,10 @@ import { i18n } from '../../boot/i18n';
 import { cardsProgress } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey1 = getPaletteColor('blue-grey-1');
+const blueGrey5 = getPaletteColor('blue-grey-5');
+const blueGrey7 = getPaletteColor('blue-grey-7');
 
 const cardFirst = cardsProgress[0];
 const card = cardsProgress[1];
@@ -75,7 +79,7 @@ describe('<CardProgress>', () => {
     it('renders dark separator', () => {
       cy.dataCy('card-progress-separator').should(
         'have.backgroundColor',
-        getPaletteColor('blue-grey-7'),
+        blueGrey7,
       );
     });
 
@@ -111,7 +115,7 @@ describe('<CardProgress>', () => {
         cy.dataCy('card-progress-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);
@@ -123,7 +127,7 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', getPaletteColor('blue-grey-5'))
+        .should('have.color', blueGrey5)
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });
@@ -147,24 +151,24 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-prize-placement')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '700')
-        .should('have.color', getPaletteColor('grey-10'));
+        .should('have.color', grey10);
 
       cy.dataCy('card-progress-prize-label')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', getPaletteColor('grey-10'));
+        .should('have.color', grey10);
     });
 
     it('renders light separator', () => {
       cy.dataCy('card-progress-separator').should(
         'have.backgroundColor',
-        getPaletteColor('blue-grey-1'),
+        blueGrey1,
       );
     });
 
     it('renders dark share link', () => {
       cy.dataCy('card-progress-share')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'text-transform', 'uppercase')
         .should('have.css', 'font-weight', '700');
@@ -172,7 +176,7 @@ describe('<CardProgress>', () => {
 
     it('renders dark share link icon', () => {
       cy.dataCy('card-progress-share-icon')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px')
         .should('contain', 'share');
@@ -194,7 +198,7 @@ describe('<CardProgress>', () => {
         cy.dataCy('card-progress-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);
@@ -206,7 +210,7 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', getPaletteColor('blue-grey-5'))
+        .should('have.color', blueGrey5)
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });

--- a/src/components/__tests__/CardProgress.cy.js
+++ b/src/components/__tests__/CardProgress.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import CardProgress from '../CardProgress.vue';
 import { i18n } from '../../boot/i18n';
 import { cardsProgress } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const cardFirst = cardsProgress[0];
 const card = cardsProgress[1];
@@ -71,8 +75,8 @@ describe('<CardProgress>', () => {
     it('renders dark separator', () => {
       cy.dataCy('card-progress-separator').should(
         'have.backgroundColor',
-        '#546e7a',
-      ); // bg-blue-grey-7
+        getPaletteColor('blue-grey-7'),
+      );
     });
 
     it('renders white share link', () => {
@@ -107,7 +111,7 @@ describe('<CardProgress>', () => {
         cy.dataCy('card-progress-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);
@@ -119,7 +123,7 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', '#78909c') // blue-grey-5
+        .should('have.color', getPaletteColor('blue-grey-5'))
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });
@@ -143,24 +147,24 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-prize-placement')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '700')
-        .should('have.color', '#212121');
+        .should('have.color', getPaletteColor('grey-10'));
 
       cy.dataCy('card-progress-prize-label')
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400')
-        .should('have.color', '#212121');
+        .should('have.color', getPaletteColor('grey-10'));
     });
 
     it('renders light separator', () => {
       cy.dataCy('card-progress-separator').should(
         'have.backgroundColor',
-        '#eceff1',
-      ); // bg-blue-grey-1
+        getPaletteColor('blue-grey-1'),
+      );
     });
 
     it('renders dark share link', () => {
       cy.dataCy('card-progress-share')
-        .should('have.color', '#212121')
+        .should('have.color', getPaletteColor('grey-10'))
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'text-transform', 'uppercase')
         .should('have.css', 'font-weight', '700');
@@ -168,7 +172,7 @@ describe('<CardProgress>', () => {
 
     it('renders dark share link icon', () => {
       cy.dataCy('card-progress-share-icon')
-        .should('have.color', '#212121')
+        .should('have.color', getPaletteColor('grey-10'))
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px')
         .should('contain', 'share');
@@ -190,7 +194,7 @@ describe('<CardProgress>', () => {
         cy.dataCy('card-progress-title')
           .should('have.css', 'font-size', '16px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', card.title)
           .then(($title) => {
             expect($title.text()).to.equal(card.title);
@@ -202,7 +206,7 @@ describe('<CardProgress>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', '#78909c') // blue-grey-5
+        .should('have.color', getPaletteColor('blue-grey-5'))
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });

--- a/src/components/__tests__/CardProgressSlider.cy.js
+++ b/src/components/__tests__/CardProgressSlider.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import CardProgressSlider from '../CardProgressSlider.vue';
 import { i18n } from '../../boot/i18n';
 import { cardsProgressSlider } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const card = cardsProgressSlider[0];
 
@@ -40,7 +44,7 @@ describe('<CardProgressSlider>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', '#eceff1') // blue-grey-1
+        .should('have.color', getPaletteColor('blue-grey-1'))
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });
@@ -154,7 +158,7 @@ describe('<CardProgressSlider>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', '#eceff1') // blue-grey-1
+        .should('have.color', getPaletteColor('blue-grey-1'))
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });

--- a/src/components/__tests__/CardProgressSlider.cy.js
+++ b/src/components/__tests__/CardProgressSlider.cy.js
@@ -5,6 +5,7 @@ import { i18n } from '../../boot/i18n';
 import { cardsProgressSlider } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const blueGrey1 = getPaletteColor('blue-grey-1');
 
 const card = cardsProgressSlider[0];
 
@@ -44,7 +45,7 @@ describe('<CardProgressSlider>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', getPaletteColor('blue-grey-1'))
+        .should('have.color', blueGrey1)
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });
@@ -158,7 +159,7 @@ describe('<CardProgressSlider>', () => {
       cy.dataCy('card-progress-header')
         .find('.q-icon')
         .should('contain', card.icon)
-        .should('have.color', getPaletteColor('blue-grey-1'))
+        .should('have.color', blueGrey1)
         .should('have.css', 'width', '18px')
         .should('have.css', 'height', '18px');
     });

--- a/src/components/__tests__/CardStats.cy.js
+++ b/src/components/__tests__/CardStats.cy.js
@@ -5,6 +5,7 @@ import { i18n } from '../../boot/i18n';
 import { cardsStats } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const blueGrey3 = getPaletteColor('blue-grey-3');
 
 const card = cardsStats[0];
 
@@ -39,7 +40,7 @@ describe('<CardStats>', () => {
     it('renders icon', () => {
       cy.dataCy('card-stats-icon')
         .should('contain', card.icon)
-        .should('have.color', getPaletteColor('blue-grey-3'))
+        .should('have.color', blueGrey3)
         .should('have.css', 'width', '48px')
         .should('have.css', 'height', '48px');
     });
@@ -59,7 +60,7 @@ describe('<CardStats>', () => {
         cy.wrap($item)
           .find('.q-icon')
           .should('contain', card.stats[index].icon)
-          .should('have.color', getPaletteColor('blue-grey-3'))
+          .should('have.color', blueGrey3)
           .should('have.css', 'width', '14px')
           .should('have.css', 'height', '14px');
       });

--- a/src/components/__tests__/CardStats.cy.js
+++ b/src/components/__tests__/CardStats.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import CardStats from '../CardStats.vue';
 import { i18n } from '../../boot/i18n';
 import { cardsStats } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 const card = cardsStats[0];
 
@@ -35,7 +39,7 @@ describe('<CardStats>', () => {
     it('renders icon', () => {
       cy.dataCy('card-stats-icon')
         .should('contain', card.icon)
-        .should('have.color', '#b0bec5') // blue-grey-3
+        .should('have.color', getPaletteColor('blue-grey-3'))
         .should('have.css', 'width', '48px')
         .should('have.css', 'height', '48px');
     });
@@ -55,7 +59,7 @@ describe('<CardStats>', () => {
         cy.wrap($item)
           .find('.q-icon')
           .should('contain', card.stats[index].icon)
-          .should('have.color', '#b0bec5') // blue-grey-3
+          .should('have.color', getPaletteColor('blue-grey-3'))
           .should('have.css', 'width', '14px')
           .should('have.css', 'height', '14px');
       });

--- a/src/components/__tests__/DrawerHeader.cy.js
+++ b/src/components/__tests__/DrawerHeader.cy.js
@@ -87,7 +87,7 @@ describe('<DrawerHeader>', () => {
     cy.window().then(() => {
       cy.dataCy('icon-notification')
         .should('be.visible')
-        .should('have.color', '#000000')
+        .should('have.color', '#000')
         .should('have.css', 'width', '24px')
         .should('contain.text', 'notifications');
     });

--- a/src/components/__tests__/DrawerHeader.cy.js
+++ b/src/components/__tests__/DrawerHeader.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import DrawerHeader from '../DrawerHeader.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 describe('<DrawerHeader>', () => {
   beforeEach(() => {
@@ -21,7 +25,7 @@ describe('<DrawerHeader>', () => {
     ];
 
     const translationKeyList = translationStrings.map(
-      (item) => `index.help.${item}`
+      (item) => `index.help.${item}`,
     );
 
     translationKeyList.forEach((translationKey) => {
@@ -54,7 +58,7 @@ describe('<DrawerHeader>', () => {
       .should('be.visible')
       .should('have.css', 'font-size', '8px')
       .should('have.css', 'font-weight', '500')
-      .should('have.backgroundColor', '#212121')
+      .should('have.backgroundColor', getPaletteColor('grey-10'))
       .should('have.css', 'border-radius', '50%'); // round
     cy.dataCy('button-help').should('contain', 'question_mark');
   });

--- a/src/components/__tests__/DrawerHeader.cy.js
+++ b/src/components/__tests__/DrawerHeader.cy.js
@@ -4,6 +4,7 @@ import DrawerHeader from '../DrawerHeader.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
 
 describe('<DrawerHeader>', () => {
   beforeEach(() => {
@@ -58,7 +59,7 @@ describe('<DrawerHeader>', () => {
       .should('be.visible')
       .should('have.css', 'font-size', '8px')
       .should('have.css', 'font-weight', '500')
-      .should('have.backgroundColor', getPaletteColor('grey-10'))
+      .should('have.backgroundColor', grey10)
       .should('have.css', 'border-radius', '50%'); // round
     cy.dataCy('button-help').should('contain', 'question_mark');
   });

--- a/src/components/__tests__/FooterBar.cy.js
+++ b/src/components/__tests__/FooterBar.cy.js
@@ -34,7 +34,7 @@ describe('<FooterBar>', () => {
         cy.dataCy('footer-logo')
           .should('be.visible')
           .should('have.css', 'height', '40px')
-          .should('have.color', '#ffffff');
+          .should('have.color', '#fff');
       });
     });
 
@@ -53,7 +53,7 @@ describe('<FooterBar>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#ffffff');
+          .should('have.color', '#fff');
       });
     });
 
@@ -63,7 +63,7 @@ describe('<FooterBar>', () => {
           .should('be.visible')
           .should('have.css', 'width', '38px')
           .should('have.css', 'height', '38px')
-          .should('have.color', '#ffffff');
+          .should('have.color', '#fff');
       });
     });
 
@@ -75,7 +75,7 @@ describe('<FooterBar>', () => {
           .should('have.css', 'flex-wrap', 'wrap')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#ffffff');
+          .should('have.color', '#fff');
       });
     });
   });

--- a/src/components/__tests__/FormLogin.cy.js
+++ b/src/components/__tests__/FormLogin.cy.js
@@ -1,8 +1,10 @@
 import { colors } from 'quasar';
-const { getPaletteColor } = colors;
 
 import FormLogin from '../FormLogin.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
 
 const rideToWorkByBikeConfig = JSON.parse(
   process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
@@ -40,7 +42,7 @@ describe('<FormLogin>', () => {
     it('renders title', () => {
       cy.dataCy('form-title-login')
         .should('be.visible')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'font-size', '24px')
         .should('have.css', 'font-weight', '700')
         .should('contain', i18n.global.t('login.form.titleLogin'));
@@ -129,7 +131,7 @@ describe('<FormLogin>', () => {
       cy.dataCy('form-password-reset').should('be.visible');
       cy.dataCy('form-password-reset-title')
         .should('be.visible')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'font-size', '24px')
         .should('have.css', 'font-weight', '700')
         .should('contain', i18n.global.t('login.form.titlePasswordReset'));
@@ -140,7 +142,7 @@ describe('<FormLogin>', () => {
       cy.dataCy('form-password-reset').should('be.visible');
       cy.dataCy('form-password-reset-description')
         .should('be.visible')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '400')
         .should(

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import HelpButton from '../HelpButton.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 const rideToWorkByBikeConfig = JSON.parse(
   process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
@@ -28,7 +32,7 @@ describe('<HelpButton>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '13px')
           .should('have.css', 'font-weight', '500')
-          .should('have.backgroundColor', '#212121')
+          .should('have.backgroundColor', getPaletteColor('grey-10'))
           .should('have.css', 'border-radius', '50%') // round
           .should('contain', 'question_mark');
       });
@@ -115,7 +119,7 @@ describe('<HelpButton>', () => {
         .should('be.visible')
         .should('have.css', 'font-size', '8px')
         .should('have.css', 'font-weight', '500')
-        .should('have.backgroundColor', '#212121')
+        .should('have.backgroundColor', getPaletteColor('grey-10'))
         .should('have.css', 'border-radius', '50%'); // round
       cy.dataCy('button-help').should('contain', 'question_mark');
     });

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -4,6 +4,7 @@ import HelpButton from '../HelpButton.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
 
 const rideToWorkByBikeConfig = JSON.parse(
   process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
@@ -32,7 +33,7 @@ describe('<HelpButton>', () => {
           .should('be.visible')
           .should('have.css', 'font-size', '13px')
           .should('have.css', 'font-weight', '500')
-          .should('have.backgroundColor', getPaletteColor('grey-10'))
+          .should('have.backgroundColor', grey10)
           .should('have.css', 'border-radius', '50%') // round
           .should('contain', 'question_mark');
       });
@@ -119,7 +120,7 @@ describe('<HelpButton>', () => {
         .should('be.visible')
         .should('have.css', 'font-size', '8px')
         .should('have.css', 'font-weight', '500')
-        .should('have.backgroundColor', getPaletteColor('grey-10'))
+        .should('have.backgroundColor', grey10)
         .should('have.css', 'border-radius', '50%'); // round
       cy.dataCy('button-help').should('contain', 'question_mark');
     });

--- a/src/components/__tests__/ListCardFollow.cy.js
+++ b/src/components/__tests__/ListCardFollow.cy.js
@@ -24,7 +24,7 @@ describe('<ListCardFollow>', () => {
         cy.dataCy('card-list-follow-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', i18n.global.t('index.cardListFollow.title'))
           .then(($title) => {
             expect($title.text()).to.equal(

--- a/src/components/__tests__/ListCardOffer.cy.js
+++ b/src/components/__tests__/ListCardOffer.cy.js
@@ -31,7 +31,7 @@ describe('<ListCardOffer>', () => {
         cy.dataCy('card-list-post-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -81,7 +81,7 @@ describe('<ListCardOffer>', () => {
         cy.dataCy('card-list-post-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);

--- a/src/components/__tests__/ListCardPost.cy.js
+++ b/src/components/__tests__/ListCardPost.cy.js
@@ -37,7 +37,7 @@ describe('<ListCardPost>', () => {
         cy.dataCy('card-list-post-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -143,7 +143,7 @@ describe('<ListCardPost>', () => {
         cy.dataCy('card-list-post-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);

--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import ListCardProgress from '../ListCardProgress.vue';
 import { i18n } from '../../boot/i18n';
 import { progressStats, cardsProgress } from '../../mocks/homepage';
+
+const { getPaletteColor } = colors;
 
 describe('<ListCardProgress>', () => {
   it('has translation for all strings', () => {
@@ -47,7 +51,7 @@ describe('<ListCardProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('.q-icon')
@@ -59,12 +63,12 @@ describe('<ListCardProgress>', () => {
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', '#212121')
+            .should('have.color', getPaletteColor('grey-10'))
             .should('have.css', 'font-weight', '700');
         });
       });

--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -5,6 +5,8 @@ import { i18n } from '../../boot/i18n';
 import { progressStats, cardsProgress } from '../../mocks/homepage';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey3 = getPaletteColor('blue-grey-3');
 
 describe('<ListCardProgress>', () => {
   it('has translation for all strings', () => {
@@ -51,24 +53,24 @@ describe('<ListCardProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', getPaletteColor('blue-grey-3'))
+            .should('have.color', blueGrey3)
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', getPaletteColor('grey-10'))
+            .should('have.color', grey10)
             .should('have.css', 'font-weight', '700');
         });
       });

--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -56,7 +56,7 @@ describe('<ListCardProgress>', () => {
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', '#b0bec5')
+            .should('have.color', getPaletteColor('blue-grey-3'))
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 

--- a/src/components/__tests__/MenuLinks.cy.js
+++ b/src/components/__tests__/MenuLinks.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import MenuLinks from '../MenuLinks.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 describe('<MenuLinks>', () => {
   context('social', () => {
@@ -42,7 +46,7 @@ describe('<MenuLinks>', () => {
         // .should('have.attr', 'href', 'https://twitter.com/spolekautomat')
         .should('contain', i18n.global.t('index.menuLinks.youtube'))
         // .should('have.attr', 'href', 'https://www.youtube.com/@spolekautomat')
-        .should('have.backgroundColor', '#eceff1')
+        .should('have.backgroundColor', getPaletteColor('blue-grey-1'))
         .should('have.css', 'border-radius', '28px')
         .should('have.css', 'margin-top', '16px')
         .find('.q-btn__content span')
@@ -72,7 +76,7 @@ describe('<MenuLinks>', () => {
         .should('contain', 'Podpořte nás')
         .should('contain', 'Kód projektu')
         .should('contain', 'Mobilní aplikace')
-        .should('have.backgroundColor', '#eceff1')
+        .should('have.backgroundColor', getPaletteColor('blue-grey-1'))
         .should('have.css', 'border-radius', '28px')
         .should('have.css', 'margin-top', '16px')
         .find('.q-btn__content span')

--- a/src/components/__tests__/MenuLinks.cy.js
+++ b/src/components/__tests__/MenuLinks.cy.js
@@ -4,6 +4,7 @@ import MenuLinks from '../MenuLinks.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const blueGrey1 = getPaletteColor('blue-grey-1');
 
 describe('<MenuLinks>', () => {
   context('social', () => {
@@ -46,7 +47,7 @@ describe('<MenuLinks>', () => {
         // .should('have.attr', 'href', 'https://twitter.com/spolekautomat')
         .should('contain', i18n.global.t('index.menuLinks.youtube'))
         // .should('have.attr', 'href', 'https://www.youtube.com/@spolekautomat')
-        .should('have.backgroundColor', getPaletteColor('blue-grey-1'))
+        .should('have.backgroundColor', blueGrey1)
         .should('have.css', 'border-radius', '28px')
         .should('have.css', 'margin-top', '16px')
         .find('.q-btn__content span')
@@ -76,7 +77,7 @@ describe('<MenuLinks>', () => {
         .should('contain', 'Podpořte nás')
         .should('contain', 'Kód projektu')
         .should('contain', 'Mobilní aplikace')
-        .should('have.backgroundColor', getPaletteColor('blue-grey-1'))
+        .should('have.backgroundColor', blueGrey1)
         .should('have.css', 'border-radius', '28px')
         .should('have.css', 'margin-top', '16px')
         .find('.q-btn__content span')

--- a/src/components/__tests__/NewsletterFeature.cy.js
+++ b/src/components/__tests__/NewsletterFeature.cy.js
@@ -31,7 +31,7 @@ describe('<NewsletterFeature>', () => {
         cy.dataCy('newsletter-feature-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', i18n.global.t('index.newsletterFeature.title'))
           .then(($title) => {
             expect($title.text()).to.equal(
@@ -46,7 +46,7 @@ describe('<NewsletterFeature>', () => {
         cy.dataCy('newsletter-feature-description')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.description'),
@@ -118,7 +118,7 @@ describe('<NewsletterFeature>', () => {
         cy.dataCy('newsletter-feature-title')
           .should('have.css', 'font-size', '20px')
           .should('have.css', 'font-weight', '500')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should('contain', i18n.global.t('index.newsletterFeature.title'))
           .then(($title) => {
             expect($title.text()).to.equal(
@@ -133,7 +133,7 @@ describe('<NewsletterFeature>', () => {
         cy.dataCy('newsletter-feature-description')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#000000')
+          .should('have.color', '#000')
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.description'),

--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -1,5 +1,9 @@
+import { colors } from 'quasar';
+
 import NewsletterItem from '../NewsletterItem.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 const icon = 'people';
 const title = i18n.global.t('index.newsletterFeature.aboutEvents');
@@ -45,7 +49,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -72,7 +76,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.css', 'border-radius', '28px')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.following'),
@@ -83,7 +87,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '18px')
           .should('have.css', 'height', '18px')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', 'check');
       });
     });
@@ -109,7 +113,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -136,7 +140,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.css', 'border-radius', '28px')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.following'),
@@ -147,7 +151,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '18px')
           .should('have.css', 'height', '18px')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', 'check');
       });
 
@@ -195,7 +199,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', '#212121')
+          .should('have.color', getPaletteColor('grey-10'))
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -211,7 +215,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.color', '#ffffff')
-          .should('have.backgroundColor', '#212121')
+          .should('have.backgroundColor', getPaletteColor('grey-10'))
           .should('contain', i18n.global.t('index.newsletterFeature.follow'));
 
         cy.dataCy('newsletter-item-button')

--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -63,7 +63,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '32px')
           .should('have.css', 'height', '32px')
-          .should('have.color', '#607d8b')
+          .should('have.color', getPaletteColor('blue-grey-6'))
           .should('contain', icon);
       });
     });
@@ -127,7 +127,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '32px')
           .should('have.css', 'height', '32px')
-          .should('have.color', '#607d8b')
+          .should('have.color', getPaletteColor('blue-grey-6'))
           .should('contain', icon);
       });
     });

--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -4,6 +4,8 @@ import NewsletterItem from '../NewsletterItem.vue';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey6 = getPaletteColor('blue-grey-6');
 
 const icon = 'people';
 const title = i18n.global.t('index.newsletterFeature.aboutEvents');
@@ -49,7 +51,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -63,7 +65,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '32px')
           .should('have.css', 'height', '32px')
-          .should('have.color', getPaletteColor('blue-grey-6'))
+          .should('have.color', blueGrey6)
           .should('contain', icon);
       });
     });
@@ -76,7 +78,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.css', 'border-radius', '28px')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.following'),
@@ -87,7 +89,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '18px')
           .should('have.css', 'height', '18px')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', 'check');
       });
     });
@@ -113,7 +115,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '400')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -127,7 +129,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '32px')
           .should('have.css', 'height', '32px')
-          .should('have.color', getPaletteColor('blue-grey-6'))
+          .should('have.color', blueGrey6)
           .should('contain', icon);
       });
     });
@@ -140,7 +142,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.css', 'border-radius', '28px')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should(
             'contain',
             i18n.global.t('index.newsletterFeature.following'),
@@ -151,7 +153,7 @@ describe('<NewsletterItem>', () => {
           .should('be.visible')
           .should('have.css', 'width', '18px')
           .should('have.css', 'height', '18px')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', 'check');
       });
 
@@ -199,7 +201,7 @@ describe('<NewsletterItem>', () => {
         cy.dataCy('newsletter-item-title')
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '700')
-          .should('have.color', getPaletteColor('grey-10'))
+          .should('have.color', grey10)
           .should('contain', title)
           .then(($title) => {
             expect($title.text()).to.equal(title);
@@ -215,7 +217,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
           .should('have.color', '#fff')
-          .should('have.backgroundColor', getPaletteColor('grey-10'))
+          .should('have.backgroundColor', grey10)
           .should('contain', i18n.global.t('index.newsletterFeature.follow'));
 
         cy.dataCy('newsletter-item-button')

--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -214,7 +214,7 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-size', '14px')
           .should('have.css', 'font-weight', '500')
           .should('have.css', 'text-transform', 'uppercase')
-          .should('have.color', '#ffffff')
+          .should('have.color', '#fff')
           .should('have.backgroundColor', getPaletteColor('grey-10'))
           .should('contain', i18n.global.t('index.newsletterFeature.follow'));
 

--- a/src/components/__tests__/SliderProgress.cy.js
+++ b/src/components/__tests__/SliderProgress.cy.js
@@ -63,7 +63,7 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', '#b0bec5')
+            .should('have.color', getPaletteColor('blue-grey-3'))
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 
@@ -204,7 +204,7 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', '#b0bec5')
+            .should('have.color', getPaletteColor('blue-grey-3'))
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 

--- a/src/components/__tests__/SliderProgress.cy.js
+++ b/src/components/__tests__/SliderProgress.cy.js
@@ -1,6 +1,10 @@
+import { colors } from 'quasar';
+
 import SliderProgress from '../SliderProgress.vue';
 import { hexToRgb } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
 
 // mocks
 import { progressStats, cardsProgress } from 'src/mocks/homepage';
@@ -54,7 +58,7 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('.q-icon')
@@ -66,12 +70,12 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', '#212121')
+            .should('have.color', getPaletteColor('grey-10'))
             .should('have.css', 'font-weight', '700');
         });
       });
@@ -145,7 +149,7 @@ describe('<SliderProgress>', () => {
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '500')
         .should('have.css', 'text-transform', 'uppercase')
-        .should('have.color', '#212121')
+        .should('have.color', getPaletteColor('grey-10'))
         .should('have.css', 'border-radius', '28px')
         .should('contain', i18n.global.t('index.progressSlider.button'))
         .then(($title) => {
@@ -195,7 +199,7 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('.q-icon')
@@ -207,12 +211,12 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', '#212121');
+            .should('have.color', getPaletteColor('grey-10'));
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', '#212121')
+            .should('have.color', getPaletteColor('grey-10'))
             .should('have.css', 'font-weight', '700');
         });
       });

--- a/src/components/__tests__/SliderProgress.cy.js
+++ b/src/components/__tests__/SliderProgress.cy.js
@@ -5,6 +5,8 @@ import { hexToRgb } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+const blueGrey3 = getPaletteColor('blue-grey-3');
 
 // mocks
 import { progressStats, cardsProgress } from 'src/mocks/homepage';
@@ -58,24 +60,24 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', getPaletteColor('blue-grey-3'))
+            .should('have.color', blueGrey3)
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', getPaletteColor('grey-10'))
+            .should('have.color', grey10)
             .should('have.css', 'font-weight', '700');
         });
       });
@@ -149,7 +151,7 @@ describe('<SliderProgress>', () => {
         .should('have.css', 'font-size', '14px')
         .should('have.css', 'font-weight', '500')
         .should('have.css', 'text-transform', 'uppercase')
-        .should('have.color', getPaletteColor('grey-10'))
+        .should('have.color', grey10)
         .should('have.css', 'border-radius', '28px')
         .should('contain', i18n.global.t('index.progressSlider.button'))
         .then(($title) => {
@@ -199,24 +201,24 @@ describe('<SliderProgress>', () => {
           cy.wrap($item)
             .should('have.css', 'font-size', '14px')
             .should('have.css', 'font-weight', '400')
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('.q-icon')
             .should('contain', progressStats[index].icon)
-            .should('have.color', getPaletteColor('blue-grey-3'))
+            .should('have.color', blueGrey3)
             .should('have.css', 'width', '18px')
             .should('have.css', 'height', '18px');
 
           cy.wrap($item)
             .find('span')
             .should('contain', progressStats[index].label)
-            .should('have.color', getPaletteColor('grey-10'));
+            .should('have.color', grey10);
 
           cy.wrap($item)
             .find('strong')
             .should('contain', progressStats[index].value)
-            .should('have.color', getPaletteColor('grey-10'))
+            .should('have.color', grey10)
             .should('have.css', 'font-weight', '700');
         });
       });


### PR DESCRIPTION
* Replace hard coded hex color values with `getPaletteColor` fn
* Shorten 6 character hex values to 3 character hex values
* Fix lint errors