### PR TITLE
src/boot: declare global color config vars

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -33,7 +33,7 @@ module.exports = configure(function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ['logger', 'i18n', 'swiper'],
+    boot: ['logger', 'i18n', 'swiper', 'global_vars'],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ['app.scss'],

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -5,6 +5,8 @@ colorPrimary = "#43449C"
 colorSecondary = "#A0D7C4"
 colorGrayLight = "#F3F7FF"
 colorGrayMiddle = "#DCE1ED"
+colorWhite = "#FFFFFF"
+colorBlack = "#000000"
 
 image = "image.png"
 width = "850px"

--- a/src/boot/global_vars.js
+++ b/src/boot/global_vars.js
@@ -11,6 +11,7 @@ const initVars = () => {
   setCssVar('black', rideToWorkByBikeConfig.colorBlack);
   setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
   setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
+  setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
 };
 
 export { rideToWorkByBikeConfig, initVars };

--- a/src/boot/global_vars.js
+++ b/src/boot/global_vars.js
@@ -1,0 +1,20 @@
+import { setCssVar } from 'quasar';
+import { boot } from 'quasar/wrappers';
+
+// config
+const rideToWorkByBikeConfig = JSON.parse(
+  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
+);
+
+const initVars = () => {
+  setCssVar('white', rideToWorkByBikeConfig.colorWhite);
+  setCssVar('black', rideToWorkByBikeConfig.colorBlack);
+  setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
+  setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
+};
+
+export { rideToWorkByBikeConfig, initVars };
+
+export default boot(() => {
+  initVars();
+});

--- a/src/components/BannerImage.vue
+++ b/src/components/BannerImage.vue
@@ -21,7 +21,6 @@
  */
 
 // libraries
-import { setCssVar } from 'quasar';
 import { defineComponent } from 'vue';
 
 // types
@@ -31,7 +30,6 @@ import { BannerImage as BannerImageType, ConfigGlobal } from './types';
 const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
   process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
 );
-setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
 
 export default defineComponent({
   name: 'BannerImage',

--- a/src/components/CountdownChallenge.vue
+++ b/src/components/CountdownChallenge.vue
@@ -21,18 +21,9 @@
 
 // libraries
 import { defineComponent } from 'vue';
-import { setCssVar } from 'quasar';
 
 // composables
 import { useCountdown } from '../composables/useCountdown';
-
-// types
-import type { ConfigGlobal } from './types';
-
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
 
 export default defineComponent({
   name: 'CountdownChallenge',

--- a/src/components/CountdownEvent.vue
+++ b/src/components/CountdownEvent.vue
@@ -21,22 +21,14 @@
  * <countdown-event :releaseDate="targetDate" />
  */
 
-import { setCssVar, date } from 'quasar';
+import { date } from 'quasar';
 import { defineComponent } from 'vue';
 // import { useI18n } from 'vue-i18n'
 
 // composables
 import { useCountdown } from '../composables/useCountdown';
 
-// types
-import type { ConfigGlobal } from './types';
-
 const { formatDate } = date;
-
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
 
 export default defineComponent({
   name: 'CountdownEvent',

--- a/src/components/FormLogin.vue
+++ b/src/components/FormLogin.vue
@@ -18,16 +18,6 @@
 
 // libraries
 import { defineComponent, ref, reactive } from 'vue';
-import { setCssVar } from 'quasar';
-
-// types
-import type { ConfigGlobal } from './types';
-
-// config
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
 
 export default defineComponent({
   name: 'FormLogin',

--- a/src/components/HelpButton.vue
+++ b/src/components/HelpButton.vue
@@ -27,23 +27,13 @@
  */
 
 // libraries
-import { setCssVar } from 'quasar';
 import { defineComponent, ref } from 'vue';
-
-// types
-import { ConfigGlobal } from './types';
 
 // components
 import ContactForm from './ContactForm.vue';
 import DialogStates from './DialogStates.vue';
 import ListFaq from './ListFaq.vue';
 import MenuLinks from './MenuLinks.vue';
-
-// config
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
 
 export default defineComponent({
   name: 'HelpButton',

--- a/src/components/LanguageSwitcher.vue
+++ b/src/components/LanguageSwitcher.vue
@@ -24,17 +24,8 @@
  */
 
 // libraries
-import { setCssVar } from 'quasar';
 import { defineComponent } from 'vue';
 import { i18n } from '../boot/i18n';
-
-// types
-import { ConfigGlobal } from './types';
-
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
 
 export default defineComponent({
   name: 'LanguageSwitcher',

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -3,6 +3,8 @@ export interface ConfigGlobal {
   colorSecondary: string;
   colorGrayLight: string;
   colorGrayMiddle: string;
+  colorWhite: string;
+  colorBlack: string;
   image: string;
   width: string;
   title: string;

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 // libraries
-import { setCssVar } from 'quasar';
 import { defineComponent } from 'vue';
 import { i18n } from '../boot/i18n';
 
@@ -11,19 +10,10 @@ import DrawerMenu from 'components/DrawerMenu.vue';
 import FooterBar from 'components/FooterBar.vue';
 import MobileBottomPanel from 'components/MobileBottomPanel.vue';
 
-// import types
-import { ConfigGlobal } from 'components/types';
-
 // set global i18n object (for test purposes)
 if (window.Cypress) {
   window.i18n = i18n;
 }
-
-// import config
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
 
 export default defineComponent({
   name: 'MainLayout',

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -20,23 +20,12 @@
  */
 
 // libraries
-import { setCssVar } from 'quasar';
 import { defineComponent } from 'vue';
-
-// types
-import { ConfigGlobal } from 'components/types';
 
 // components
 import HelpButton from 'components/HelpButton.vue';
 import LanguageSwitcher from 'components/LanguageSwitcher.vue';
 import FormLogin from 'components/FormLogin.vue';
-
-// config
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
-setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
-setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
 
 export default defineComponent({
   name: 'LoginPage',

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -14,6 +14,10 @@ const getAppConfig = (process) => {
     config['colorGrayLight'] = process.env.COLOR_GRAY_LIGHT;
   } else if (process.env.COLOR_GRAY_MIDDLE) {
     config['colorGrayMiddle'] = process.env.COLOR_GRAY_MIDDLE;
+  } else if (process.env.COLOR_WHITE) {
+    config['colorWhite'] = process.env.COLOR_WHITE;
+  } else if (process.env.COLOR_BLACK) {
+    config['colorBlack'] = process.env.COLOR_BLACK;
   } else if (process.env.IMAGE) {
     config['image'] = process.env.IMAGE;
   } else if (process.env.WIDTH) {

--- a/test/cypress/support/component.js
+++ b/test/cypress/support/component.js
@@ -38,6 +38,7 @@ const { config } = VueTestUtils;
 
 // Example to import i18n from boot and use as plugin
 // import { i18n } from 'src/boot/i18n';
+import { initVars } from 'src/boot/global_vars';
 
 // You can modify the global config here for all tests or pass in the configuration per test
 // For example use the actual i18n instance or mock it
@@ -63,6 +64,9 @@ Cypress.Commands.add('mount', (component, options = {}) => {
   options.global = options.global || {};
   options.global.plugins = options.global.plugins || [];
 
+  // Initialize global variables
+  initVars();
+
   // Register Swiper third party lib component
   register();
 
@@ -71,6 +75,7 @@ Cypress.Commands.add('mount', (component, options = {}) => {
     install(app) {
       app.use(i18nApp);
       app.use(VueLogger, loggerOptions);
+      app.use();
     },
   });
 


### PR DESCRIPTION
* Add boot file `global_vars.js` for central color class override
* Add `colorBlack` and `colorWhite` to config
* Add color override function to `cypress/support/component.js` to sync color variables in component tests 
* Remove global config from components if imported for css var override
* Replace hex values of black and white colors in tests with `getPaletteColor` fn vars

Note: Overriden color value `info` cannot be imported using the `getPaletteColor` fn inside tests (it returns default Quasar value). Currently using config object for test comparison.