### PR TITLE
src/components/__tests__: update test to correctly check for full width

### DIFF
--- a/src/components/__tests__/CardEvent.cy.js
+++ b/src/components/__tests__/CardEvent.cy.js
@@ -246,8 +246,8 @@ describe('<CardEvent>', () => {
 
     it('shows modal with one column', () => {
       cy.dataCy('card-link').click();
-      cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
-      cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 100);
+      cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 100);
     });
   });
 });

--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -201,8 +201,8 @@ describe('<CardOffer>', () => {
     it('shows modal with one column', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
-        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 100);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 100);
       });
     });
   });


### PR DESCRIPTION
Previously, the test for full width of the dialog would only pass for a lower value.
This is no longer the case - removing the workaround.