### PR TITLE
src/components: fix 'card-progress-share' test by explicitly defining text color

### DIFF
--- a/src/components/CardProgress.vue
+++ b/src/components/CardProgress.vue
@@ -180,6 +180,7 @@ export default defineComponent({
           clickable
           :to="card.url"
           class="justify-center items-center text-uppercase text-weight-bold q-py-sm"
+          :class="isDark(card) ? 'text-white' : 'text-grey-10'"
           :style="{ 'border-radius': borderRadius }"
           data-cy="card-progress-share"
         >


### PR DESCRIPTION
Tests in PR #121 fail on testing color in `CardProgress` component.

Element with `data-cy="card-progress-share"` should implicitly have text color set. However, browser does not seem to recognize this and renders it always with the same color (`rgb(67, 68, 156)`).

This change sets the color explicitly on the element.