### PR TITLE
test/cypress/e2e: use dynamic path for login tests + refactor lang switch test

### DIFF
--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -1,3 +1,4 @@
+import { testLanguageSwitcher } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 
 describe('Login page', () => {
@@ -107,42 +108,8 @@ describe('Login page', () => {
         });
     });
 
-    it('allows user to switch language', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          const locales = i18n.global.availableLocales;
-          const initialActiveLocale = i18n.global.locale;
-
-          // active language has active class
-          cy.dataCy('switcher-' + initialActiveLocale)
-            .find('.q-btn')
-            .should('have.class', 'bg-secondary');
-
-          locales.forEach((locale) => {
-            if (locale !== initialActiveLocale) {
-              // changing the language
-              cy.dataCy('switcher-' + locale)
-                .should('exist')
-                .and('be.visible')
-                .find('.q-btn')
-                .click();
-              // old language becomes inactive
-              cy.dataCy('switcher-' + initialActiveLocale)
-                .find('.q-btn')
-                .should('have.class', 'bg-white');
-              // new language becomes active
-              cy.dataCy('switcher-' + locale)
-                .find('.q-btn')
-                .should('have.class', 'bg-secondary');
-            }
-          });
-        });
-    });
+    // switching between languages can only be tested in E2E context
+    testLanguageSwitcher();
 
     it('renders form title', () => {
       let i18n;

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -1,7 +1,9 @@
+import { routesConf } from '../../../src/router/routes_conf';
+
 describe('Login page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('/#/login');
+      cy.visit('#' + routesConf['login']['path']);
       cy.viewport('macbook-16');
     });
 


### PR DESCRIPTION
In `login.spec.cy.js` make updates based on recent PRs:

* Use dynamic path from `routesConf`
* Use common testLanguageSwitcher() fn for testing the header language switcher