### PR TITLE
test/cypress/e2e: fix re-apply input widget lazy validation rules during component/e2e tests

### DIFF
--- a/src/components/__tests__/FormFieldEmail.cy.js
+++ b/src/components/__tests__/FormFieldEmail.cy.js
@@ -80,59 +80,41 @@ describe('<FormFieldEmail>', () => {
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('simple@example.com');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('very.common@example.com');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('x@example.com');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type(
         'long.email-address-with-hyphens@and.subdomains.example.com',
       );
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('user.name+tag+sorting@example.com');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('name/surname@example.com');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('mailhost!username@example.org');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('user%example.com@example.org');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
       // valid email
       cy.dataCy('form-email-input').type('user-@example.org');
-      cy.get(
-        '*[data-cy="form-email"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-email-input').clear();
     });
   });

--- a/src/components/__tests__/FormFieldPhone.cy.js
+++ b/src/components/__tests__/FormFieldPhone.cy.js
@@ -121,21 +121,15 @@ describe('<FormFieldPhone>', () => {
 
       // valid phone
       cy.dataCy('form-phone-input').type('+420 736 123 456');
-      cy.get(
-        '*[data-cy="form-phone"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-phone-input').clear();
       // valid phone
       cy.dataCy('form-phone-input').type('+420736123456');
-      cy.get(
-        '*[data-cy="form-phone"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
       cy.dataCy('form-phone-input').clear();
       // valid phone
       cy.dataCy('form-phone-input').type('736123456');
-      cy.get(
-        '*[data-cy="form-phone"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.get('.q-field__messages').should('be.empty');
     });
   });
 });

--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -136,9 +136,10 @@ describe('<FormRegister>', () => {
         );
       cy.dataCy('form-register-password-input').clear();
       cy.dataCy('form-register-password-input').type('12345a');
-      cy.get(
-        '*[data-cy="form-register-password"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.dataCy('form-register-password-input').blur();
+      cy.dataCy('form-register-password')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('register.form.hintPassword'));
     });
 
     it('validates password confirm correctly', () => {
@@ -157,6 +158,7 @@ describe('<FormRegister>', () => {
       cy.dataCy('form-register-password-confirm-input').clear();
       // test password confirm not matching
       cy.dataCy('form-register-password-confirm-input').type('12345b');
+      cy.dataCy('form-register-password-confirm-input').blur();
       cy.dataCy('form-register-password-confirm')
         .find('.q-field__messages')
         .should(
@@ -166,8 +168,10 @@ describe('<FormRegister>', () => {
       cy.dataCy('form-register-password-confirm-input').clear();
       // test password confirm matching
       cy.dataCy('form-register-password-confirm-input').type('12345a');
+      cy.dataCy('form-register-password-confirm-input').blur();
+      // testing non-existence of element fails on .find() method
       cy.get(
-        '*[data-cy="form-register-password-confirm"] .q-field__messages [role="alert"]',
+        '*[data-cy="form-register-coordinator-terms] .q-field__messages',
       ).should('not.exist');
     });
 

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -338,9 +338,9 @@ describe('<FormRegisterCoordinator>', () => {
         );
       cy.dataCy('form-register-coordinator-company').click();
       cy.get('.q-menu .q-item').first().click();
-      cy.get(
-        '*[data-cy="form-register-coordinator-company"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.dataCy('form-register-coordinator-company')
+        .find('.q-field__messages')
+        .should('be.empty');
     });
 
     it('validates password correctly', () => {
@@ -389,9 +389,10 @@ describe('<FormRegisterCoordinator>', () => {
         );
       cy.dataCy('form-register-coordinator-password-input').clear();
       cy.dataCy('form-register-coordinator-password-input').type('12345a');
-      cy.get(
-        '*[data-cy="form-register-coordinator-password"] .q-field__messages [role="alert"]',
-      ).should('not.exist');
+      cy.dataCy('form-register-coordinator-password-input').blur();
+      cy.dataCy('form-register-coordinator-password')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('register.form.hintPassword'));
     });
 
     it('validates password confirm correctly', () => {
@@ -428,6 +429,7 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-password-confirm-input').type(
         '12345b',
       );
+      cy.dataCy('form-register-coordinator-password-confirm-input').blur();
       cy.dataCy('form-register-coordinator-password-confirm')
         .find('.q-field__messages')
         .should(
@@ -441,8 +443,10 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-password-confirm-input').type(
         '12345a',
       );
+      cy.dataCy('form-register-coordinator-password-confirm-input').blur();
+      // testing non-existence of element fails on .find() method
       cy.get(
-        '*[data-cy="form-register-coordinator-password-confirm"] .q-field__messages [role="alert"]',
+        '*[data-cy="form-register-coordinator-terms] .q-field__messages',
       ).should('not.exist');
     });
 
@@ -479,6 +483,7 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-responsibility')
         .find('.q-checkbox')
         .click();
+      // testing non-existence of element fails on .find() method
       cy.get(
         '*[data-cy="form-register-coordinator-responsibility] .q-field__messages',
       ).should('not.exist');
@@ -494,6 +499,7 @@ describe('<FormRegisterCoordinator>', () => {
         );
       // test terms checkbox checked
       cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
+      // testing non-existence of element fails on .find() method
       cy.get(
         '*[data-cy="form-register-coordinator-terms] .q-field__messages',
       ).should('not.exist');

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -271,7 +271,7 @@ describe('<HelpButton>', () => {
         .type('question');
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
-        .should('not.be.visible');
+        .should('be.empty');
       cy.dataCy('contact-form-subject')
         .find('.q-field__control')
         .should('not.have.class', 'text-negative');

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -269,6 +269,7 @@ describe('<HelpButton>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
+      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
         .should('be.empty');

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -269,7 +269,6 @@ describe('<HelpButton>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
-      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
         .should('be.empty');

--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -101,6 +101,7 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
+      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
         .should('be.empty');

--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -72,6 +72,7 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
+      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-message-input')
         .should('be.visible')
         .type('what is the minimum distance to ride to work?');
@@ -101,6 +102,7 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
+      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
         .should('be.empty');

--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -72,7 +72,6 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
-      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-message-input')
         .should('be.visible')
         .type('what is the minimum distance to ride to work?');
@@ -102,7 +101,6 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-subject-input')
         .should('be.visible')
         .type('question');
-      cy.dataCy('contact-form-subject-input').blur();
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
         .should('be.empty');

--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -103,7 +103,7 @@ describe('<LoginRegisterHeader>', () => {
         .type('question');
       cy.dataCy('contact-form-subject')
         .find('.q-field__messages')
-        .should('not.be.visible');
+        .should('be.empty');
       cy.dataCy('contact-form-subject')
         .find('.q-field__control')
         .should('not.have.class', 'text-negative');

--- a/src/components/global/ContactForm.vue
+++ b/src/components/global/ContactForm.vue
@@ -23,6 +23,9 @@
 // libraries
 import { defineComponent, reactive } from 'vue';
 
+// composables
+import { useValidation } from 'src/composables/useValidation';
+
 export default defineComponent({
   name: 'ContactForm',
   emits: ['formSubmit'],
@@ -34,7 +37,7 @@ export default defineComponent({
       email: '',
     });
 
-    const isContactFormValid = (val: string): boolean => val?.length > 0;
+    const { isEmail, isFilled } = useValidation();
 
     const onSubmit = () => {
       emit('formSubmit');
@@ -45,7 +48,8 @@ export default defineComponent({
     return {
       contactForm,
       onSubmit,
-      isContactFormValid,
+      isEmail,
+      isFilled,
     };
   },
 });
@@ -59,17 +63,14 @@ export default defineComponent({
         {{ $t('index.contact.subject') }}
       </label>
       <q-input
+        dense
+        outlined
+        lazy-rules
         v-model="contactForm.subject"
         id="contact-form-subject"
         name="subject"
-        lazy-rules
-        :rules="[
-          (val) =>
-            isContactFormValid(val) || $t('index.contact.subjectRequired'),
-        ]"
+        :rules="[(val) => isFilled(val) || $t('index.contact.subjectRequired')]"
         class="q-mt-sm"
-        outlined
-        dense
         data-cy="contact-form-subject-input"
       />
     </div>
@@ -79,29 +80,27 @@ export default defineComponent({
         {{ $t('index.contact.message') }}
       </label>
       <q-input
+        dense
+        outlined
+        lazy-rules
         v-model="contactForm.message"
         id="contact-form-message"
         name="message"
         type="textarea"
-        :rules="[
-          (val) =>
-            isContactFormValid(val) || $t('index.contact.messageRequired'),
-        ]"
+        :rules="[(val) => isFilled(val) || $t('index.contact.messageRequired')]"
         class="q-mt-sm"
-        outlined
-        dense
         data-cy="contact-form-message-input"
       />
     </div>
     <!-- File input widget -->
     <div data-cy="contact-form-file">
       <q-file
+        dense
+        borderless
         v-model="contactForm.file"
         :label="$t('index.contact.file')"
         label-color="black"
         class="file-input text-body2 text-uppercase"
-        borderless
-        dense
         data-cy="contact-form-file-input"
       >
         <template v-slot:prepend>
@@ -115,17 +114,19 @@ export default defineComponent({
         {{ $t('index.contact.email') }}
       </label>
       <q-input
+        dense
+        outlined
+        lazy-rules
         v-model="contactForm.email"
         id="contact-form-email"
         name="email"
         type="email"
-        lazy-rules
         :rules="[
-          (val) => isContactFormValid(val) || $t('index.contact.emailRequired'),
+          (val) =>
+            (isFilled(val) && isEmail(val)) ||
+            $t('index.contact.emailRequired'),
         ]"
         class="q-mt-sm"
-        outlined
-        dense
         data-cy="contact-form-email-input"
       />
     </div>

--- a/src/components/global/FormFieldPhone.vue
+++ b/src/components/global/FormFieldPhone.vue
@@ -72,7 +72,7 @@ export default defineComponent({
       dense
       outlined
       v-model="phone"
-      lazy-rules
+      :lazy-rules="!testing"
       :rules="[
         (val) =>
           isFilled(val) ||

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -115,6 +115,7 @@ describe('Home page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
+          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');
@@ -355,6 +356,7 @@ describe('Home page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
+          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -117,7 +117,7 @@ describe('Home page', () => {
             .type('question');
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
-            .should('not.be.visible');
+            .should('be.empty');
           cy.dataCy('contact-form-subject')
             .find('.q-field__control')
             .should('not.have.class', 'text-negative');
@@ -357,7 +357,7 @@ describe('Home page', () => {
             .type('question');
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
-            .should('not.be.visible');
+            .should('be.empty');
           cy.dataCy('contact-form-subject')
             .find('.q-field__control')
             .should('not.have.class', 'text-negative');

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -115,7 +115,6 @@ describe('Home page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
-          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');
@@ -356,7 +355,6 @@ describe('Home page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
-          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -79,7 +79,7 @@ describe('Login page', () => {
             .type('question');
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
-            .should('not.be.visible');
+            .should('be.empty');
           cy.dataCy('contact-form-subject')
             .find('.q-field__control')
             .should('not.have.class', 'text-negative');

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -77,6 +77,7 @@ describe('Login page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
+          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -77,7 +77,6 @@ describe('Login page', () => {
           cy.dataCy('contact-form-subject-input')
             .should('be.visible')
             .type('question');
-          cy.dataCy('contact-form-subject-input').blur();
           cy.dataCy('contact-form-subject')
             .find('.q-field__messages')
             .should('be.empty');


### PR DESCRIPTION
Cypress test fix for automatic update in PR #181 

* use `.should('be.empty')` instead of `.should('not.be.visible')` for checking input error messages: this should be a more robust method in general as it relies on DOM content and not the message visibility implementation (CSS).
* update `rules` in `src/components/global/ContactForm.vue`: as the component was using outdated rules and tests pass for other input elements.