### PR TITLE
test/cypress/e2e: add RegisterPage e2e tests

### DIFF
--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -1,0 +1,38 @@
+import { testLanguageSwitcher } from '../support/commonTests';
+import { routesConf } from '../../../src/router/routes_conf';
+
+describe('Login page', () => {
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.visit('#' + routesConf['register']['path']);
+      cy.viewport('macbook-16');
+    });
+
+    it('renders page header', () => {
+      cy.dataCy('login-register-header').should('be.visible');
+    });
+
+    // switching between languages can only be tested in E2E context
+    testLanguageSwitcher();
+
+    it('renders register form', () => {
+      cy.dataCy('form-register').should('be.visible');
+    });
+
+    it('renders page title', () => {
+      let i18n;
+      cy.window().should('have.property', 'i18n');
+      cy.window()
+        .then((win) => {
+          i18n = win.i18n;
+        })
+        .then(() => {
+          cy.dataCy('form-register-title')
+            .should('be.visible')
+            .and('have.css', 'font-size', '24px')
+            .and('have.css', 'font-weight', '700')
+            .and('contain', i18n.global.t('register.form.titleRegister'));
+        });
+    });
+  });
+});


### PR DESCRIPTION
Issue: `RegisterPage` is missing E2E test.

* Add `register.spec.cy.js` test file

Tests are kept to a minimum as all the components on the page are already tested.