### PR TITLE
src/components/global: add `FormFieldPassword`, `FormFieldPasswordConfirm` components

### DIFF
--- a/src/components/__tests__/FormFieldPassword.cy.js
+++ b/src/components/__tests__/FormFieldPassword.cy.js
@@ -1,0 +1,104 @@
+import { colors } from 'quasar';
+
+import FormFieldTestWrapper from 'components/global/FormFieldTestWrapper.vue';
+import { i18n } from '../../boot/i18n';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
+import { testPasswordInputReveal } from '../../../test/cypress/support/commonTests';
+
+const colorPrimary = rideToWorkByBikeConfig.colorPrimary;
+
+const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+
+describe('<FormFieldPassword>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['labelPassword', 'hintPassword', 'messagePasswordStrong'],
+      'form',
+      i18n,
+    );
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldTestWrapper, {
+        props: {
+          component: 'FormFieldPassword',
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders password field', () => {
+      // input label
+      cy.dataCy('form-password')
+        .should('be.visible')
+        .find('label[for="form-password"]')
+        .should('be.visible')
+        .and('have.color', grey10)
+        .and(
+          'have.text',
+          i18n.global.t('register.coordinator.form.labelPassword'),
+        );
+      // input wrapper
+      cy.dataCy('form-password')
+        .find('.q-field__control')
+        .should('be.visible')
+        .and('have.css', 'border-radius', '8px');
+      // input
+      cy.dataCy('form-password-input').should('be.visible');
+      // icon
+      cy.dataCy('form-password-icon')
+        .should('contain', 'visibility')
+        .and('have.color', colorPrimary);
+      cy.dataCy('form-password-icon').invoke('height').should('be.equal', 18);
+      cy.dataCy('form-password-icon').invoke('width').should('be.equal', 18);
+    });
+
+    it('allows user to reveal and hide password', () => {
+      testPasswordInputReveal({
+        identifierPassword: 'form-password',
+      });
+    });
+
+    it('validates password correctly', () => {
+      // test password empty
+      cy.dataCy('form-password-input').focus();
+      cy.dataCy('form-password-input').blur();
+      cy.dataCy('form-password')
+        .find('.q-field__messages')
+        .should(
+          'contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelPassword'),
+          }),
+        );
+      // test password length
+      cy.dataCy('form-password-input').type('12a');
+      cy.dataCy('form-password-input').blur();
+      cy.dataCy('form-password')
+        .find('.q-field__messages')
+        .should(
+          'contain',
+          i18n.global.t('register.coordinator.form.messagePasswordStrong'),
+        );
+      cy.dataCy('form-password-input').clear();
+      // test password strength
+      cy.dataCy('form-password-input').type('12345');
+      cy.dataCy('form-password-input').blur();
+      cy.dataCy('form-password')
+        .find('.q-field__messages')
+        .should(
+          'contain',
+          i18n.global.t('register.coordinator.form.messagePasswordStrong'),
+        );
+      cy.dataCy('form-password-input').clear();
+      // valid password (shows hint)
+      cy.dataCy('form-password-input').type('123456a');
+      cy.dataCy('form-password-input').blur();
+      cy.dataCy('form-password')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('form.hintPassword'));
+    });
+  });
+});

--- a/src/components/__tests__/FormFieldPasswordConfirm.cy.js
+++ b/src/components/__tests__/FormFieldPasswordConfirm.cy.js
@@ -1,0 +1,112 @@
+import { colors } from 'quasar';
+
+import FormFieldTestWrapper from 'components/global/FormFieldTestWrapper.vue';
+import { i18n } from '../../boot/i18n';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
+import { testPasswordInputReveal } from '../../../test/cypress/support/commonTests';
+
+const colorPrimary = rideToWorkByBikeConfig.colorPrimary;
+
+const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+
+describe('<FormFieldPasswordConfirm>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      [
+        'labelPassword',
+        'hintPassword',
+        'messagePasswordStrong',
+        'messagePasswordNotIdentical',
+      ],
+      'form',
+      i18n,
+    );
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldTestWrapper, {
+        props: {
+          component: 'FormFieldPasswordConfirm',
+          compareValue: '123456a',
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders password field', () => {
+      // input label
+      cy.dataCy('form-password-confirm')
+        .should('be.visible')
+        .find('label[for="form-password-confirm"]')
+        .should('be.visible')
+        .and('have.color', grey10)
+        .and('have.text', i18n.global.t('form.labelPassword'));
+      // input wrapper
+      cy.dataCy('form-password-confirm')
+        .find('.q-field__control')
+        .should('be.visible')
+        .and('have.css', 'border-radius', '8px');
+      // input
+      cy.dataCy('form-password-confirm-input').should('be.visible');
+      // icon
+      cy.dataCy('form-password-confirm-icon')
+        .should('contain', 'visibility')
+        .and('have.color', colorPrimary);
+      cy.dataCy('form-password-confirm-icon')
+        .invoke('height')
+        .should('be.equal', 18);
+      cy.dataCy('form-password-confirm-icon')
+        .invoke('width')
+        .should('be.equal', 18);
+    });
+
+    it('allows user to reveal and hide password', () => {
+      testPasswordInputReveal({
+        identifierPassword: 'form-password-confirm',
+      });
+    });
+
+    it('validates password correctly', () => {
+      // test password empty
+      cy.dataCy('form-password-confirm-input').focus();
+      cy.dataCy('form-password-confirm-input').blur();
+      cy.dataCy('form-password-confirm')
+        .find('.q-field__messages')
+        .should(
+          'contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelPassword'),
+          }),
+        );
+      // test password length
+      cy.dataCy('form-password-confirm-input').type('12a');
+      cy.dataCy('form-password-confirm-input').blur();
+      cy.dataCy('form-password-confirm')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('form.messagePasswordStrong'));
+      cy.dataCy('form-password-confirm-input').clear();
+      // test password strength
+      cy.dataCy('form-password-confirm-input').type('12345');
+      cy.dataCy('form-password-confirm-input').blur();
+      cy.dataCy('form-password-confirm')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('form.messagePasswordStrong'));
+      cy.dataCy('form-password-confirm-input').clear();
+      // test non-matching password
+      cy.dataCy('form-password-confirm-input').type('12345a');
+      cy.dataCy('form-password-confirm-input').blur();
+      cy.dataCy('form-password-confirm')
+        .find('.q-field__messages')
+        .should('contain', i18n.global.t('form.messagePasswordNotIdentical'));
+      cy.dataCy('form-password-confirm-input').clear();
+      // valid password (shows hint)
+      cy.dataCy('form-password-confirm-input').type('123456a');
+      cy.dataCy('form-password-confirm-input').blur();
+      cy.get('*[data-cy="form-password-confirm"] .q-field__messages').should(
+        'not.exist',
+      );
+    });
+  });
+});

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -2,13 +2,9 @@ import { colors } from 'quasar';
 
 import FormRegisterCoordinator from 'components/register/FormRegisterCoordinator.vue';
 import { i18n } from '../../boot/i18n';
-import { rideToWorkByBikeConfig } from '../../boot/global_vars';
-import { testPasswordInputReveal } from '../../../test/cypress/support/commonTests';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
-
-const colorPrimary = rideToWorkByBikeConfig.colorPrimary;
 
 describe('<FormRegisterCoordinator>', () => {
   it('has translation for all strings', () => {
@@ -125,67 +121,13 @@ describe('<FormRegisterCoordinator>', () => {
     });
 
     it('renders password field', () => {
-      // input label
-      cy.dataCy('form-register-coordinator-password')
-        .should('be.visible')
-        .find('label[for="form-register-coordinator-password"]')
-        .should('be.visible')
-        .and('have.color', grey10)
-        .and(
-          'have.text',
-          i18n.global.t('register.coordinator.form.labelPassword'),
-        );
-      // input wrapper
-      cy.dataCy('form-register-coordinator-password')
-        .find('.q-field__control')
-        .should('be.visible')
-        .and('have.css', 'border-radius', '8px');
-      // input
-      cy.dataCy('form-register-coordinator-password-input').should(
-        'be.visible',
-      );
-      // icon
-      cy.dataCy('form-register-coordinator-password-icon')
-        .should('contain', 'visibility')
-        .and('have.color', colorPrimary);
-      cy.dataCy('form-register-coordinator-password-icon')
-        .invoke('height')
-        .should('be.equal', 18);
-      cy.dataCy('form-register-coordinator-password-icon')
-        .invoke('width')
-        .should('be.equal', 18);
+      cy.dataCy('form-register-coordinator-password').should('be.visible');
     });
 
     it('renders password confirm field', () => {
-      // input label
-      cy.dataCy('form-register-coordinator-password-confirm')
-        .should('be.visible')
-        .find('label[for="form-register-coordinator-password-confirm"]')
-        .should('be.visible')
-        .and('have.color', grey10)
-        .and(
-          'have.text',
-          i18n.global.t('register.coordinator.form.labelPasswordConfirm'),
-        );
-      // input wrapper
-      cy.dataCy('form-register-coordinator-password-confirm')
-        .find('.q-field__control')
-        .should('be.visible')
-        .and('have.css', 'border-radius', '8px');
-      // input
-      cy.dataCy('form-register-coordinator-password-confirm-input').should(
+      cy.dataCy('form-register-coordinator-password-confirm').should(
         'be.visible',
       );
-      // icon
-      cy.dataCy('form-register-coordinator-password-confirm-icon')
-        .should('contain', 'visibility')
-        .and('have.color', colorPrimary);
-      cy.dataCy('form-register-coordinator-password-confirm-icon')
-        .invoke('height')
-        .should('be.equal', 18);
-      cy.dataCy('form-register-coordinator-password-confirm-icon')
-        .invoke('width')
-        .should('be.equal', 18);
     });
 
     it('renders checkbox responsibility', () => {
@@ -237,133 +179,6 @@ describe('<FormRegisterCoordinator>', () => {
         .should('be.equal', 18);
     });
 
-    it('allows user to reveal and hide password', () => {
-      testPasswordInputReveal({
-        identifierPassword: 'form-register-coordinator-password',
-      });
-    });
-
-    it('allows user to reveal and hide password confirm', () => {
-      testPasswordInputReveal({
-        identifierPassword: 'form-register-coordinator-password-confirm',
-      });
-    });
-
-    it('validates password correctly', () => {
-      // fill in other parts of the form to be able to test password
-      cy.dataCy('form-register-coordinator-first-name')
-        .find('input')
-        .type('John');
-      cy.dataCy('form-register-coordinator-last-name')
-        .find('input')
-        .type('Doe');
-      cy.dataCy('form-register-coordinator-company').find('input').click();
-      cy.get('.q-menu .q-item').first().click();
-      cy.dataCy('form-register-coordinator-job-title').find('input').type('IT');
-      cy.dataCy('form-register-coordinator-email')
-        .find('input')
-        .type('simple@example.com');
-      cy.dataCy('form-register-coordinator-phone')
-        .find('input')
-        .type('+420 736 456 789');
-      // test password
-      cy.dataCy('form-register-coordinator-submit')
-        .should('be.visible')
-        .click();
-      cy.dataCy('form-register-coordinator-password')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t('register.coordinator.form.messageFieldRequired', {
-            fieldName: i18n.global.t('register.coordinator.form.labelPassword'),
-          }),
-        );
-      cy.dataCy('form-register-coordinator-password-input').clear();
-      cy.dataCy('form-register-coordinator-password-input').type('12345');
-      cy.dataCy('form-register-coordinator-submit')
-        .should('be.visible')
-        .click();
-      cy.dataCy('form-register-coordinator-password')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t('register.coordinator.form.messagePasswordStrong'),
-        );
-      cy.dataCy('form-register-coordinator-password-input').clear();
-      cy.dataCy('form-register-coordinator-password-input').type('123456789');
-      cy.dataCy('form-register-coordinator-password')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t('register.coordinator.form.messagePasswordStrong'),
-        );
-      cy.dataCy('form-register-coordinator-password-input').clear();
-      cy.dataCy('form-register-coordinator-password-input').type('12345a');
-      cy.dataCy('form-register-coordinator-password-input').blur();
-      cy.dataCy('form-register-coordinator-password')
-        .find('.q-field__messages')
-        .should('contain', i18n.global.t('register.form.hintPassword'));
-    });
-
-    it('validates password confirm correctly', () => {
-      // fill in other parts of the form to be able to test password
-      cy.dataCy('form-register-coordinator-first-name')
-        .find('input')
-        .type('John');
-      cy.dataCy('form-register-coordinator-last-name')
-        .find('input')
-        .type('Doe');
-      cy.dataCy('form-register-coordinator-company').find('input').click();
-      cy.get('.q-menu .q-item').first().click();
-      cy.dataCy('form-register-coordinator-job-title').find('input').type('IT');
-      cy.dataCy('form-register-coordinator-email')
-        .find('input')
-        .type('simple@example.com');
-      cy.dataCy('form-register-coordinator-phone')
-        .find('input')
-        .type('+420 736 456 789');
-      // fill in password input to be able to test password confirm
-      cy.dataCy('form-register-coordinator-password-input').type('12345a');
-      // test password confirm empty
-      cy.dataCy('form-register-coordinator-submit')
-        .should('be.visible')
-        .click();
-      cy.dataCy('form-register-coordinator-password-confirm')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t('register.coordinator.form.messageFieldRequired', {
-            fieldName: i18n.global.t(
-              'register.coordinator.form.labelPasswordConfirm',
-            ),
-          }),
-        );
-      cy.dataCy('form-register-coordinator-password-confirm-input').clear();
-      // test password confirm not matching
-      cy.dataCy('form-register-coordinator-password-confirm-input').type(
-        '12345b',
-      );
-      cy.dataCy('form-register-coordinator-password-confirm-input').blur();
-      cy.dataCy('form-register-coordinator-password-confirm')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t(
-            'register.coordinator.form.messagePasswordConfirmNotMatch',
-          ),
-        );
-      cy.dataCy('form-register-coordinator-password-confirm-input').clear();
-      // test password confirm matching
-      cy.dataCy('form-register-coordinator-password-confirm-input').type(
-        '12345a',
-      );
-      cy.dataCy('form-register-coordinator-password-confirm-input').blur();
-      // testing non-existence of element fails on .find() method
-      cy.get(
-        '*[data-cy="form-register-coordinator-terms] .q-field__messages',
-      ).should('not.exist');
-    });
-
     it('validates checkboxes correctly', () => {
       // fill in other parts of the form to be able to test password
       cy.dataCy('form-register-coordinator-first-name')
@@ -381,10 +196,12 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-phone')
         .find('input')
         .type('+420 736 456 789');
-      cy.dataCy('form-register-coordinator-password-input').type('12345a');
-      cy.dataCy('form-register-coordinator-password-confirm-input').type(
-        '12345a',
-      );
+      cy.dataCy('form-register-coordinator-password')
+        .find('input')
+        .type('12345a');
+      cy.dataCy('form-register-coordinator-password-confirm')
+        .find('input')
+        .type('12345a');
       // test responsibility checkbox unchecked
       cy.dataCy('form-register-coordinator-submit')
         .should('be.visible')

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -1,0 +1,117 @@
+<script lang="ts">
+/**
+ * FormFieldPassword Component
+ *
+ * The `FormFieldPassword` displays password input.
+ *
+ * @description * Use this component to render password input in forms.
+ *
+ * Note: This component is commonly used in `FormRegisterCoordinator`,
+ * `FormChallenge`.
+ *
+ * @props
+ * - `value` (string, required): The object representing user input.
+ *   It should be of type `string`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @example
+ * <form-field-password-register />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6385%3A26514&mode=dev)
+ */
+
+// libraries
+import { computed, defineComponent, ref } from 'vue';
+
+// composables
+import { useValidation } from 'src/composables/useValidation';
+
+export default defineComponent({
+  name: 'FormFieldPassword',
+  props: {
+    modelValue: {
+      type: String,
+      required: true,
+    },
+    bgColor: {
+      type: String as () => 'white' | 'transparent',
+      default: 'transparent',
+    },
+    testing: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const password = computed({
+      get() {
+        return props.modelValue;
+      },
+      set(value: string) {
+        emit('update:modelValue', value);
+      },
+    });
+
+    const { isFilled, isStrongPassword } = useValidation();
+
+    const isHiddenPassword = ref(true);
+
+    return {
+      password,
+      isHiddenPassword,
+      isFilled,
+      isStrongPassword,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="col-12 col-sm-6" data-cy="form-register-coordinator-password">
+    <!-- Label -->
+    <label
+      for="form-register-coordinator-password"
+      class="text-caption text-bold"
+    >
+      {{ $t('register.coordinator.form.labelPassword') }}
+    </label>
+    <!-- Input -->
+    <q-input
+      dense
+      outlined
+      hide-bottom-space
+      v-model="password"
+      id="form-register-coordinator-password"
+      :hint="$t('register.coordinator.form.hintPassword')"
+      :type="isHiddenPassword ? 'password' : 'text'"
+      :rules="[
+        (val) =>
+          isFilled(val) ||
+          $t('register.coordinator.form.messageFieldRequired', {
+            fieldName: $t('register.coordinator.form.labelPassword'),
+          }),
+        (val) =>
+          isStrongPassword(val) ||
+          $t('register.coordinator.form.messagePasswordStrong'),
+      ]"
+      lazy-rules
+      class="q-mt-sm"
+      data-cy="form-register-coordinator-password-input"
+    >
+      <!-- Icon: show password -->
+      <template v-slot:append>
+        <q-icon
+          color="primary"
+          :name="isHiddenPassword ? 'visibility_off' : 'visibility'"
+          class="cursor-pointer"
+          size="18px"
+          @click="isHiddenPassword = !isHiddenPassword"
+          data-cy="form-register-coordinator-password-icon"
+        />
+      </template>
+    </q-input>
+  </div>
+</template>

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -70,13 +70,10 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="col-12 col-sm-6" data-cy="form-register-coordinator-password">
+  <div class="col-12 col-sm-6" data-cy="form-password">
     <!-- Label -->
-    <label
-      for="form-register-coordinator-password"
-      class="text-caption text-bold"
-    >
-      {{ $t('register.coordinator.form.labelPassword') }}
+    <label for="form-password" class="text-caption text-bold text-grey-10">
+      {{ $t('form.labelPassword') }}
     </label>
     <!-- Input -->
     <q-input
@@ -84,22 +81,20 @@ export default defineComponent({
       outlined
       hide-bottom-space
       v-model="password"
-      id="form-register-coordinator-password"
-      :hint="$t('register.coordinator.form.hintPassword')"
+      id="form-password"
+      :hint="$t('form.hintPassword')"
       :type="isHiddenPassword ? 'password' : 'text'"
       :rules="[
         (val) =>
           isFilled(val) ||
-          $t('register.coordinator.form.messageFieldRequired', {
-            fieldName: $t('register.coordinator.form.labelPassword'),
+          $t('form.messageFieldRequired', {
+            fieldName: $t('form.labelPassword'),
           }),
-        (val) =>
-          isStrongPassword(val) ||
-          $t('register.coordinator.form.messagePasswordStrong'),
+        (val) => isStrongPassword(val) || $t('form.messagePasswordStrong'),
       ]"
       lazy-rules
       class="q-mt-sm"
-      data-cy="form-register-coordinator-password-input"
+      data-cy="form-password-input"
     >
       <!-- Icon: show password -->
       <template v-slot:append>
@@ -109,9 +104,15 @@ export default defineComponent({
           class="cursor-pointer"
           size="18px"
           @click="isHiddenPassword = !isHiddenPassword"
-          data-cy="form-register-coordinator-password-icon"
+          data-cy="form-password-icon"
         />
       </template>
     </q-input>
   </div>
 </template>
+
+<style lang="scss" scoped>
+:deep(.q-field__control) {
+  border-radius: 8px;
+}
+</style>

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -13,7 +13,7 @@
  * - `modelValue` (string, required): The object representing user input.
  *   It should be of type `string`.
  * - `bgColor` (string, default: 'transparent'): The background color of the
- * input.
+ *   input.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -10,8 +10,10 @@
  * `FormChallenge`.
  *
  * @props
- * - `value` (string, required): The object representing user input.
+ * - `modelValue` (string, required): The object representing user input.
  *   It should be of type `string`.
+ * - `bgColor` (string, default: 'transparent'): The background color of the
+ * input.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
@@ -38,10 +40,6 @@ export default defineComponent({
     bgColor: {
       type: String as () => 'white' | 'transparent',
       default: 'transparent',
-    },
-    testing: {
-      type: Boolean,
-      default: false,
     },
   },
   emits: ['update:modelValue'],

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -17,7 +17,7 @@
  * - `update:modelValue`: Emitted as a part of v-model structure.
  *
  * @example
- * <form-field-password-register />
+ * <form-field-password v-model="password" />
  *
  * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6385%3A26514&mode=dev)
  */
@@ -70,7 +70,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="col-12 col-sm-6" data-cy="form-password">
+  <div data-cy="form-password">
     <!-- Label -->
     <label for="form-password" class="text-caption text-bold text-grey-10">
       {{ $t('form.labelPassword') }}

--- a/src/components/global/FormFieldPasswordConfirm.vue
+++ b/src/components/global/FormFieldPasswordConfirm.vue
@@ -90,7 +90,6 @@ export default defineComponent({
       hide-bottom-space
       v-model="password"
       id="form-password-confirm"
-      :hint="$t('form.hintPassword')"
       :type="isHiddenPassword ? 'password' : 'text'"
       :rules="[
         (val) =>

--- a/src/components/global/FormFieldPasswordConfirm.vue
+++ b/src/components/global/FormFieldPasswordConfirm.vue
@@ -10,8 +10,12 @@
  * `FormChallenge`.
  *
  * @props
- * - `value` (string, required): The object representing user input.
+ * - `modelValue` (string, required): The object representing user input.
  *   It should be of type `string`.
+ * - `compareValue` (string, required): The object representing password value
+ *   to be compared with the `modelValue`.
+ * - `bgColor` (string, default: 'transparent'): The background color of the
+ *   input.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
@@ -42,10 +46,6 @@ export default defineComponent({
     bgColor: {
       type: String as () => 'white' | 'transparent',
       default: 'transparent',
-    },
-    testing: {
-      type: Boolean,
-      default: false,
     },
   },
   emits: ['update:modelValue'],

--- a/src/components/global/FormFieldPasswordConfirm.vue
+++ b/src/components/global/FormFieldPasswordConfirm.vue
@@ -1,0 +1,129 @@
+<script lang="ts">
+/**
+ * FormFieldPasswordConfirm Component
+ *
+ * The `FormFieldPasswordConfirm` displays password confirm input.
+ *
+ * @description * Use this component to render password confirm input in forms.
+ *
+ * Note: This component is commonly used in `FormRegisterCoordinator`,
+ * `FormChallenge`.
+ *
+ * @props
+ * - `value` (string, required): The object representing user input.
+ *   It should be of type `string`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @example
+ * <form-field-password-confirm v-model="passwordConfirm" />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6385%3A28513&mode=dev)
+ */
+
+// libraries
+import { computed, defineComponent, ref } from 'vue';
+
+// composables
+import { useValidation } from 'src/composables/useValidation';
+
+export default defineComponent({
+  name: 'FormFieldPasswordConfirm',
+  props: {
+    modelValue: {
+      type: String,
+      required: true,
+    },
+    compareValue: {
+      type: String,
+      required: true,
+    },
+    bgColor: {
+      type: String as () => 'white' | 'transparent',
+      default: 'transparent',
+    },
+    testing: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const password = computed({
+      get() {
+        return props.modelValue;
+      },
+      set(value: string) {
+        emit('update:modelValue', value);
+      },
+    });
+
+    const { isFilled, isStrongPassword, isIdentical } = useValidation();
+
+    const isHiddenPassword = ref(true);
+
+    return {
+      password,
+      isHiddenPassword,
+      isFilled,
+      isIdentical,
+      isStrongPassword,
+    };
+  },
+});
+</script>
+
+<template>
+  <div data-cy="form-password-confirm">
+    <!-- Label -->
+    <label
+      for="form-password-confirm"
+      class="text-caption text-bold text-grey-10"
+    >
+      {{ $t('form.labelPassword') }}
+    </label>
+    <!-- Input -->
+    <q-input
+      dense
+      outlined
+      hide-bottom-space
+      v-model="password"
+      id="form-password-confirm"
+      :hint="$t('form.hintPassword')"
+      :type="isHiddenPassword ? 'password' : 'text'"
+      :rules="[
+        (val) =>
+          isFilled(val) ||
+          $t('form.messageFieldRequired', {
+            fieldName: $t('form.labelPassword'),
+          }),
+        (val) => isStrongPassword(val) || $t('form.messagePasswordStrong'),
+        (val) =>
+          isIdentical(val, compareValue) ||
+          $t('form.messagePasswordNotIdentical'),
+      ]"
+      lazy-rules
+      class="q-mt-sm"
+      data-cy="form-password-confirm-input"
+    >
+      <!-- Icon: show password -->
+      <template v-slot:append>
+        <q-icon
+          color="primary"
+          :name="isHiddenPassword ? 'visibility_off' : 'visibility'"
+          class="cursor-pointer"
+          size="18px"
+          @click="isHiddenPassword = !isHiddenPassword"
+          data-cy="form-password-confirm-icon"
+        />
+      </template>
+    </q-input>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+:deep(.q-field__control) {
+  border-radius: 8px;
+}
+</style>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+/**
+ * FormFieldTestWrapper Component
+ *
+ * The `FormFieldTestWrapper` serves as a wrapper for testing
+ * the FormField- components.
+ *
+ * @description * Use this component to test the FormField- components.
+ *
+ * @components
+ * - `FormFieldPassword`: Component to render password input field.
+ * - `FormFieldPasswordConfirm`: Component to render password input field.
+ *
+ * @example
+ * <form-field-test-wrapper component="FormFieldPassword" :testing="true" />
+ */
+
+// libraries
+import { defineComponent, ref } from 'vue';
+
+// components
+import FormFieldPassword from './FormFieldPassword.vue';
+
+export default defineComponent({
+  name: 'FormFieldTestWrapper',
+  components: {
+    FormFieldPassword,
+  },
+  props: {
+    component: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    const inputValue = ref('');
+
+    return {
+      inputValue,
+    };
+  },
+});
+</script>
+
+<template>
+  <component :is="component" v-model="inputValue" :testing="true" />
+</template>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -20,16 +20,24 @@ import { defineComponent, ref } from 'vue';
 
 // components
 import FormFieldPassword from './FormFieldPassword.vue';
+import FormFieldPasswordConfirm from './FormFieldPasswordConfirm.vue';
 
 export default defineComponent({
   name: 'FormFieldTestWrapper',
   components: {
     FormFieldPassword,
+    FormFieldPasswordConfirm,
   },
   props: {
     component: {
       type: String,
       required: true,
+    },
+    compareValue: {
+      type: String,
+    },
+    testing: {
+      type: Boolean,
     },
   },
   setup() {
@@ -43,5 +51,10 @@ export default defineComponent({
 </script>
 
 <template>
-  <component :is="component" v-model="inputValue" :testing="true" />
+  <component
+    :is="component"
+    v-model="inputValue"
+    :compare-value="compareValue"
+    :testing="testing"
+  />
 </template>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -7,6 +7,10 @@
  *
  * @description * Use this component to test the FormField- components.
  *
+ * @props
+ * - `component` (string, required): The name of the tested component.
+ * - `compareValue` (string): The value used for password comparison.
+ *
  * @components
  * - `FormFieldPassword`: Component to render password input field.
  * - `FormFieldPasswordConfirm`: Component to render password input field.
@@ -36,9 +40,6 @@ export default defineComponent({
     compareValue: {
       type: String,
     },
-    testing: {
-      type: Boolean,
-    },
   },
   setup() {
     const inputValue = ref('');
@@ -55,6 +56,5 @@ export default defineComponent({
     :is="component"
     v-model="inputValue"
     :compare-value="compareValue"
-    :testing="testing"
   />
 </template>

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -18,10 +18,7 @@
  */
 
 // libraries
-import { defineComponent, reactive, ref } from 'vue';
-
-// composables
-import { useValidation } from '../../composables/useValidation';
+import { defineComponent, reactive } from 'vue';
 
 // components
 import FormFieldCompany from '../global/FormFieldCompany.vue';
@@ -55,9 +52,6 @@ export default defineComponent({
       terms: false,
     });
 
-    const { isEmail, isFilled, isIdentical, isPhone, isStrongPassword } =
-      useValidation();
-
     const onSubmit = (): void => {
       // noop
     };
@@ -68,11 +62,6 @@ export default defineComponent({
 
     return {
       formRegisterCoordinator,
-      isEmail,
-      isFilled,
-      isIdentical,
-      isPhone,
-      isStrongPassword,
       onReset,
       onSubmit,
     };

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -28,6 +28,7 @@ import FormFieldCompany from '../global/FormFieldCompany.vue';
 import FormFieldEmail from './../global/FormFieldEmail.vue';
 import FormFieldTextRequired from './../global/FormFieldTextRequired.vue';
 import FormFieldPassword from '../global/FormFieldPassword.vue';
+import FormFieldPasswordConfirm from '../global/FormFieldPasswordConfirm.vue';
 import FormFieldPhone from './../global/FormFieldPhone.vue';
 
 export default defineComponent({
@@ -37,6 +38,7 @@ export default defineComponent({
     FormFieldEmail,
     FormFieldTextRequired,
     FormFieldPassword,
+    FormFieldPasswordConfirm,
     FormFieldPhone,
   },
   setup() {
@@ -142,7 +144,15 @@ export default defineComponent({
           <!-- Input: password -->
           <form-field-password
             v-model="formRegisterCoordinator.password"
+            class="col-12 col-sm-6"
             data-cy="form-register-coordinator-password"
+          />
+          <!-- Input: password confirm -->
+          <form-field-password-confirm
+            v-model="formRegisterCoordinator.passwordConfirm"
+            :compare-value="formRegisterCoordinator.password"
+            class="col-12 col-sm-6"
+            data-cy="form-register-coordinator-password-confirm"
           />
           <!-- Input: confirm responsibility -->
           <div

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -27,6 +27,7 @@ import { useValidation } from '../../composables/useValidation';
 import FormFieldCompany from '../global/FormFieldCompany.vue';
 import FormFieldEmail from './../global/FormFieldEmail.vue';
 import FormFieldTextRequired from './../global/FormFieldTextRequired.vue';
+import FormFieldPassword from '../global/FormFieldPassword.vue';
 import FormFieldPhone from './../global/FormFieldPhone.vue';
 
 export default defineComponent({
@@ -35,6 +36,7 @@ export default defineComponent({
     FormFieldCompany,
     FormFieldEmail,
     FormFieldTextRequired,
+    FormFieldPassword,
     FormFieldPhone,
   },
   setup() {
@@ -51,9 +53,6 @@ export default defineComponent({
       terms: false,
     });
 
-    const isPassword = ref(true);
-    const isPasswordConfirm = ref(true);
-
     const { isEmail, isFilled, isIdentical, isPhone, isStrongPassword } =
       useValidation();
 
@@ -67,8 +66,6 @@ export default defineComponent({
 
     return {
       formRegisterCoordinator,
-      isPassword,
-      isPasswordConfirm,
       isEmail,
       isFilled,
       isIdentical,
@@ -143,104 +140,10 @@ export default defineComponent({
             data-cy="form-register-coordinator-phone"
           />
           <!-- Input: password -->
-          <div
-            class="col-12 col-sm-6"
+          <form-field-password
+            v-model="formRegisterCoordinator.password"
             data-cy="form-register-coordinator-password"
-          >
-            <!-- Label -->
-            <label
-              for="form-register-coordinator-password"
-              class="text-caption text-bold"
-            >
-              {{ $t('register.coordinator.form.labelPassword') }}
-            </label>
-            <!-- Input -->
-            <q-input
-              dense
-              outlined
-              hide-bottom-space
-              v-model="formRegisterCoordinator.password"
-              id="form-register-coordinator-password"
-              :hint="$t('register.coordinator.form.hintPassword')"
-              :type="isPassword ? 'password' : 'text'"
-              :rules="[
-                (val) =>
-                  isFilled(val) ||
-                  $t('register.coordinator.form.messageFieldRequired', {
-                    fieldName: $t('register.coordinator.form.labelPassword'),
-                  }),
-                (val) =>
-                  isStrongPassword(val) ||
-                  $t('register.coordinator.form.messagePasswordStrong'),
-              ]"
-              lazy-rules
-              class="q-mt-sm"
-              data-cy="form-register-coordinator-password-input"
-            >
-              <!-- Icon: show password -->
-              <template v-slot:append>
-                <q-icon
-                  color="primary"
-                  :name="isPassword ? 'visibility_off' : 'visibility'"
-                  class="cursor-pointer"
-                  size="18px"
-                  @click="isPassword = !isPassword"
-                  data-cy="form-register-coordinator-password-icon"
-                />
-              </template>
-            </q-input>
-          </div>
-          <!-- Input: password confirm -->
-          <div
-            class="col-12 col-sm-6"
-            data-cy="form-register-coordinator-password-confirm"
-          >
-            <!-- Label -->
-            <label
-              for="form-register-coordinator-password-confirm"
-              class="text-caption text-bold"
-            >
-              {{ $t('register.coordinator.form.labelPasswordConfirm') }}
-            </label>
-            <!-- Input -->
-            <q-input
-              dense
-              outlined
-              hide-bottom-space
-              v-model="formRegisterCoordinator.passwordConfirm"
-              id="form-register-coordinator-password"
-              :type="isPasswordConfirm ? 'password' : 'text'"
-              :rules="[
-                (val) =>
-                  isFilled(val) ||
-                  $t('register.coordinator.form.messageFieldRequired', {
-                    fieldName: $t(
-                      'register.coordinator.form.labelPasswordConfirm',
-                    ),
-                  }),
-                (val) =>
-                  isIdentical(val, formRegisterCoordinator.password) ||
-                  $t(
-                    'register.coordinator.form.messagePasswordConfirmNotMatch',
-                  ),
-              ]"
-              lazy-rules
-              class="q-mt-sm"
-              data-cy="form-register-coordinator-password-confirm-input"
-            >
-              <!-- Icon: show password -->
-              <template v-slot:append>
-                <q-icon
-                  color="primary"
-                  :name="isPasswordConfirm ? 'visibility_off' : 'visibility'"
-                  class="cursor-pointer"
-                  size="18px"
-                  @click="isPasswordConfirm = !isPasswordConfirm"
-                  data-cy="form-register-coordinator-password-confirm-icon"
-                />
-              </template>
-            </q-input>
-          </div>
+          />
           <!-- Input: confirm responsibility -->
           <div
             class="col-12"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -47,7 +47,8 @@ messageFieldRequired = "Pole {fieldName} je povinné"
 messageNoCompany = "Žádnou firmu jsme nenašli. Zkuste hledat znovu, nebo vytvořte novou firmu."
 messagePhoneInvalid = "Prosím vyplňte platné telefonní číslo"
 messagePasswordStrong = "Heslo musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
-messagePasswordConfirmNotMatch = "Hesla se neshodují"
+messagePasswordNotIdentical = "Hesla se neshodují"
+
 
 [index]
 title = "Domov"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -31,6 +31,7 @@ continue = "Pokračovat"
 back = "Zpět"
 
 [form]
+hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
 labelCompany = "Firma, pro kterou chcete být koordinátorem"
 labelCompanyShort = "Firma"
 labelEmail = "E-mail"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -31,6 +31,7 @@ continue = "Continue"
 back = "Back"
 
 [form]
+hintPassword = "It must contain at least 6 characters and at least 1 letter."
 labelCompany = "The company you want to be a coordinator for"
 labelCompanyShort = "Company"
 labelEmail = "E-mail"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -47,7 +47,7 @@ messageFieldRequired = "{fieldName} is required"
 messageNoCompany = "We couldn't find any company. Try searching again or create a new company."
 messagePhoneInvalid = "Please fill in a valid phone number"
 messagePasswordStrong = "Password must contain at least 6 characters and at least 1 letter."
-messagePasswordConfirmNotMatch = "Passwords don't match"
+messagePasswordNotIdentical = "Passwords don't match"
 
 [index]
 title = "Home"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -31,6 +31,7 @@ continue = "Pokračovať"
 back = "Späť"
 
 [form]
+hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 labelCompany = "Spoločnosť, pre ktorú chcete byť koordinátorom"
 labelCompanyShort = "Spoločnosť"
 labelEmail = "E-mail"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -47,7 +47,7 @@ messageFieldRequired = "Pole {fieldName} je povinné"
 messageNoCompany = "Nenašli sme žiadnu spoločnosť. Skúste hľadať znova alebo vytvorte novú spoločnosť."
 messagePhoneInvalid = "Vyplňte platné telefónne číslo"
 messagePasswordStrong = "Heslo musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
-messagePasswordConfirmNotMatch = "Heslá sa nezhodujú"
+messagePasswordNotIdentical = "Heslá sa nezhodujú"
 
 [index]
 title = "Domovská stránka"


### PR DESCRIPTION
Issue: Password and Password confirm tests are duplicated across form components and their code repeats.

Solution:
* Refactor inputs into `FormFieldPassword` and `FormFieldPasswordConfirm` components
* Add a general testing wrapper for FormField components
* Refactor `FormRegisterCoordinator` component and tests

To do: Replace other FormField test wrapper components with `FormFieldTestWrapper`.