### PR TITLE
components/global: use `FormFieldEmail` component across all forms

### DIFF
--- a/src/components/__tests__/ContactForm.cy.js
+++ b/src/components/__tests__/ContactForm.cy.js
@@ -66,15 +66,7 @@ describe('<ContactForm>', () => {
     });
 
     it('should render contact-form-email field', () => {
-      cy.dataCy('contact-form-email')
-        .should('be.visible')
-        .find('label[for="contact-form-email"]')
-        .should('be.visible')
-        .and('have.text', i18n.global.t('index.contact.email'));
-      cy.dataCy('contact-form-email')
-        .find('.q-field__control')
-        .should('be.visible')
-        .and('have.css', 'border-radius', '8px');
+      cy.dataCy('contact-form-email').should('be.visible');
     });
 
     it('should render a submit button', () => {

--- a/src/components/__tests__/HelpButton.cy.js
+++ b/src/components/__tests__/HelpButton.cy.js
@@ -243,7 +243,8 @@ describe('<HelpButton>', () => {
       cy.dataCy('contact-form-message-input')
         .should('be.visible')
         .type('what is the minimum distance to ride to work?');
-      cy.dataCy('contact-form-email-input')
+      cy.dataCy('contact-form-email')
+        .find('input')
         .should('be.visible')
         .type('P7LlQ@example.com');
       cy.dataCy('contact-form-submit').should('be.visible').click();
@@ -294,7 +295,12 @@ describe('<HelpButton>', () => {
       cy.dataCy('contact-form-email')
         .find('.q-field__messages')
         .should('be.visible')
-        .and('contain', i18n.global.t('index.contact.emailRequired'));
+        .and(
+          'contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelEmail'),
+          }),
+        );
       cy.dataCy('contact-form-email')
         .find('.q-field__control')
         .should('have.class', 'text-negative');

--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -75,7 +75,8 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-message-input')
         .should('be.visible')
         .type('what is the minimum distance to ride to work?');
-      cy.dataCy('contact-form-email-input')
+      cy.dataCy('contact-form-email')
+        .find('input')
         .should('be.visible')
         .type('P7LlQ@example.com');
       cy.dataCy('contact-form-submit').should('be.visible').click();
@@ -126,7 +127,12 @@ describe('<LoginRegisterHeader>', () => {
       cy.dataCy('contact-form-email')
         .find('.q-field__messages')
         .should('be.visible')
-        .and('contain', i18n.global.t('index.contact.emailRequired'));
+        .and(
+          'contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelEmail'),
+          }),
+        );
       cy.dataCy('contact-form-email')
         .find('.q-field__control')
         .should('have.class', 'text-negative');

--- a/src/components/global/ContactForm.vue
+++ b/src/components/global/ContactForm.vue
@@ -23,11 +23,17 @@
 // libraries
 import { defineComponent, reactive } from 'vue';
 
+// components
+import FormFieldEmail from './../global/FormFieldEmail.vue';
+
 // composables
 import { useValidation } from 'src/composables/useValidation';
 
 export default defineComponent({
   name: 'ContactForm',
+  components: {
+    FormFieldEmail,
+  },
   emits: ['formSubmit'],
   setup(props, { emit }) {
     const contactForm = reactive({
@@ -108,28 +114,11 @@ export default defineComponent({
         </template>
       </q-file>
     </div>
-    <!-- Email input widget -->
-    <div class="q-mt-none" data-cy="contact-form-email">
-      <label for="contact-form-email" class="text-caption text-bold">
-        {{ $t('index.contact.email') }}
-      </label>
-      <q-input
-        dense
-        outlined
-        lazy-rules
-        v-model="contactForm.email"
-        id="contact-form-email"
-        name="email"
-        type="email"
-        :rules="[
-          (val) =>
-            (isFilled(val) && isEmail(val)) ||
-            $t('index.contact.emailRequired'),
-        ]"
-        class="q-mt-sm"
-        data-cy="contact-form-email-input"
-      />
-    </div>
+    <!-- Input: email -->
+    <form-field-email
+      v-model="contactForm.email"
+      data-cy="contact-form-email"
+    />
     <!-- Submit button -->
     <div class="flex justify-end">
       <q-btn

--- a/src/components/global/FormFieldEmail.vue
+++ b/src/components/global/FormFieldEmail.vue
@@ -6,7 +6,8 @@
  *
  * @description * Use this component to render email input in forms.
  *
- * Note: This component is commonly used in `FormRegister`, `FormLogin`.
+ * Note: This component is commonly used in `FormRegister`, `FormLogin`,
+ * `FormRegistrationCoordinator`, `ContactForm`.
  *
  * @props
  * - `value` (string, required): The object representing user input.

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -87,7 +87,8 @@ describe('Home page', () => {
             .should('be.visible')
             .type('what is the minimum distance to ride to work?');
 
-          cy.dataCy('contact-form-email-input')
+          cy.dataCy('contact-form-email')
+            .find('input')
             .should('be.visible')
             .type('P7LlQ@example.com');
 
@@ -148,7 +149,12 @@ describe('Home page', () => {
           cy.dataCy('contact-form-email')
             .find('.q-field__messages')
             .should('be.visible')
-            .and('contain', i18n.global.t('index.contact.emailRequired'));
+            .and(
+              'contain',
+              i18n.global.t('form.messageFieldRequired', {
+                fieldName: i18n.global.t('form.labelEmail'),
+              }),
+            );
           cy.dataCy('contact-form-email')
             .find('.q-field__control')
             .should('have.class', 'text-negative');
@@ -324,7 +330,8 @@ describe('Home page', () => {
           cy.dataCy('contact-form-message-input')
             .should('be.visible')
             .type('what is the minimum distance to ride to work?');
-          cy.dataCy('contact-form-email-input')
+          cy.dataCy('contact-form-email')
+            .find('input')
             .should('be.visible')
             .type('P7LlQ@example.com');
           cy.dataCy('contact-form-submit').should('be.visible').click();
@@ -384,7 +391,12 @@ describe('Home page', () => {
           cy.dataCy('contact-form-email')
             .find('.q-field__messages')
             .should('be.visible')
-            .and('contain', i18n.global.t('index.contact.emailRequired'));
+            .and(
+              'contain',
+              i18n.global.t('form.messageFieldRequired', {
+                fieldName: i18n.global.t('form.labelEmail'),
+              }),
+            );
           cy.dataCy('contact-form-email')
             .find('.q-field__control')
             .should('have.class', 'text-negative');

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -44,7 +44,8 @@ describe('Login page', () => {
       cy.dataCy('contact-form-message-input')
         .should('be.visible')
         .type('what is the minimum distance to ride to work?');
-      cy.dataCy('contact-form-email-input')
+      cy.dataCy('contact-form-email')
+        .find('input')
         .should('be.visible')
         .type('P7LlQ@example.com');
       cy.dataCy('contact-form-submit').should('be.visible').click();
@@ -102,7 +103,12 @@ describe('Login page', () => {
           cy.dataCy('contact-form-email')
             .find('.q-field__messages')
             .should('be.visible')
-            .and('contain', i18n.global.t('index.contact.emailRequired'));
+            .and(
+              'contain',
+              i18n.global.t('form.messageFieldRequired', {
+                fieldName: i18n.global.t('form.labelEmail'),
+              }),
+            );
           cy.dataCy('contact-form-email')
             .find('.q-field__control')
             .should('have.class', 'text-negative');


### PR DESCRIPTION
Use `FormFieldEmail` across all forms:

* Use component in `ContactForm`
* Remove duplicate tests from `ContactForm.cy.js`
* Update usage docs in `FormFieldEmail` component
