### PR TITLE
src/css/form: add global border radius style

### DIFF
--- a/src/components/global/ContactForm.vue
+++ b/src/components/global/ContactForm.vue
@@ -124,9 +124,3 @@ export default defineComponent({
     </div>
   </q-form>
 </template>
-
-<style scoped lang="scss">
-form :deep(.q-field__control) {
-  border-radius: 8px;
-}
-</style>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -156,9 +156,3 @@ export default defineComponent({
     </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-:deep(.q-field__control) {
-  border-radius: 8px;
-}
-</style>

--- a/src/components/global/FormFieldPassword.vue
+++ b/src/components/global/FormFieldPassword.vue
@@ -108,9 +108,3 @@ export default defineComponent({
     </q-input>
   </div>
 </template>
-
-<style lang="scss" scoped>
-:deep(.q-field__control) {
-  border-radius: 8px;
-}
-</style>

--- a/src/components/global/FormFieldPasswordConfirm.vue
+++ b/src/components/global/FormFieldPasswordConfirm.vue
@@ -120,9 +120,3 @@ export default defineComponent({
     </q-input>
   </div>
 </template>
-
-<style lang="scss" scoped>
-:deep(.q-field__control) {
-  border-radius: 8px;
-}
-</style>

--- a/src/components/global/FormFieldTextRequired.vue
+++ b/src/components/global/FormFieldTextRequired.vue
@@ -106,9 +106,3 @@ export default defineComponent({
     />
   </div>
 </template>
-
-<style scoped lang="scss">
-:deep(.q-field__control) {
-  border-radius: 8px;
-}
-</style>

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -307,7 +307,6 @@ export default defineComponent({
 
 <style scoped lang="scss">
 :deep(.q-field__control) {
-  border-radius: 8px;
   &:before {
     border-color: transparent;
   }

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -243,7 +243,6 @@ export default defineComponent({
 
 <style scoped lang="scss">
 :deep(.q-field__control) {
-  border-radius: 8px;
   &:before {
     border-color: transparent;
   }

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -226,9 +226,6 @@ export default defineComponent({
 </template>
 
 <style scoped lang="scss">
-:deep(.q-field__control) {
-  border-radius: 8px;
-}
 :deep(.q-checkbox__bg) {
   border: 1px solid $grey-6;
   border-radius: 4px;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -3,3 +3,4 @@
 @import './utility';
 @import './swiper.scss';
 @import './circular-progress.scss';
+@import './form.scss';

--- a/src/css/form.scss
+++ b/src/css/form.scss
@@ -1,0 +1,3 @@
+.q-field__control {
+  border-radius: 8px !important;
+}


### PR DESCRIPTION
Issue: Scoped style for input field border radius was repeated.

* Created global stylesheet `form.scss` for form styles
* Added global rule for border radius
* Removed SFC scoped styles from form field components