### PR TITLE
src/components/form: add components to select merch in challenge registration

### DIFF
--- a/src/assets/svg/numeric-7-fill.svg
+++ b/src/assets/svg/numeric-7-fill.svg
@@ -1,0 +1,4 @@
+<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="21" cy="21" r="19.5" fill="#43449C" stroke="white" stroke-width="3"/>
+<path d="M25.3816 16.914L20.8636 27.75H17.7136L22.2856 17.256H16.6876V14.628H25.3816V16.914Z" fill="white"/>
+</svg>

--- a/src/components/__tests__/FormCardMerch.cy.js
+++ b/src/components/__tests__/FormCardMerch.cy.js
@@ -38,7 +38,7 @@ describe('<FormCardMerch>', () => {
       'form.merch',
       i18n,
     );
-    cy.testLanguageStringsInContext(['moreInfo'], 'navigation', i18n);
+    cy.testLanguageStringsInContext(['select'], 'navigation', i18n);
   });
 
   context('desktop', () => {
@@ -54,12 +54,13 @@ describe('<FormCardMerch>', () => {
     it('renders card with image and title', () => {
       cy.dataCy('form-card-merch').should('be.visible');
       // rounded corners
-      cy.dataCy('form-card-merch').should(
-        'have.css',
-        'border-radius',
-        rideToWorkByBikeConfig.borderRadiusCard,
-      );
-      cy.dataCy('form-card-merch-top').should('have.css', 'padding', '16px');
+      cy.dataCy('form-card-merch')
+        .should(
+          'have.css',
+          'border-radius',
+          rideToWorkByBikeConfig.borderRadiusCard,
+        )
+        .and('have.css', 'padding', '16px');
       // image
       cy.dataCy('form-card-merch-image')
         .find('img')
@@ -100,7 +101,7 @@ describe('<FormCardMerch>', () => {
     it('renders button', () => {
       cy.dataCy('form-card-merch-button')
         .should('be.visible')
-        .and('contain.text', i18n.global.t('navigation.moreInfo'));
+        .and('contain.text', i18n.global.t('navigation.select'));
     });
   });
 });

--- a/src/components/__tests__/FormCardMerch.cy.js
+++ b/src/components/__tests__/FormCardMerch.cy.js
@@ -1,0 +1,51 @@
+import FormCardMerch from 'components/form/FormCardMerch.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<FormCardMerch>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['labelAuthor', 'labelMaterial', 'labelSizes'],
+      'form.merch',
+      i18n,
+    );
+    cy.testLanguageStringsInContext(['moreInfo'], 'navigation', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormCardMerch, {
+        props: {
+          option: {
+            dialogDescription:
+              'Qui veniam labore nisi laborum nisi occaecat et voluptate aute labore nulla. Velit deserunt eiusmod consequat ea qui esse minim officia culpa ea. Labore excepteur elit quis eiusmod velit aute eiusmod ut. Laboris consectetur sunt amet id ut ullamco eu aliquip minim aliqua nostrud dolor veniam exercitation. Consequat magna consectetur elit nostrud do qui amet deserunt excepteur enim id labore consectetur amet. Esse et et nulla. Aliquip occaecat laboris elit mollit proident occaecat enim anim minim. Voluptate excepteur officia cillum id proident ex dolor esse ad duis aliquip esse laboris.',
+            dialogImages: ['https://picsum.photos/id/70/340/200'],
+            dialogTitle: 'dialogTitle',
+            image: 'https://picsum.photos/id/70/340/200',
+            title: 'title',
+            sizes: [
+              {
+                label: 'L',
+                value: 'L',
+              },
+              {
+                label: 'XL',
+                value: 'XL',
+              },
+              {
+                label: 'XXL',
+                value: 'XXL',
+              },
+            ],
+            author: 'author',
+            material: 'material',
+          },
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders card', () => {
+      cy.dataCy('form-card-merch').should('be.visible');
+    });
+  });
+});

--- a/src/components/__tests__/FormCardMerch.cy.js
+++ b/src/components/__tests__/FormCardMerch.cy.js
@@ -1,5 +1,35 @@
+import { colors } from 'quasar';
 import FormCardMerch from 'components/form/FormCardMerch.vue';
 import { i18n } from '../../boot/i18n';
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
+const { getPaletteColor } = colors;
+const black = getPaletteColor('black');
+
+const option = {
+  dialogDescription:
+    'Qui veniam labore nisi laborum nisi occaecat et voluptate aute labore nulla. Velit deserunt eiusmod consequat ea qui esse minim officia culpa ea. Labore excepteur elit quis eiusmod velit aute eiusmod ut. Laboris consectetur sunt amet id ut ullamco eu aliquip minim aliqua nostrud dolor veniam exercitation. Consequat magna consectetur elit nostrud do qui amet deserunt excepteur enim id labore consectetur amet. Esse et et nulla. Aliquip occaecat laboris elit mollit proident occaecat enim anim minim. Voluptate excepteur officia cillum id proident ex dolor esse ad duis aliquip esse laboris.',
+  dialogImages: ['https://picsum.photos/id/70/340/200'],
+  dialogTitle: 'dialogTitle',
+  image: 'https://picsum.photos/id/70/340/200',
+  title: 'title',
+  sizes: [
+    {
+      label: 'L',
+      value: 'L',
+    },
+    {
+      label: 'XL',
+      value: 'XL',
+    },
+    {
+      label: 'XXL',
+      value: 'XXL',
+    },
+  ],
+  author: 'author',
+  material: 'material',
+};
 
 describe('<FormCardMerch>', () => {
   it('has translation for all strings', () => {
@@ -15,37 +45,62 @@ describe('<FormCardMerch>', () => {
     beforeEach(() => {
       cy.mount(FormCardMerch, {
         props: {
-          option: {
-            dialogDescription:
-              'Qui veniam labore nisi laborum nisi occaecat et voluptate aute labore nulla. Velit deserunt eiusmod consequat ea qui esse minim officia culpa ea. Labore excepteur elit quis eiusmod velit aute eiusmod ut. Laboris consectetur sunt amet id ut ullamco eu aliquip minim aliqua nostrud dolor veniam exercitation. Consequat magna consectetur elit nostrud do qui amet deserunt excepteur enim id labore consectetur amet. Esse et et nulla. Aliquip occaecat laboris elit mollit proident occaecat enim anim minim. Voluptate excepteur officia cillum id proident ex dolor esse ad duis aliquip esse laboris.',
-            dialogImages: ['https://picsum.photos/id/70/340/200'],
-            dialogTitle: 'dialogTitle',
-            image: 'https://picsum.photos/id/70/340/200',
-            title: 'title',
-            sizes: [
-              {
-                label: 'L',
-                value: 'L',
-              },
-              {
-                label: 'XL',
-                value: 'XL',
-              },
-              {
-                label: 'XXL',
-                value: 'XXL',
-              },
-            ],
-            author: 'author',
-            material: 'material',
-          },
+          option: option,
         },
       });
       cy.viewport('macbook-16');
     });
 
-    it('renders card', () => {
+    it('renders card with image and title', () => {
       cy.dataCy('form-card-merch').should('be.visible');
+      // rounded corners
+      cy.dataCy('form-card-merch').should(
+        'have.css',
+        'border-radius',
+        rideToWorkByBikeConfig.borderRadiusCard,
+      );
+      cy.dataCy('form-card-merch-top').should('have.css', 'padding', '16px');
+      // image
+      cy.dataCy('form-card-merch-image')
+        .find('img')
+        .should('be.visible')
+        .then(($img) => {
+          cy.testImageHeight($img);
+          expect($img.attr('src')).to.equal(option.image);
+        });
+      // title
+      cy.dataCy('form-card-merch-title')
+        .should('be.visible')
+        .and('have.css', 'font-size', '16px')
+        .and('have.css', 'font-weight', '700')
+        .and('have.color', black)
+        .and('contain', option.title);
+    });
+
+    it('renders parameters', () => {
+      cy.dataCy('form-card-merch-parameters')
+        .find('dt')
+        .should('be.visible')
+        .and('have.css', 'font-size', '14px')
+        .and('have.css', 'font-weight', '400')
+        .and('contain', i18n.global.t('form.merch.labelAuthor'))
+        .and('contain', i18n.global.t('form.merch.labelMaterial'))
+        .and('contain', i18n.global.t('form.merch.labelSizes'));
+      cy.dataCy('form-card-merch-parameters')
+        .find('dd')
+        .should('be.visible')
+        .and('have.css', 'font-size', '14px')
+        .and('have.css', 'font-weight', '700')
+        .and('have.color', black)
+        .and('contain', option.author)
+        .and('contain', option.material)
+        .and('contain', option.sizes[0].label);
+    });
+
+    it('renders button', () => {
+      cy.dataCy('form-card-merch-button')
+        .should('be.visible')
+        .and('contain.text', i18n.global.t('navigation.moreInfo'));
     });
   });
 });

--- a/src/components/__tests__/FormCardMerch.cy.js
+++ b/src/components/__tests__/FormCardMerch.cy.js
@@ -6,31 +6,6 @@ import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 const { getPaletteColor } = colors;
 const black = getPaletteColor('black');
 
-const option = {
-  dialogDescription:
-    'Qui veniam labore nisi laborum nisi occaecat et voluptate aute labore nulla. Velit deserunt eiusmod consequat ea qui esse minim officia culpa ea. Labore excepteur elit quis eiusmod velit aute eiusmod ut. Laboris consectetur sunt amet id ut ullamco eu aliquip minim aliqua nostrud dolor veniam exercitation. Consequat magna consectetur elit nostrud do qui amet deserunt excepteur enim id labore consectetur amet. Esse et et nulla. Aliquip occaecat laboris elit mollit proident occaecat enim anim minim. Voluptate excepteur officia cillum id proident ex dolor esse ad duis aliquip esse laboris.',
-  dialogImages: ['https://picsum.photos/id/70/340/200'],
-  dialogTitle: 'dialogTitle',
-  image: 'https://picsum.photos/id/70/340/200',
-  label: 'Title',
-  sizes: [
-    {
-      label: 'L',
-      value: 'L',
-    },
-    {
-      label: 'XL',
-      value: 'XL',
-    },
-    {
-      label: 'XXL',
-      value: 'XXL',
-    },
-  ],
-  author: 'author',
-  material: 'material',
-};
-
 describe('<FormCardMerch>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
@@ -43,59 +18,65 @@ describe('<FormCardMerch>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.mount(FormCardMerch, {
-        props: {
-          option: option,
-        },
+      cy.fixture('cardMerch').then((option) => {
+        cy.mount(FormCardMerch, {
+          props: {
+            option: option,
+          },
+        });
       });
       cy.viewport('macbook-16');
     });
 
     it('renders card with image and title', () => {
-      cy.dataCy('form-card-merch').should('be.visible');
-      // rounded corners
-      cy.dataCy('form-card-merch')
-        .should(
-          'have.css',
-          'border-radius',
-          rideToWorkByBikeConfig.borderRadiusCard,
-        )
-        .and('have.css', 'padding', '16px');
-      // image
-      cy.dataCy('form-card-merch-image')
-        .find('img')
-        .should('be.visible')
-        .then(($img) => {
-          cy.testImageHeight($img);
-          expect($img.attr('src')).to.equal(option.image);
-        });
-      // title
-      cy.dataCy('form-card-merch-title')
-        .should('be.visible')
-        .and('have.css', 'font-size', '16px')
-        .and('have.css', 'font-weight', '700')
-        .and('have.color', black)
-        .and('contain', option.label);
+      cy.fixture('cardMerch').then((option) => {
+        cy.dataCy('form-card-merch').should('be.visible');
+        // rounded corners
+        cy.dataCy('form-card-merch')
+          .should(
+            'have.css',
+            'border-radius',
+            rideToWorkByBikeConfig.borderRadiusCard,
+          )
+          .and('have.css', 'padding', '16px');
+        // image
+        cy.dataCy('form-card-merch-image')
+          .find('img')
+          .should('be.visible')
+          .then(($img) => {
+            cy.testImageHeight($img);
+            expect($img.attr('src')).to.equal(option.image);
+          });
+        // title
+        cy.dataCy('form-card-merch-title')
+          .should('be.visible')
+          .and('have.css', 'font-size', '16px')
+          .and('have.css', 'font-weight', '700')
+          .and('have.color', black)
+          .and('contain', option.label);
+      });
     });
 
     it('renders parameters', () => {
-      cy.dataCy('form-card-merch-parameters')
-        .find('dt')
-        .should('be.visible')
-        .and('have.css', 'font-size', '14px')
-        .and('have.css', 'font-weight', '400')
-        .and('contain', i18n.global.t('form.merch.labelAuthor'))
-        .and('contain', i18n.global.t('form.merch.labelMaterial'))
-        .and('contain', i18n.global.t('form.merch.labelSizes'));
-      cy.dataCy('form-card-merch-parameters')
-        .find('dd')
-        .should('be.visible')
-        .and('have.css', 'font-size', '14px')
-        .and('have.css', 'font-weight', '700')
-        .and('have.color', black)
-        .and('contain', option.author)
-        .and('contain', option.material)
-        .and('contain', option.sizes[0].label);
+      cy.fixture('cardMerch').then((option) => {
+        cy.dataCy('form-card-merch-parameters')
+          .find('dt')
+          .should('be.visible')
+          .and('have.css', 'font-size', '14px')
+          .and('have.css', 'font-weight', '400')
+          .and('contain', i18n.global.t('form.merch.labelAuthor'))
+          .and('contain', i18n.global.t('form.merch.labelMaterial'))
+          .and('contain', i18n.global.t('form.merch.labelSizes'));
+        cy.dataCy('form-card-merch-parameters')
+          .find('dd')
+          .should('be.visible')
+          .and('have.css', 'font-size', '14px')
+          .and('have.css', 'font-weight', '700')
+          .and('have.color', black)
+          .and('contain', option.author)
+          .and('contain', option.material)
+          .and('contain', option.sizes[0].label);
+      });
     });
 
     it('renders button', () => {
@@ -107,11 +88,13 @@ describe('<FormCardMerch>', () => {
 
   context('selected', () => {
     beforeEach(() => {
-      cy.mount(FormCardMerch, {
-        props: {
-          option: option,
-          selected: true,
-        },
+      cy.fixture('cardMerch').then((option) => {
+        cy.mount(FormCardMerch, {
+          props: {
+            option: option,
+            selected: true,
+          },
+        });
       });
       cy.viewport('macbook-16');
     });

--- a/src/components/__tests__/FormCardMerch.cy.js
+++ b/src/components/__tests__/FormCardMerch.cy.js
@@ -12,7 +12,7 @@ const option = {
   dialogImages: ['https://picsum.photos/id/70/340/200'],
   dialogTitle: 'dialogTitle',
   image: 'https://picsum.photos/id/70/340/200',
-  title: 'title',
+  label: 'Title',
   sizes: [
     {
       label: 'L',
@@ -38,7 +38,7 @@ describe('<FormCardMerch>', () => {
       'form.merch',
       i18n,
     );
-    cy.testLanguageStringsInContext(['select'], 'navigation', i18n);
+    cy.testLanguageStringsInContext(['select', 'selected'], 'navigation', i18n);
   });
 
   context('desktop', () => {
@@ -75,7 +75,7 @@ describe('<FormCardMerch>', () => {
         .and('have.css', 'font-size', '16px')
         .and('have.css', 'font-weight', '700')
         .and('have.color', black)
-        .and('contain', option.title);
+        .and('contain', option.label);
     });
 
     it('renders parameters', () => {
@@ -102,6 +102,24 @@ describe('<FormCardMerch>', () => {
       cy.dataCy('form-card-merch-button')
         .should('be.visible')
         .and('contain.text', i18n.global.t('navigation.select'));
+    });
+  });
+
+  context('selected', () => {
+    beforeEach(() => {
+      cy.mount(FormCardMerch, {
+        props: {
+          option: option,
+          selected: true,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders button', () => {
+      cy.dataCy('form-card-merch-button')
+        .should('be.visible')
+        .and('contain.text', i18n.global.t('navigation.selected'));
     });
   });
 });

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -37,12 +37,11 @@ describe('<FormFieldListMerch>', () => {
         .and('have.color', grey8);
       // component is visible
       cy.dataCy('list-merch').should('be.visible');
-      // cards are visible
-      cy.dataCy('form-card-merch').should('be.visible');
+      // female cards are visible
+      cy.dataCy('form-card-merch-female').should('be.visible');
       // tabs are visible
-      cy.dataCy('list-merch-tab')
-        // male and female tabs
-        .should('have.length', 2);
+      cy.dataCy('list-merch-tab-female').should('be.visible');
+      cy.dataCy('list-merch-tab-male').should('be.visible');
     });
 
     it('should render 3 cards in a row', () => {
@@ -57,6 +56,15 @@ describe('<FormFieldListMerch>', () => {
       cy.dataCy('list-merch').should('not.be.visible');
       cy.dataCy('no-merch').click();
       cy.dataCy('list-merch').should('be.visible');
+    });
+
+    it('allows to switch between tabs', () => {
+      cy.dataCy('list-merch-tab-male').click();
+      cy.dataCy('form-card-merch-female').should('not.exist');
+      cy.dataCy('form-card-merch-male').should('be.visible');
+      cy.dataCy('list-merch-tab-female').click();
+      cy.dataCy('form-card-merch-female').should('be.visible');
+      cy.dataCy('form-card-merch-male').should('not.exist');
     });
   });
 

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -8,7 +8,12 @@ const grey10 = getPaletteColor('grey-10');
 
 describe('<FormFieldListMerch>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'index.component', i18n);
+    cy.testLanguageStringsInContext(
+      ['labelNoMerch', 'hintNoMerch'],
+      'form.merch',
+      i18n,
+    );
+    cy.testLanguageStringsInContext(['male', 'female'], 'global', i18n);
   });
 
   context('desktop', () => {

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -46,6 +46,13 @@ describe('<FormFieldListMerch>', () => {
         33,
       );
     });
+
+    it('allows to disable merch options', () => {
+      cy.dataCy('no-merch').click();
+      cy.dataCy('list-merch').should('not.be.visible');
+      cy.dataCy('no-merch').click();
+      cy.dataCy('list-merch').should('be.visible');
+    });
   });
 
   context('mobile', () => {

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -15,7 +15,21 @@ describe('<FormFieldListMerch>', () => {
     });
 
     it('renders component', () => {
-      cy.dataCy('form-field-list-merch').should('be.visible');
+      // component is visible
+      cy.dataCy('list-merch').should('be.visible');
+      // cards are visible
+      cy.dataCy('form-card-merch').should('be.visible');
+      // tabs are visible
+      cy.dataCy('list-merch-tab')
+        // male and female tabs
+        .should('have.length', 2);
+    });
+
+    it('should render 3 cards in a row', () => {
+      cy.testElementPercentageWidth(
+        cy.dataCy('list-merch-option-group').children(),
+        33,
+      );
     });
   });
 
@@ -25,6 +39,13 @@ describe('<FormFieldListMerch>', () => {
         props: {},
       });
       cy.viewport('iphone-6');
+    });
+
+    it('should render 1 card in a row', () => {
+      cy.testElementPercentageWidth(
+        cy.dataCy('list-merch-option-group').children(),
+        100,
+      );
     });
   });
 });

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -1,5 +1,10 @@
+import { colors } from 'quasar';
 import FormFieldListMerch from 'components/form/FormFieldListMerch.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
+const grey8 = getPaletteColor('grey-8');
+const grey10 = getPaletteColor('grey-10');
 
 describe('<FormFieldListMerch>', () => {
   it('has translation for all strings', () => {
@@ -15,6 +20,16 @@ describe('<FormFieldListMerch>', () => {
     });
 
     it('renders component', () => {
+      cy.dataCy('no-merch-label')
+        .should('be.visible')
+        .and('have.css', 'font-size', '14px')
+        .and('have.css', 'font-weight', '400')
+        .and('have.color', grey10);
+      cy.dataCy('no-merch-hint')
+        .should('be.visible')
+        .and('have.css', 'font-size', '12px')
+        .and('have.css', 'font-weight', '400')
+        .and('have.color', grey8);
       // component is visible
       cy.dataCy('list-merch').should('be.visible');
       // cards are visible

--- a/src/components/__tests__/FormFieldListMerch.cy.js
+++ b/src/components/__tests__/FormFieldListMerch.cy.js
@@ -1,0 +1,30 @@
+import FormFieldListMerch from 'components/form/FormFieldListMerch.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<FormFieldListMerch>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldListMerch, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders component', () => {
+      cy.dataCy('form-field-list-merch').should('be.visible');
+    });
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldListMerch, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+  });
+});

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -1,0 +1,116 @@
+<script lang="ts">
+/**
+ * FormCardMerch Component
+ *
+ * The `FormCardMerch` is used in FormFieldOptionGroup to show merch options.
+ *
+ * @description * Use this component to display options in the form.
+ *
+ * Note: This component is commonly used in `FormFieldOptionGroup`.
+ *
+ * @props
+ * - `option` (object, required): The object representing the option.
+ *   It should be of type `object` with the following properties:
+ *   - dialogDescription (string)
+ *   - dialogImages (Array<string>)
+ *   - dialogTitle (string)
+ *   - image (string)
+ *   - title (string)
+ *   - sizes (Array)
+ *   - gender (Array)
+ *   - author (string)
+ *   - material (string)
+ *
+ * @events
+ * - `update:formValue`: Emitted as a part of v-model structure.
+ *
+ * @slots
+ * - `form`: For displaying form (size options) within dialog.
+ *
+ * @components
+ * - `DialogDefault`: Component to display dialog.
+ *
+ * @example
+ * <form-card-merch />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=4858%3A103131&mode=dev)
+ */
+
+import { defineComponent, ref } from 'vue';
+
+// config
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
+// types
+import type { FormCardMerch } from 'src/components/types/Form';
+
+export default defineComponent({
+  name: 'FormCardMerch',
+  props: {
+    option: {
+      type: Object as () => FormCardMerch,
+      required: true,
+    },
+  },
+  setup() {
+    const isOpen = ref<boolean>(false);
+
+    const borderRadius: string = rideToWorkByBikeConfig.borderRadiusCardSmall;
+
+    return {
+      borderRadius,
+      isOpen,
+    };
+  },
+});
+</script>
+
+<template>
+  <q-card
+    flat
+    bordered
+    class="q-mt-sm"
+    :style="{ 'border-radius': borderRadius, 'max-width': '400px' }"
+    data-cy="form-card-merch"
+  >
+    <q-card-section class="q-pa-sm" data-cy="form-card-merch-top">
+      <!-- Image -->
+      <q-img ratio="1.33" :src="option.image" />
+      <!-- Title -->
+      <h3 class="text-body1 text-black text-weight-bold q-my-sm">
+        {{ option.title }}
+      </h3>
+      <!-- Parameters -->
+      <dl class="q-mt-sm">
+        <div class="flex q-gutter-x-xs">
+          <dt>{{ $t('form.merch.labelSizes') }}:</dt>
+          <dd class="text-weight-bold">
+            <span v-for="(size, index) in option.sizes" :key="size.value">
+              {{ size.label
+              }}<span v-if="index < option.sizes.length - 1">, </span>
+            </span>
+          </dd>
+        </div>
+        <div class="flex q-gutter-x-xs">
+          <dt>{{ $t('form.merch.labelAuthor') }}:</dt>
+          <dd class="text-weight-bold">{{ option.author }}</dd>
+        </div>
+        <div class="flex q-gutter-x-xs">
+          <dt>{{ $t('form.merch.labelMaterial') }}:</dt>
+          <dd class="text-weight-bold">{{ option.material }}</dd>
+        </div>
+      </dl>
+    </q-card-section>
+    <!-- Separator -->
+    <q-separator />
+    <q-card-section
+      class="full-width flex items-center justify-center q-pa-sm"
+      data-cy="form-card-merch-button"
+    >
+      <!-- Button: more info -->
+      <q-btn flat rounded class="full-width" @click="isOpen = true">
+        {{ $t('navigation.moreInfo') }}
+      </q-btn>
+    </q-card-section>
+  </q-card>
+</template>

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -20,6 +20,7 @@
  *   - gender (Array)
  *   - author (string)
  *   - material (string)
+ * - `selected` (boolean, required): Whether or not option shows as selected.
  *
  * @events
  * - `update:formValue`: Emitted as a part of v-model structure.

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -42,13 +42,13 @@ import { defineComponent, ref } from 'vue';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
 // types
-import type { FormCardMerch } from 'src/components/types/Form';
+import type { FormCardMerchType } from 'src/components/types/Form';
 
 export default defineComponent({
   name: 'FormCardMerch',
   props: {
     option: {
-      type: Object as () => FormCardMerch,
+      type: Object as () => FormCardMerchType,
       required: true,
     },
   },

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -56,9 +56,12 @@ export default defineComponent({
     const isOpen = ref<boolean>(false);
 
     const borderRadius: string = rideToWorkByBikeConfig.borderRadiusCard;
+    const borderRadiusSmall: string =
+      rideToWorkByBikeConfig.borderRadiusCardSmall;
 
     return {
       borderRadius,
+      borderRadiusSmall,
       isOpen,
     };
   },
@@ -68,22 +71,29 @@ export default defineComponent({
 <template>
   <q-card
     flat
-    bordered
     :style="{ 'border-radius': borderRadius, 'max-width': '400px' }"
+    class="q-pa-md"
     data-cy="form-card-merch"
   >
-    <q-card-section class="q-pa-md" data-cy="form-card-merch-top">
+    <q-card-section class="q-pa-none" data-cy="form-card-merch-top">
       <!-- Image -->
-      <q-img ratio="1.33" :src="option.image" data-cy="form-card-merch-image" />
+      <q-img
+        ratio="1.33"
+        :src="option.image"
+        data-cy="form-card-merch-image"
+        :style="{ 'border-radius': borderRadiusSmall }"
+      />
       <!-- Title -->
       <h3
-        class="text-body1 text-black text-weight-bold q-my-md"
+        class="text-body1 text-black text-weight-bold q-my-sm"
         data-cy="form-card-merch-title"
       >
-        {{ option.title }}
+        <a href="#" class="text-black" @click.prevent="isOpen = true">{{
+          option.title
+        }}</a>
       </h3>
       <!-- Parameters -->
-      <dl class="q-mt-sm" data-cy="form-card-merch-parameters">
+      <dl class="q-my-sm" data-cy="form-card-merch-parameters">
         <div class="flex q-gutter-x-xs">
           <dt>{{ $t('form.merch.labelSizes') }}:</dt>
           <dd class="text-weight-bold">
@@ -103,21 +113,21 @@ export default defineComponent({
         </div>
       </dl>
     </q-card-section>
-    <!-- Separator -->
-    <q-separator />
     <q-card-section
-      class="full-width flex items-center justify-center q-pa-sm"
+      class="full-width flex items-center justify-center q-pa-none"
       data-cy="form-card-merch-button"
     >
       <!-- Button: more info -->
       <q-btn
-        flat
+        unelevated
         rounded
+        outline
+        color="primary"
         class="full-width"
         @click.prevent="isOpen = true"
         data-cy="button-more-info"
       >
-        {{ $t('navigation.moreInfo') }}
+        {{ $t('navigation.select') }}
       </q-btn>
     </q-card-section>
   </q-card>

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -51,6 +51,10 @@ export default defineComponent({
       type: Object as () => FormCardMerchType,
       required: true,
     },
+    selected: {
+      type: Boolean,
+      required: true,
+    },
   },
   setup() {
     const isOpen = ref<boolean>(false);
@@ -119,6 +123,7 @@ export default defineComponent({
     >
       <!-- Button: more info -->
       <q-btn
+        v-show="!selected"
         unelevated
         rounded
         outline
@@ -128,6 +133,19 @@ export default defineComponent({
         data-cy="button-more-info"
       >
         {{ $t('navigation.select') }}
+      </q-btn>
+      <q-btn
+        v-show="selected"
+        unelevated
+        rounded
+        color="secondary"
+        text-color="primary"
+        icon-right="done"
+        class="full-width"
+        @click.prevent="isOpen = true"
+        data-cy="button-more-info"
+      >
+        {{ $t('navigation.selected') }}
       </q-btn>
     </q-card-section>
   </q-card>

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -89,7 +89,7 @@ export default defineComponent({
         data-cy="form-card-merch-title"
       >
         <a href="#" class="text-black" @click.prevent="isOpen = true">{{
-          option.title
+          option.label
         }}</a>
       </h3>
       <!-- Parameters -->

--- a/src/components/form/FormCardMerch.vue
+++ b/src/components/form/FormCardMerch.vue
@@ -55,7 +55,7 @@ export default defineComponent({
   setup() {
     const isOpen = ref<boolean>(false);
 
-    const borderRadius: string = rideToWorkByBikeConfig.borderRadiusCardSmall;
+    const borderRadius: string = rideToWorkByBikeConfig.borderRadiusCard;
 
     return {
       borderRadius,
@@ -69,19 +69,21 @@ export default defineComponent({
   <q-card
     flat
     bordered
-    class="q-mt-sm"
     :style="{ 'border-radius': borderRadius, 'max-width': '400px' }"
     data-cy="form-card-merch"
   >
-    <q-card-section class="q-pa-sm" data-cy="form-card-merch-top">
+    <q-card-section class="q-pa-md" data-cy="form-card-merch-top">
       <!-- Image -->
-      <q-img ratio="1.33" :src="option.image" />
+      <q-img ratio="1.33" :src="option.image" data-cy="form-card-merch-image" />
       <!-- Title -->
-      <h3 class="text-body1 text-black text-weight-bold q-my-sm">
+      <h3
+        class="text-body1 text-black text-weight-bold q-my-md"
+        data-cy="form-card-merch-title"
+      >
         {{ option.title }}
       </h3>
       <!-- Parameters -->
-      <dl class="q-mt-sm">
+      <dl class="q-mt-sm" data-cy="form-card-merch-parameters">
         <div class="flex q-gutter-x-xs">
           <dt>{{ $t('form.merch.labelSizes') }}:</dt>
           <dd class="text-weight-bold">
@@ -108,7 +110,13 @@ export default defineComponent({
       data-cy="form-card-merch-button"
     >
       <!-- Button: more info -->
-      <q-btn flat rounded class="full-width" @click="isOpen = true">
+      <q-btn
+        flat
+        rounded
+        class="full-width"
+        @click.prevent="isOpen = true"
+        data-cy="button-more-info"
+      >
         {{ $t('navigation.moreInfo') }}
       </q-btn>
     </q-card-section>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -25,7 +25,7 @@
  */
 
 // libraries
-import { defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 
 // components
 import FormCardMerch from 'src/components/form/FormCardMerch.vue';
@@ -41,11 +41,13 @@ export default defineComponent({
   setup() {
     const tab = ref('female');
 
-    const formValue = ref();
+    const selectedModel = ref<string | null>(null);
+    const selectedSize = ref<string | null>(null);
+    const selectedGender = ref<string | null>(null);
 
     const isNotMerch = ref<boolean>(false);
 
-    const femaleOptions: FormCardMerchType[] = [
+    const options: FormCardMerchType[] = [
       {
         value: '1',
         label: 'T-Shirt',
@@ -61,6 +63,10 @@ export default defineComponent({
           {
             label: 'Female',
             value: 'female',
+          },
+          {
+            label: 'Female',
+            value: 'male',
           },
         ],
         sizes: [
@@ -93,35 +99,6 @@ export default defineComponent({
         dialogDescription: 'T-Shirt',
         gender: [
           {
-            label: 'Male',
-            value: 'male',
-          },
-        ],
-        sizes: [
-          {
-            label: 'S',
-            value: 'S',
-          },
-        ],
-        material: 'Bavlna',
-        author: 'Jaromír 99',
-      },
-    ];
-
-    const maleOptions: FormCardMerchType[] = [
-      {
-        value: '1',
-        label: 'T-Shirt',
-        image: 'https://cdn.quasar.dev/img/mountains.jpg',
-        dialogTitle: 'T-Shirt',
-        dialogImages: [
-          'https://cdn.quasar.dev/img/mountains.jpg',
-          'https://cdn.quasar.dev/img/mountains.jpg',
-          'https://cdn.quasar.dev/img/mountains.jpg',
-        ],
-        dialogDescription: 'T-Shirt',
-        gender: [
-          {
             label: 'Female',
             value: 'female',
           },
@@ -133,38 +110,32 @@ export default defineComponent({
           },
         ],
         material: 'Bavlna',
-        author: 'Cotton lady',
-      },
-      {
-        value: '2',
-        label: 'T-Shirt',
-        image: 'https://cdn.quasar.dev/img/mountains.jpg',
-        dialogTitle: 'T-Shirt',
-        dialogImages: [
-          'https://cdn.quasar.dev/img/mountains.jpg',
-          'https://cdn.quasar.dev/img/mountains.jpg',
-          'https://cdn.quasar.dev/img/mountains.jpg',
-        ],
-        dialogDescription: 'T-Shirt',
-        gender: [
-          {
-            label: 'Male',
-            value: 'male',
-          },
-        ],
-        sizes: [
-          {
-            label: 'S',
-            value: 'S',
-          },
-        ],
-        material: 'Bavlna',
         author: 'Jaromír 99',
       },
     ];
 
+    const femaleOptions = computed((): FormCardMerchType[] => {
+      return options.filter((option: FormCardMerchType) => {
+        const genderValues = option.gender.map(
+          (gender: { value: string }) => gender.value,
+        );
+        return genderValues.includes('female');
+      });
+    });
+
+    const maleOptions = computed((): FormCardMerchType[] => {
+      return options.filter((option: FormCardMerchType) => {
+        const genderValues = option.gender.map(
+          (gender: { value: string }) => gender.value,
+        );
+        return genderValues.includes('male');
+      });
+    });
+
     return {
-      formValue,
+      selectedModel,
+      selectedSize,
+      selectedGender,
       femaleOptions,
       isNotMerch,
       maleOptions,

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -41,9 +41,9 @@ export default defineComponent({
   setup() {
     const tab = ref('female');
 
-    const selectedModel = ref<string | null>(null);
+    const selectedGender = ref<string | null>('female');
+    const selectedModel = ref<string | null>('1');
     const selectedSize = ref<string | null>(null);
-    const selectedGender = ref<string | null>(null);
 
     const isNotMerch = ref<boolean>(false);
 
@@ -132,13 +132,20 @@ export default defineComponent({
       });
     });
 
+    const isSelected = (option: FormCardMerchType): boolean => {
+      const isModel = selectedModel.value === option.value;
+      const isGender = selectedGender.value === tab.value;
+      return isModel && isGender;
+    };
+
     return {
+      femaleOptions,
+      isNotMerch,
+      isSelected,
+      maleOptions,
       selectedModel,
       selectedSize,
       selectedGender,
-      femaleOptions,
-      isNotMerch,
-      maleOptions,
       tab,
     };
   },
@@ -191,7 +198,8 @@ export default defineComponent({
           <FormCardMerch
             v-for="option in femaleOptions"
             :option="option"
-            :key="option.value"
+            :key="`${option.value}-female`"
+            :selected="isSelected(option)"
             class="col-12 col-md-6 col-lg-4"
             data-cy="form-card-merch"
           >
@@ -203,9 +211,10 @@ export default defineComponent({
       <q-tab-panel name="male">
         <div class="row q-gutter-x-none" data-cy="list-merch-option-group">
           <FormCardMerch
-            v-for="option in femaleOptions"
+            v-for="option in maleOptions"
             :option="option"
-            :key="option.value"
+            :key="`${option.value}-female`"
+            :selected="isSelected(option)"
             class="col-12 col-md-6 col-lg-4"
             data-cy="form-card-merch"
           >

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -82,14 +82,14 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-card data-cy="form-field-list-merch">
+  <q-card flat data-cy="form-field-list-merch">
     <q-tabs
       v-model="tab"
       dense
       class="text-grey"
       active-color="primary"
       indicator-color="primary"
-      align="justify"
+      align="left"
     >
       <q-tab name="female" :label="$t('global.female')" />
       <q-tab name="male" :label="$t('global.male')" />

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -43,6 +43,8 @@ export default defineComponent({
 
     const formValue = ref();
 
+    const isNotMerch = ref<boolean>(false);
+
     const femaleOptions: FormCardMerchType[] = [
       {
         value: '1',
@@ -65,6 +67,14 @@ export default defineComponent({
           {
             label: 'S',
             value: 'S',
+          },
+          {
+            label: 'M',
+            value: 'M',
+          },
+          {
+            label: 'L',
+            value: 'L',
           },
         ],
         material: 'Bavlna',
@@ -156,6 +166,7 @@ export default defineComponent({
     return {
       formValue,
       femaleOptions,
+      isNotMerch,
       maleOptions,
       tab,
     };
@@ -164,7 +175,26 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-card flat data-cy="list-merch" style="max-width: 1024px">
+  <q-item tag="label" v-ripple>
+    <q-item-section avatar top>
+      <q-checkbox dense v-model="isNotMerch" :val="true" color="primary" />
+    </q-item-section>
+    <q-item-section>
+      <q-item-label class="text-grey-10" data-cy="no-merch-label">{{
+        $t('form.merch.labelNoMerch')
+      }}</q-item-label>
+      <q-item-label class="text-grey-8" caption data-cy="no-merch-hint">
+        {{ $t('form.merch.hintNoMerch') }}
+      </q-item-label>
+    </q-item-section>
+  </q-item>
+  <q-card
+    v-show="!isNotMerch"
+    flat
+    class="q-mt-lg"
+    style="max-width: 1024px"
+    data-cy="list-merch"
+  >
     <q-tabs
       v-model="tab"
       dense

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -187,66 +187,32 @@ export default defineComponent({
 
     <q-tab-panels v-model="tab" animated>
       <q-tab-panel name="female">
-        <q-option-group
-          v-model="formValue"
-          type="radio"
-          :options="femaleOptions"
-          class="option-grid"
-          data-cy="list-merch-option-group"
-        >
-          <template v-slot:label="options">
-            <FormCardMerch
-              :option="options as FormCardMerchType"
-              data-cy="form-card-merch"
-            >
-              <!-- TODO: add form slot for merch customization within dialog -->
-            </FormCardMerch>
-          </template>
-        </q-option-group>
+        <div class="row q-gutter-x-none" data-cy="list-merch-option-group">
+          <FormCardMerch
+            v-for="option in femaleOptions"
+            :option="option"
+            :key="option.value"
+            class="col-12 col-md-6 col-lg-4"
+            data-cy="form-card-merch"
+          >
+            <!-- TODO: add form slot for merch customization within dialog -->
+          </FormCardMerch>
+        </div>
       </q-tab-panel>
 
       <q-tab-panel name="male">
-        <q-option-group
-          v-model="formValue"
-          type="radio"
-          :options="maleOptions"
-          class="option-grid"
-          data-cy="list-merch-option-group"
-        >
-          <template v-slot:label="options">
-            <FormCardMerch :option="options as FormCardMerchType">
-              <!-- TODO: add form slot for merch customization within dialog -->
-            </FormCardMerch>
-          </template>
-        </q-option-group>
+        <div class="row q-gutter-x-none" data-cy="list-merch-option-group">
+          <FormCardMerch
+            v-for="option in femaleOptions"
+            :option="option"
+            :key="option.value"
+            class="col-12 col-md-6 col-lg-4"
+            data-cy="form-card-merch"
+          >
+            <!-- TODO: add form slot for merch customization within dialog -->
+          </FormCardMerch>
+        </div>
       </q-tab-panel>
     </q-tab-panels>
   </q-card>
 </template>
-
-<style scoped lang="scss">
-// hide radio button
-:deep(.q-radio__inner) {
-  display: none;
-}
-:deep(.q-radio) {
-  width: 100%;
-}
-:deep(.q-radio__label) {
-  width: 100%;
-}
-// override default q-gutter-x-sm
-:deep(.option-grid > *) {
-  margin: 0;
-}
-.option-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-gap: 0;
-}
-@media (max-width: $breakpoint-sm-max) {
-  .option-grid {
-    grid-template-columns: repeat(1, 1fr);
-  }
-}
-</style>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -193,7 +193,7 @@ export default defineComponent({
     <q-separator />
 
     <q-tab-panels v-model="tab" animated>
-      <q-tab-panel name="female">
+      <q-tab-panel name="female" class="q-pa-none">
         <div class="row q-gutter-x-none" data-cy="list-merch-option-group">
           <FormCardMerch
             v-for="option in femaleOptions"

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 
     const formValue = ref();
 
-    const options: FormCardMerchType[] = [
+    const femaleOptions: FormCardMerchType[] = [
       {
         value: '1',
         label: 'T-Shirt',
@@ -67,14 +67,44 @@ export default defineComponent({
             value: 'S',
           },
         ],
-        material: 'Cotton',
+        material: 'Bavlna',
         author: 'Cotton lady',
+      },
+    ];
+
+    const maleOptions: FormCardMerchType[] = [
+      {
+        value: '2',
+        label: 'T-Shirt',
+        image: 'https://cdn.quasar.dev/img/mountains.jpg',
+        dialogTitle: 'T-Shirt',
+        dialogImages: [
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+        ],
+        dialogDescription: 'T-Shirt',
+        gender: [
+          {
+            label: 'Male',
+            value: 'male',
+          },
+        ],
+        sizes: [
+          {
+            label: 'S',
+            value: 'S',
+          },
+        ],
+        material: 'Bavlna',
+        author: 'Jaromír 99',
       },
     ];
 
     return {
       formValue,
-      options,
+      femaleOptions,
+      maleOptions,
       tab,
     };
   },
@@ -102,18 +132,30 @@ export default defineComponent({
         <q-option-group
           v-model="formValue"
           type="radio"
-          :options="options"
+          :options="femaleOptions"
           class="q-gutter-md"
         >
-          <template v-slot:label="opt">
-            <FormCardMerch :option="opt as FormCardMerchType"> </FormCardMerch>
+          <template v-slot:label="options">
+            <FormCardMerch :option="options as FormCardMerchType">
+              <!-- TODO: add form slot for merch customization within dialog -->
+            </FormCardMerch>
           </template>
         </q-option-group>
       </q-tab-panel>
 
       <q-tab-panel name="male">
-        <div class="text-h6">{{ $t('global.male') }}</div>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit.
+        <q-option-group
+          v-model="formValue"
+          type="radio"
+          :options="maleOptions"
+          class="q-gutter-md"
+        >
+          <template v-slot:label="options">
+            <FormCardMerch :option="options as FormCardMerchType">
+              <!-- TODO: add form slot for merch customization within dialog -->
+            </FormCardMerch>
+          </template>
+        </q-option-group>
       </q-tab-panel>
     </q-tab-panels>
   </q-card>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -185,9 +185,13 @@ export default defineComponent({
       <q-tab
         name="female"
         :label="$t('global.female')"
-        data-cy="list-merch-tab"
+        data-cy="list-merch-tab-female"
       />
-      <q-tab name="male" :label="$t('global.male')" data-cy="list-merch-tab" />
+      <q-tab
+        name="male"
+        :label="$t('global.male')"
+        data-cy="list-merch-tab-male"
+      />
     </q-tabs>
 
     <q-separator />
@@ -201,7 +205,7 @@ export default defineComponent({
             :key="`${option.value}-female`"
             :selected="isSelected(option)"
             class="col-12 col-md-6 col-lg-4"
-            data-cy="form-card-merch"
+            data-cy="form-card-merch-female"
           >
             <!-- TODO: add form slot for merch customization within dialog -->
           </FormCardMerch>
@@ -216,7 +220,7 @@ export default defineComponent({
             :key="`${option.value}-female`"
             :selected="isSelected(option)"
             class="col-12 col-md-6 col-lg-4"
-            data-cy="form-card-merch"
+            data-cy="form-card-merch-male"
           >
             <!-- TODO: add form slot for merch customization within dialog -->
           </FormCardMerch>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -1,0 +1,133 @@
+<script lang="ts">
+/**
+ * FormFieldListMerch Component
+ *
+ * The `FormFieldListMerch`
+ *
+ * @description * Use this component to render a list of t-shirts.
+ *
+ * Note: This component is commonly used in `FormRegisterChallenge`.
+ *
+ * @props
+ * - `formValue` (FormMerchFields, required): The object representing form state.
+ *   It should be of type `FormMerchFields`.
+ *
+ * @events
+ * - `update:formValue`: Emitted as a part of v-model structure.
+ *
+ * @components
+ * - `FormCardMerch`: Component to render a merch card (option).
+ *
+ * @example
+ * <form-field-list-merch />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=7003%3A32273&mode=dev)
+ */
+
+// libraries
+import { defineComponent, ref } from 'vue';
+
+// components
+import FormCardMerch from 'src/components/form/FormCardMerch.vue';
+
+// types
+import type { FormCardMerchType } from 'src/components/types/Form';
+
+export default defineComponent({
+  name: 'FormFieldListMerch',
+  components: {
+    FormCardMerch,
+  },
+  setup() {
+    const tab = ref('female');
+
+    const formValue = ref();
+
+    const options: FormCardMerchType[] = [
+      {
+        id: '1',
+        title: 'T-Shirt',
+        image: 'https://cdn.quasar.dev/img/mountains.jpg',
+        dialogTitle: 'T-Shirt',
+        dialogImages: [
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+        ],
+        dialogDescription: 'T-Shirt',
+        gender: [
+          {
+            label: 'Female',
+            value: 'female',
+          },
+        ],
+        sizes: [
+          {
+            label: 'S',
+            value: 'S',
+          },
+        ],
+        material: 'Cotton',
+        author: 'Cotton lady',
+      },
+    ];
+
+    return {
+      formValue,
+      options,
+      tab,
+    };
+  },
+});
+</script>
+
+<template>
+  <q-card data-cy="form-field-list-merch">
+    <q-tabs
+      v-model="tab"
+      dense
+      class="text-grey"
+      active-color="primary"
+      indicator-color="primary"
+      align="justify"
+    >
+      <q-tab name="female" :label="$t('global.female')" />
+      <q-tab name="male" :label="$t('global.male')" />
+    </q-tabs>
+
+    <q-separator />
+
+    <q-tab-panels v-model="tab" animated>
+      <q-tab-panel name="female">
+        <q-option-group
+          v-model="formValue"
+          type="radio"
+          :options="options"
+          class="q-gutter-md"
+        >
+          <template v-slot:label="opt">
+            <FormCardMerch :option="opt as FormCardMerchType"> </FormCardMerch>
+          </template>
+        </q-option-group>
+      </q-tab-panel>
+
+      <q-tab-panel name="male">
+        <div class="text-h6">{{ $t('global.male') }}</div>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit.
+      </q-tab-panel>
+    </q-tab-panels>
+  </q-card>
+</template>
+
+<style scoped lang="scss">
+// hide radio button
+:deep(.q-radio__inner) {
+  display: none;
+}
+:deep(.q-radio) {
+  width: 100%;
+}
+:deep(.q-radio__label) {
+  width: 100%;
+}
+</style>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -45,8 +45,8 @@ export default defineComponent({
 
     const options: FormCardMerchType[] = [
       {
-        id: '1',
-        title: 'T-Shirt',
+        value: '1',
+        label: 'T-Shirt',
         image: 'https://cdn.quasar.dev/img/mountains.jpg',
         dialogTitle: 'T-Shirt',
         dialogImages: [

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -175,7 +175,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-item tag="label" v-ripple>
+  <q-item tag="label" v-ripple data-cy="no-merch">
     <q-item-section avatar top>
       <q-checkbox dense v-model="isNotMerch" :val="true" color="primary" />
     </q-item-section>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -70,9 +70,61 @@ export default defineComponent({
         material: 'Bavlna',
         author: 'Cotton lady',
       },
+      {
+        value: '2',
+        label: 'T-Shirt',
+        image: 'https://cdn.quasar.dev/img/mountains.jpg',
+        dialogTitle: 'T-Shirt',
+        dialogImages: [
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+        ],
+        dialogDescription: 'T-Shirt',
+        gender: [
+          {
+            label: 'Male',
+            value: 'male',
+          },
+        ],
+        sizes: [
+          {
+            label: 'S',
+            value: 'S',
+          },
+        ],
+        material: 'Bavlna',
+        author: 'Jaromír 99',
+      },
     ];
 
     const maleOptions: FormCardMerchType[] = [
+      {
+        value: '1',
+        label: 'T-Shirt',
+        image: 'https://cdn.quasar.dev/img/mountains.jpg',
+        dialogTitle: 'T-Shirt',
+        dialogImages: [
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+          'https://cdn.quasar.dev/img/mountains.jpg',
+        ],
+        dialogDescription: 'T-Shirt',
+        gender: [
+          {
+            label: 'Female',
+            value: 'female',
+          },
+        ],
+        sizes: [
+          {
+            label: 'S',
+            value: 'S',
+          },
+        ],
+        material: 'Bavlna',
+        author: 'Cotton lady',
+      },
       {
         value: '2',
         label: 'T-Shirt',
@@ -112,7 +164,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-card flat data-cy="form-field-list-merch">
+  <q-card flat data-cy="list-merch" style="max-width: 1024px">
     <q-tabs
       v-model="tab"
       dense
@@ -120,9 +172,14 @@ export default defineComponent({
       active-color="primary"
       indicator-color="primary"
       align="left"
+      data-cy="list-merch-tabs"
     >
-      <q-tab name="female" :label="$t('global.female')" />
-      <q-tab name="male" :label="$t('global.male')" />
+      <q-tab
+        name="female"
+        :label="$t('global.female')"
+        data-cy="list-merch-tab"
+      />
+      <q-tab name="male" :label="$t('global.male')" data-cy="list-merch-tab" />
     </q-tabs>
 
     <q-separator />
@@ -133,10 +190,14 @@ export default defineComponent({
           v-model="formValue"
           type="radio"
           :options="femaleOptions"
-          class="q-gutter-md"
+          class="option-grid"
+          data-cy="list-merch-option-group"
         >
           <template v-slot:label="options">
-            <FormCardMerch :option="options as FormCardMerchType">
+            <FormCardMerch
+              :option="options as FormCardMerchType"
+              data-cy="form-card-merch"
+            >
               <!-- TODO: add form slot for merch customization within dialog -->
             </FormCardMerch>
           </template>
@@ -148,7 +209,8 @@ export default defineComponent({
           v-model="formValue"
           type="radio"
           :options="maleOptions"
-          class="q-gutter-md"
+          class="option-grid"
+          data-cy="list-merch-option-group"
         >
           <template v-slot:label="options">
             <FormCardMerch :option="options as FormCardMerchType">
@@ -171,5 +233,19 @@ export default defineComponent({
 }
 :deep(.q-radio__label) {
   width: 100%;
+}
+// override default q-gutter-x-sm
+:deep(.option-grid > *) {
+  margin: 0;
+}
+.option-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 0;
+}
+@media (max-width: $breakpoint-sm-max) {
+  .option-grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
 }
 </style>

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -25,3 +25,15 @@ export type FormAddCompanyFields = {
   referenceCity?: string;
   department?: string;
 };
+
+export type FormCardMerch = {
+  dialogDescription: string;
+  dialogImages: string[];
+  dialogTitle: string;
+  image: string;
+  title: string;
+  sizes: FormOption[];
+  gender: FormOption[];
+  author: string;
+  material: string;
+};

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -32,9 +32,9 @@ export type FormCardMerchType = {
   dialogImages: string[];
   dialogTitle: string;
   gender: FormOption[];
-  id: string;
+  value: string;
   image: string;
   material: string;
-  title: string;
+  label: string;
   sizes: FormOption[];
 };

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -26,14 +26,15 @@ export type FormAddCompanyFields = {
   department?: string;
 };
 
-export type FormCardMerch = {
+export type FormCardMerchType = {
+  author: string;
   dialogDescription: string;
   dialogImages: string[];
   dialogTitle: string;
+  gender: FormOption[];
+  id: string;
   image: string;
+  material: string;
   title: string;
   sizes: FormOption[];
-  gender: FormOption[];
-  author: string;
-  material: string;
 };

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -35,6 +35,7 @@ continue = "Pokračovat"
 back = "Zpět"
 discard = "Zahodit"
 moreInfo = "Více info"
+select = "Vybrat"
 
 [form]
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -272,6 +272,7 @@ titleStepPersonalDetails = "Osobní údaje"
 titleStepPayment = "Platba"
 titleStepParticipation = "Účast"
 titleStepCompany = "Firma / škola / skupina"
+titleStepMerch = "Startovací balíček"
 buttonAddCompany = "Přidat novou"
 
 [register.coordinator]

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -70,9 +70,11 @@ messageTermsRequired = "Musíte souhlasit se zpracováním osobních údajů"
 messageVatIdInvalid = "Neplatné IČO"
 
 [form.merch]
+hintNoMerch = "Necháte tak plnou částku na neziskové aktivity AutoMatu."
 labelSizes = "Velikosti"
 labelAuthor = "Autor"
 labelMaterial = "Materiál"
+labelNoMerch = "Nechci triko ani nákrčník"
 
 [form.personalDetails]
 labelNewsletterAll = "O všech informacích od Do práce na kole"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -17,7 +17,9 @@ donate = "Darujte"
 more = "Více"
 
 [global]
+female = "Dámské"
 man = "Muž"
+male = "Pánské"
 woman = "Žena"
 
 [time]

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -38,6 +38,7 @@ back = "Zpět"
 discard = "Zahodit"
 moreInfo = "Více info"
 select = "Vybrat"
+selected = "Vybráno"
 
 [form]
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -34,6 +34,7 @@ secondShort = "s."
 continue = "Pokračovat"
 back = "Zpět"
 discard = "Zahodit"
+moreInfo = "Více info"
 
 [form]
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
@@ -64,6 +65,11 @@ messagePasswordStrong = "Heslo musí obsahovat alespoň 6 znaků a alespoň 1 p�
 messagePasswordNotIdentical = "Hesla se neshodují"
 messageTermsRequired = "Musíte souhlasit se zpracováním osobních údajů"
 messageVatIdInvalid = "Neplatné IČO"
+
+[form.merch]
+labelSizes = "Velikosti"
+labelAuthor = "Autor"
+labelMaterial = "Materiál"
 
 [form.personalDetails]
 labelNewsletterAll = "O všech informacích od Do práce na kole"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -272,6 +272,7 @@ titleStepPersonalDetails = "Personal details"
 titleStepPayment = "Payment"
 titleStepParticipation = "Participation"
 titleStepCompany = "Company / school / group"
+titleStepMerch = "Starter package"
 buttonAddCompany = "Add new"
 
 [register.coordinator]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -17,7 +17,9 @@ donate = "Donate"
 more = "More"
 
 [global]
+female = "Female"
 man = "Man"
+male = "Male"
 woman = "Woman"
 
 [time]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -34,6 +34,7 @@ secondShort = "s"
 continue = "Continue"
 back = "Back"
 discard = "Discard"
+moreInfo = "More info"
 
 [form]
 hintPassword = "It must contain at least 6 characters and at least 1 letter."
@@ -64,6 +65,11 @@ messagePasswordStrong = "Password must contain at least 6 characters and at leas
 messagePasswordNotIdentical = "Passwords don't match"
 messageTermsRequired = "You must consent to the processing of personal data"
 messageVatIdInvalid = "Invalid registration number"
+
+[form.merch]
+labelSizes = "Sizes"
+labelAuthor = "Author"
+labelMaterial = "Material"
 
 [form.personalDetails]
 labelNewsletterAll = "About everything around Ride to Work by Bike"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -38,6 +38,7 @@ back = "Back"
 discard = "Discard"
 moreInfo = "More info"
 select = "Select"
+selected = "Selected"
 
 [form]
 hintPassword = "It must contain at least 6 characters and at least 1 letter."

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -35,6 +35,7 @@ continue = "Continue"
 back = "Back"
 discard = "Discard"
 moreInfo = "More info"
+select = "Select"
 
 [form]
 hintPassword = "It must contain at least 6 characters and at least 1 letter."

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -70,9 +70,11 @@ messageTermsRequired = "You must consent to the processing of personal data"
 messageVatIdInvalid = "Invalid registration number"
 
 [form.merch]
+hintNoMerch = "This will leave the full amount for AutoMat's non-profit activities."
 labelSizes = "Sizes"
 labelAuthor = "Author"
 labelMaterial = "Material"
+labelNoMerch = "I don't want a shirt or a neck warmer"
 
 [form.personalDetails]
 labelNewsletterAll = "About everything around Ride to Work by Bike"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -35,6 +35,7 @@ continue = "Pokračovať"
 back = "Späť"
 discard = "Vyhodiť"
 moreInfo = "Viac informácií"
+select = "Vybrať"
 
 [form]
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -38,6 +38,7 @@ back = "Späť"
 discard = "Vyhodiť"
 moreInfo = "Viac informácií"
 select = "Vybrať"
+selected = "Vybrané"
 
 [form]
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -272,6 +272,7 @@ titleStepPersonalDetails = "Osobné údaje"
 titleStepPayment = "Platba"
 titleStepParticipation = "Účasť"
 titleStepCompany = "Spoločnosť / škola / skupina"
+titleStepMerch = "Štartovací balíček"
 buttonAddCompany = "Pridanie novej"
 
 [register.coordinator]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -34,6 +34,7 @@ secondShort = "s."
 continue = "Pokračovať"
 back = "Späť"
 discard = "Vyhodiť"
+moreInfo = "Viac informácií"
 
 [form]
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
@@ -64,6 +65,11 @@ messagePasswordStrong = "Heslo musí obsahovať aspoň 6 znakov a aspoň 1 písm
 messagePasswordNotIdentical = "Heslá sa nezhodujú"
 messageTermsRequired = "Musíte súhlasiť so spracovaním osobných údajov"
 messageVatIdInvalid = "Neplatné registrační číslo"
+
+[form.merch]
+labelSizes = "Veľkosti"
+labelAuthor = "Autor"
+labelMaterial = "Materiál"
 
 [form.personalDetails]
 labelNewsletterAll = "O všetkých informáciách zo stránky Do práce na bicykli"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -17,7 +17,9 @@ donate = "Darujte"
 more = "Viac"
 
 [global]
+female = "Dámske"
 man = "Muž"
+male = "Pánske"
 woman = "Žena"
 
 [time]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -70,9 +70,11 @@ messageTermsRequired = "Musíte súhlasiť so spracovaním osobných údajov"
 messageVatIdInvalid = "Neplatné registrační číslo"
 
 [form.merch]
+hintNoMerch = "Celá suma tak zostane na neziskové aktivity spoločnosti AutoMat."
 labelSizes = "Veľkosti"
 labelAuthor = "Autor"
 labelMaterial = "Materiál"
+labelNoMerch = "Nechcem košeľu ani nákrčník"
 
 [form.personalDetails]
 labelNewsletterAll = "O všetkých informáciách zo stránky Do práce na bicykli"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -87,6 +87,14 @@ export default defineComponent({
       new URL('../assets/svg/numeric-4-fill.svg', import.meta.url).href
     }`;
     const doneIconImgSrcStepper4 = doneIcon;
+    // Stepper 7 imgs
+    const iconImgSrcStepper7 = `img:${
+      new URL('../assets/svg/numeric-7-outline.svg', import.meta.url).href
+    }`;
+    const activeIconImgSrcStepper7 = `img:${
+      new URL('../assets/svg/numeric-7-fill.svg', import.meta.url).href
+    }`;
+    const doneIconImgSrcStepper7 = doneIcon;
 
     const personalDetails = ref<FormPersonalDetailsFields>({
       firstName: '',
@@ -139,6 +147,9 @@ export default defineComponent({
       iconImgSrcStepper4,
       activeIconImgSrcStepper4,
       doneIconImgSrcStepper4,
+      iconImgSrcStepper7,
+      activeIconImgSrcStepper7,
+      doneIconImgSrcStepper7,
       participation,
       company,
       personalDetails,
@@ -321,9 +332,9 @@ export default defineComponent({
           <q-step
             :name="7"
             :title="$t('register.challenge.titleStepMerch')"
-            :icon="iconImgSrcStepper4"
-            :active-icon="activeIconImgSrcStepper4"
-            :done-icon="doneIconImgSrcStepper4"
+            :icon="iconImgSrcStepper7"
+            :active-icon="activeIconImgSrcStepper7"
+            :done-icon="doneIconImgSrcStepper7"
             :done="step > 7"
             class="bg-white q-mt-lg"
             data-cy="step-7"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -8,6 +8,10 @@
  * individual challenge.
  *
  * @components
+ * - `FormFieldCompanySelect`: Component to render company select widget.
+ * - `FormFieldListMerch`: Component to render list of merch options.
+ * - `FormFieldOptionGroup`: Component to render radio buttons.
+ * - `FormPersonalDetails`: Component to render personal details form.
  * - `LoginRegisterHeader`: Component to render page header.
  *
  * @layout
@@ -24,8 +28,9 @@ import { QForm, QStepper } from 'quasar';
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // components
-import FormFieldOptionGroup from 'src/components/form/FormFieldOptionGroup.vue';
 import FormFieldCompanySelect from 'src/components/form/FormFieldCompanySelect.vue';
+import FormFieldListMerch from 'src/components/form/FormFieldListMerch.vue';
+import FormFieldOptionGroup from 'src/components/form/FormFieldOptionGroup.vue';
 import FormPersonalDetails from 'src/components/form/FormPersonalDetails.vue';
 import LoginRegisterHeader from 'components/global/LoginRegisterHeader.vue';
 
@@ -38,8 +43,9 @@ import type { FormPersonalDetailsFields } from 'src/components/types/Form';
 export default defineComponent({
   name: 'RegisterChallengePage',
   components: {
-    FormFieldOptionGroup,
     FormFieldCompanySelect,
+    FormFieldListMerch,
+    FormFieldOptionGroup,
     FormPersonalDetails,
     LoginRegisterHeader,
   },
@@ -308,6 +314,41 @@ export default defineComponent({
                 :label="$t('navigation.back')"
                 class="q-ml-sm"
                 data-cy="step-4-back"
+              />
+            </q-stepper-navigation>
+          </q-step>
+          <!-- Step: Merch -->
+          <q-step
+            :name="7"
+            :title="$t('register.challenge.titleStepMerch')"
+            :icon="iconImgSrcStepper4"
+            :active-icon="activeIconImgSrcStepper4"
+            :done-icon="doneIconImgSrcStepper4"
+            :done="step > 7"
+            class="bg-white q-mt-lg"
+            data-cy="step-7"
+          >
+            <q-form ref="stepMerchRef">
+              <form-field-list-merch />
+            </q-form>
+            <q-stepper-navigation>
+              <q-btn
+                unelevated
+                rounded
+                color="primary"
+                :label="$t('navigation.continue')"
+                @click="onContinue"
+                data-cy="step-7-continue"
+              />
+              <q-btn
+                unelevated
+                rounded
+                outline
+                @click="onBack"
+                color="primary"
+                :label="$t('navigation.back')"
+                class="q-ml-sm"
+                data-cy="step-7-back"
               />
             </q-stepper-navigation>
           </q-step>

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -40,6 +40,16 @@ const activeIconImgSrcStepper4 = new URL(
   '../../../src/assets/svg/numeric-4-fill.svg',
   cy.config().baseUrl,
 ).href;
+const doneIconImgSrcStepper4 = doneIcon;
+// Stepper 7 imgs
+const iconImgSrcStepper7 = new URL(
+  '../../../src/assets/svg/numeric-7-outline.svg',
+  cy.config().baseUrl,
+).href;
+const activeIconImgSrcStepper7 = new URL(
+  '../../../src/assets/svg/numeric-7-fill.svg',
+  cy.config().baseUrl,
+).href;
 
 describe('Register Challenge page', () => {
   context('desktop', () => {
@@ -148,6 +158,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
       // click when last name is missing
       cy.dataCy('form-firstName-input').type('John');
       cy.dataCy('step-1-continue').should('be.visible').click();
@@ -155,6 +166,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
       // click when terms are not checked
       cy.dataCy('form-firstName-input').type('John');
       cy.dataCy('form-lastName-input').type('Doe');
@@ -163,6 +175,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
 
       // click when form is valid
       cy.dataCy('form-firstName-input').type('John');
@@ -176,6 +189,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-3').find('.q-stepper__step-content').should('be.visible');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
       // click when participation is selected
       cy.dataCy('form-field-option').first().click();
       cy.dataCy('step-3-continue').should('be.visible').click();
@@ -183,6 +197,14 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
+      // click when participation is selected
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      cy.dataCy('step-1').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-4').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
     });
 
     it('changes icons when step changes', () => {
@@ -199,6 +221,9 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-4')
         .find('img')
         .should('have.attr', 'src', iconImgSrcStepper4);
+      cy.dataCy('step-7')
+        .find('img')
+        .should('have.attr', 'src', iconImgSrcStepper7);
       // fill in form data
       cy.dataCy('form-firstName-input').type('John');
       cy.dataCy('form-lastName-input').type('Doe');
@@ -219,6 +244,9 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-4')
         .find('img')
         .should('have.attr', 'src', iconImgSrcStepper4);
+      cy.dataCy('step-7')
+        .find('img')
+        .should('have.attr', 'src', iconImgSrcStepper7);
       // change step
       cy.dataCy('step-2-continue').should('be.visible').click();
       // active icon 3
@@ -234,6 +262,9 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-4')
         .find('img')
         .should('have.attr', 'src', iconImgSrcStepper4);
+      cy.dataCy('step-7')
+        .find('img')
+        .should('have.attr', 'src', iconImgSrcStepper7);
       // select participation option
       cy.dataCy('form-field-option').first().click();
       // change step
@@ -251,9 +282,30 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-4')
         .find('img')
         .should('have.attr', 'src', activeIconImgSrcStepper4);
+      cy.dataCy('step-7')
+        .find('img')
+        .should('have.attr', 'src', iconImgSrcStepper7);
+      // change step
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      // active icon 7
+      cy.dataCy('step-1')
+        .find('img')
+        .should('have.attr', 'src', doneIconImgSrcStepper1);
+      cy.dataCy('step-2')
+        .find('img')
+        .should('have.attr', 'src', doneIconImgSrcStepper2);
+      cy.dataCy('step-3')
+        .find('img')
+        .should('have.attr', 'src', doneIconImgSrcStepper3);
+      cy.dataCy('step-4')
+        .find('img')
+        .should('have.attr', 'src', doneIconImgSrcStepper4);
+      cy.dataCy('step-7')
+        .find('img')
+        .should('have.attr', 'src', activeIconImgSrcStepper7);
     });
 
-    it('allows user to pass through the registration process', () => {
+    it('allows user to pass back and through the registration process', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let i18n;
       cy.window().should('have.property', 'i18n');
@@ -274,6 +326,13 @@ describe('Register Challenge page', () => {
           cy.dataCy('form-field-option').first().click();
           cy.dataCy('step-3-continue').should('be.visible').click();
           cy.dataCy('step-4-continue').should('be.visible').click();
+          cy.dataCy('step-7-continue').should('be.visible');
+          // test back navigation in the stepper
+          cy.dataCy('step-7-back').should('be.visible').click();
+          cy.dataCy('step-4-back').should('be.visible').click();
+          cy.dataCy('step-3-back').should('be.visible').click();
+          cy.dataCy('step-2-back').should('be.visible').click();
+          cy.dataCy('step-1-continue').should('be.visible');
         });
     });
   });

--- a/test/cypress/fixtures/cardMerch.json
+++ b/test/cypress/fixtures/cardMerch.json
@@ -1,0 +1,23 @@
+{
+  "dialogDescription": "Qui veniam labore nisi laborum nisi occaecat et voluptate aute labore nulla. Velit deserunt eiusmod consequat ea qui esse minim officia culpa ea. Labore excepteur elit quis eiusmod velit aute eiusmod ut. Laboris consectetur sunt amet id ut ullamco eu aliquip minim aliqua nostrud dolor veniam exercitation. Consequat magna consectetur elit nostrud do qui amet deserunt excepteur enim id labore consectetur amet. Esse et et nulla. Aliquip occaecat laboris elit mollit proident occaecat enim anim minim. Voluptate excepteur officia cillum id proident ex dolor esse ad duis aliquip esse laboris.",
+  "dialogImages": ["https://picsum.photos/id/70/340/200"],
+  "dialogTitle": "dialogTitle",
+  "image": "https://picsum.photos/id/70/340/200",
+  "label": "Title",
+  "sizes": [
+    {
+      "label": "L",
+      "value": "L"
+    },
+    {
+      "label": "XL",
+      "value": "XL"
+    },
+    {
+      "label": "XXL",
+      "value": "XXL"
+    }
+  ],
+  "author": "author",
+  "material": "material"
+}


### PR DESCRIPTION
Add registration step for selecting merchandise option.
Uses two components:

* `FormFieldListMerch` - displays list of option cards and handles logic
* `FormCardMerch` - displays single option (dialog included)

Includes step number `7` in `RegisterChallengePage`

Next PR: Add customization form for each merchandise option (shows inside the dialog).
