### PR TITLE
src/components/form: add `FormFieldCompanyAddress` to challenge registration

### DIFF
--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -1,0 +1,21 @@
+import FormFieldCompanyAddress from 'components/form/FormFieldCompanyAddress.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<FormFieldCompanyAddress>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'form', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldCompanyAddress, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders component', () => {
+      cy.dataCy('form-field-company-address').should('be.visible');
+    });
+  });
+});

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -15,7 +15,7 @@ describe('<FormFieldCompanyAddress>', () => {
     cy.testLanguageStringsInContext(
       [
         'buttonAddAddress',
-        'buttonAddBranch',
+        'buttonAddSubdivision',
         'hintAddress',
         'labelAddress',
         'titleAddAddress',
@@ -111,7 +111,7 @@ describe('<FormFieldCompanyAddress>', () => {
         .and('have.text', i18n.global.t('navigation.discard'));
       cy.dataCy('dialog-button-submit')
         .should('be.visible')
-        .and('have.text', i18n.global.t('form.company.buttonAddBranch'));
+        .and('have.text', i18n.global.t('form.company.buttonAddSubdivision'));
     });
   });
 

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -1,9 +1,29 @@
+import { colors } from 'quasar';
 import FormFieldCompanyAddress from 'components/form/FormFieldCompanyAddress.vue';
 import { i18n } from '../../boot/i18n';
 
+const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+
 describe('<FormFieldCompanyAddress>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'form', i18n);
+    cy.testLanguageStringsInContext(
+      ['messageNoResult', 'labelAddress'],
+      'form',
+      i18n,
+    );
+    cy.testLanguageStringsInContext(
+      [
+        'buttonAddAddress',
+        'buttonAddBranch',
+        'hintAddress',
+        'labelAddress',
+        'titleAddAddress',
+      ],
+      'form.company',
+      i18n,
+    );
+    cy.testLanguageStringsInContext(['discard'], 'navigation', i18n);
   });
 
   context('desktop', () => {
@@ -15,7 +35,97 @@ describe('<FormFieldCompanyAddress>', () => {
     });
 
     it('renders component', () => {
-      cy.dataCy('form-field-company-address').should('be.visible');
+      cy.dataCy('form-company-address').should('be.visible');
+      // label
+      cy.dataCy('form-company-address-label')
+        .should('be.visible')
+        .and('have.css', 'font-size', '12px')
+        .and('have.css', 'font-weight', '700')
+        .and('have.color', grey10)
+        .and('have.text', i18n.global.t('form.company.labelAddress'));
+      // input
+      cy.dataCy('form-company-address').find('.q-select').should('be.visible');
+      // hint
+      cy.dataCy('form-company-address')
+        .find('.q-field__messages')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.hintAddress'));
+      cy.dataCy('button-add-address').should('be.visible');
+    });
+
+    it('allows user to select option', () => {
+      cy.dataCy('form-company-address').find('.q-select').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
+      // test selected option
+      cy.dataCy('form-company-address')
+        .find('input')
+        .invoke('val')
+        .should('eq', 'Address 1');
+    });
+
+    it('validates address field correctly', () => {
+      cy.dataCy('form-company-address').find('input').focus();
+      cy.dataCy('form-company-address').find('input').blur();
+      cy.dataCy('form-company-address')
+        .find('.q-field__messages')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelAddress'),
+          }),
+        );
+      cy.dataCy('form-company-address').find('input').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
+      cy.dataCy('form-company-address')
+        .find('.q-field__messages')
+        .should(
+          'not.contain',
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelAddress'),
+          }),
+        );
+    });
+
+    it('renders dialog for adding a new address', () => {
+      cy.dataCy('button-add-address').click();
+      cy.dataCy('dialog-add-address').should('be.visible');
+      cy.dataCy('dialog-add-address')
+        .find('h3')
+        .should('be.visible')
+        .and('have.css', 'font-size', '20px')
+        .and('have.css', 'font-weight', '500')
+        .and('contain', i18n.global.t('form.company.titleAddAddress'));
+      cy.dataCy('dialog-button-cancel')
+        .should('be.visible')
+        .and('have.text', i18n.global.t('navigation.discard'));
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('have.text', i18n.global.t('form.company.buttonAddBranch'));
+    });
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldCompanyAddress, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    it('renders input and button in a stacked layout', () => {
+      cy.testElementPercentageWidth(cy.dataCy('col-input'), 100);
+      cy.testElementPercentageWidth(cy.dataCy('col-button'), 100);
     });
   });
 });

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -35,7 +35,7 @@ import FormFieldTextRequired from 'src/components/global/FormFieldTextRequired.v
 import FormFieldVatId from 'src/components/form/FormFieldVatId.vue';
 
 // types
-import type { FormAddCompanyFields } from 'src/components/types/Form';
+import type { FormCompanyFields } from 'src/components/types/Form';
 
 export default defineComponent({
   name: 'FormAddCompany',
@@ -45,7 +45,7 @@ export default defineComponent({
   },
   props: {
     formValues: {
-      type: Object as () => FormAddCompanyFields,
+      type: Object as () => FormCompanyFields,
       required: true,
     },
     variant: {

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -147,6 +147,7 @@ export default defineComponent({
                 fieldName: $t('form.labelAddress'),
               }),
           ]"
+          data-cy="form-company-address-input"
           @update:model-value="onUpdate"
         >
           <!-- Item: No option -->

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -121,14 +121,14 @@ export default defineComponent({
 
 <template>
   <div data-cy="form-company-address">
-    <label
-      for="form-company-address"
-      class="text-caption text-bold text-grey-10"
-      data-cy="form-company-address-label"
-    >
-      {{ $t('form.company.labelAddress') }}
-    </label>
-    <div class="row q-mt-sm q-col-gutter-md">
+    <div class="row q-mt-sm q-col-gutter-sm">
+      <label
+        for="form-company-address"
+        class="col-12 text-caption text-bold text-grey-10"
+        data-cy="form-company-address-label"
+      >
+        {{ $t('form.company.labelAddress') }}
+      </label>
       <div class="col-12 col-sm" data-cy="col-input">
         <!-- Input: Autocomplete -->
         <q-select

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -211,7 +211,7 @@ export default defineComponent({
             data-cy="dialog-button-submit"
             @click="onSubmit"
           >
-            {{ $t('form.company.buttonAddBranch') }}
+            {{ $t('form.company.buttonAddSubdivision') }}
           </q-btn>
         </div>
       </div>

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -1,0 +1,137 @@
+<script lang="ts">
+/**
+ * FormFieldCompanyAddress Component
+ *
+ * The `FormFieldCompanyAddress`
+ *
+ * @description * Use this component to render address selection field.
+ *
+ * Note: This component is commonly used in `RegisterChallengePage`.
+ *
+ * @props
+ * - `modelValue` (object, required): The object representing address.
+ *   It should be of type `FormAddressType`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @components
+ * - `DialogDefault`: Component to render a dialog window.
+ * - `FormAddAddress`: Component to render address form fields.
+ *
+ * @example
+ * <form-field-company-address />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6485%3A29568&mode=dev)
+ */
+
+// libraries
+import { defineComponent, nextTick, ref } from 'vue';
+
+import type { FormOption } from 'src/components/types/Form';
+
+export default defineComponent({
+  name: 'FormFieldCompanyAddress',
+  emits: ['update:formValue'],
+  props: {
+    companyId: {
+      type: String,
+    },
+  },
+  setup(props, { emit }) {
+    const addressValue = ref(null);
+    const isDialogOpen = ref<boolean>(false);
+
+    const onUpdate = (): void => {
+      // wait for next tick to emit the value after update
+      nextTick((): void => {
+        emit('update:formValue', addressValue.value);
+      });
+    };
+
+    const options: FormOption[] = [
+      {
+        label: 'Address 1',
+        value: {
+          street: 'Street',
+          streetNumber: '123',
+          city: 'City',
+          zip: '1234',
+          referenceCity: 'Ref City',
+          department: 'Department',
+        },
+      },
+      {
+        label: 'Address 2',
+        value: {
+          street: 'Street',
+          streetNumber: '123',
+          city: 'City',
+          zip: '1234',
+          referenceCity: 'Ref City',
+          department: 'Department',
+        },
+      },
+    ];
+
+    return {
+      addressValue,
+      isDialogOpen,
+      options,
+      onUpdate,
+    };
+  },
+});
+</script>
+
+<template>
+  <div data-cy="form-field-company-address">
+    <label
+      for="form-company-address"
+      class="text-body1 text-bold text-black q-mt-none q-mb-md"
+    >
+      {{ $t('form.company.labelAddress') }}
+    </label>
+    <div class="row">
+      <div class="col-12 col-sm" data-cy="col-input">
+        <!-- Input: Autocomplete -->
+        <q-select
+          id="form-company-address"
+          outlined
+          v-model="addressValue"
+          :options="options"
+          @update:model-value="onUpdate"
+        >
+          <!-- Item: No option -->
+          <template v-slot:no-option>
+            <q-item>
+              <q-item-section class="text-grey">
+                {{ $t('form.messageNoResult') }}
+              </q-item-section>
+            </q-item>
+          </template>
+        </q-select>
+      </div>
+      <div
+        class="col-12 col-sm-auto flex items-start justify-end q-pt-sm q-pl-md"
+        style="margin-top: 2px"
+        data-cy="col-button"
+      >
+        <!-- Button: Add company -->
+        <q-btn
+          flat
+          rounded
+          icon="mdi-plus"
+          color="primary"
+          @click.prevent="isDialogOpen = true"
+          data-cy="button-add-company"
+        >
+          <!-- Label -->
+          <span class="inline-block q-pl-xs">
+            {{ $t('form.company.buttonAddAddress') }}
+          </span>
+        </q-btn>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -17,7 +17,7 @@
  *
  * @components
  * - `DialogDefault`: Component to render a dialog window.
- * - `FormAddAddress`: Component to render address form fields.
+ * - `FormAddress`: Component to render address form fields.
  *
  * @example
  * <form-field-company-address />
@@ -28,16 +28,23 @@
 // libraries
 import { defineComponent, nextTick, ref } from 'vue';
 
+// components
+import DialogDefault from 'src/components/global/DialogDefault.vue';
+
+// types
 import type { FormOption } from 'src/components/types/Form';
 
 export default defineComponent({
   name: 'FormFieldCompanyAddress',
-  emits: ['update:formValue'],
+  components: {
+    DialogDefault,
+  },
   props: {
     companyId: {
       type: String,
     },
   },
+  emits: ['update:formValue'],
   setup(props, { emit }) {
     const addressValue = ref(null);
     const isDialogOpen = ref<boolean>(false);
@@ -74,10 +81,21 @@ export default defineComponent({
       },
     ];
 
+    const onClose = (): void => {
+      isDialogOpen.value = false;
+    };
+
+    const onSubmit = async (): Promise<void> => {
+      // noop
+      isDialogOpen.value = false;
+    };
+
     return {
       addressValue,
       isDialogOpen,
       options,
+      onClose,
+      onSubmit,
       onUpdate,
     };
   },
@@ -92,13 +110,14 @@ export default defineComponent({
     >
       {{ $t('form.company.labelAddress') }}
     </label>
-    <div class="row">
+    <div class="row q-mt-sm">
       <div class="col-12 col-sm" data-cy="col-input">
         <!-- Input: Autocomplete -->
         <q-select
-          id="form-company-address"
           outlined
+          id="form-company-address"
           v-model="addressValue"
+          :hint="$t('form.company.hintAddress')"
           :options="options"
           @update:model-value="onUpdate"
         >
@@ -134,4 +153,43 @@ export default defineComponent({
       </div>
     </div>
   </div>
+  <!-- Dialog: Add address -->
+  <dialog-default v-model="isDialogOpen" data-cy="dialog-add-address">
+    <template #title>
+      {{ $t('form.company.titleAddAddress') }}
+    </template>
+    <template #content>
+      <q-form ref="formRef">
+        <!-- <form-address
+          :form-values="addressNew"
+          variant="simple"
+          @update:form-values="addressNew = $event"
+        ></form-address> -->
+      </q-form>
+      <!-- Action buttons -->
+      <div class="flex justify-end q-mt-sm">
+        <div class="flex gap-8">
+          <q-btn
+            rounded
+            unelevated
+            outline
+            color="primary"
+            data-cy="dialog-button-cancel"
+            @click="onClose"
+          >
+            {{ $t('navigation.discard') }}
+          </q-btn>
+          <q-btn
+            rounded
+            unelevated
+            color="primary"
+            data-cy="dialog-button-submit"
+            @click="onSubmit"
+          >
+            {{ $t('form.company.buttonAddBranch') }}
+          </q-btn>
+        </div>
+      </div>
+    </template>
+  </dialog-default>
 </template>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -38,7 +38,7 @@ import FormAddCompany from 'src/components/form/FormAddCompany.vue';
 import { useValidation } from 'src/composables/useValidation';
 
 // types
-import type { FormAddCompanyFields } from 'src/components/types/Form';
+import type { FormCompanyFields } from 'src/components/types/Form';
 
 // constants
 const stringOptions: string[] = ['Company 1', 'Company 2'];
@@ -67,7 +67,7 @@ export default defineComponent({
       },
     });
 
-    const companyNew: FormAddCompanyFields = {
+    const companyNew: FormCompanyFields = {
       name: '',
       vatId: '',
     };

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -10,14 +10,18 @@ export type FormPersonalDetailsFields = {
 
 export type FormOption = {
   label: string;
-  value: string;
+  value: string | FormCompanyAddressFields;
   icon?: string;
   description?: string;
 };
 
-export type FormAddCompanyFields = {
+export type FormCompanyFields = {
   name: string;
   vatId: string;
+  address?: FormCompanyAddressFields[];
+};
+
+export type FormCompanyAddressFields = {
   street?: string;
   streetNumber?: string;
   city?: string;

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -63,6 +63,7 @@ linkTerms = "Zásad o ochraně a zpracování údajů"
 messageEmailInvalid = "Prosím vyplňte platný e-mail"
 messageFieldRequired = "Pole {fieldName} je povinné"
 messageNoCompany = "Žádnou firmu jsme nenašli. Zkuste hledat znovu, nebo vytvořte novou firmu."
+messageNoResult = "Nenalezeno"
 messageOptionRequired = "Prosím, zvolte jednu z možností"
 messagePhoneInvalid = "Prosím vyplňte platné telefonní číslo"
 messagePasswordStrong = "Heslo musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
@@ -95,9 +96,11 @@ titleParticipation = "S kým se budete výzvy účastnit?"
 hintPariticipation = "I pokud plánujete soutěžit sám/sama, zvolte skupinu, z které by se k vám případně mohl někdo pak přidat do týmu."
 
 [form.company]
+labelAddress = "Adresa firmy či pobočky"
 labelCompany = "Název firmy"
 titleAddCompany = "Přidat firmu"
 buttonAddCompany = "Přidat firmu"
+buttonAddAddress = "Přidat novou"
 
 [index]
 title = "Domov"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -43,6 +43,7 @@ selected = "Vybráno"
 [form]
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
 hintNickname = "Zobrazí se ve veřejných výsledcích místo vašeho jména"
+labelAddress = "Adresa"
 labelCompany = "Firma, pro kterou chcete být koordinátorem"
 labelCompanyShort = "Firma"
 labelEmail = "E-mail"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -98,7 +98,7 @@ hintPariticipation = "I pokud plánujete soutěžit sám/sama, zvolte skupinu, z
 
 [form.company]
 buttonAddAddress = "Přidat novou"
-buttonAddBranch = "Přidat pobočku"
+buttonAddSubdivision = "Přidat pobočku"
 buttonAddCompany = "Přidat firmu"
 hintAddress = "Na tuto adresu doručíme startovní balíček pro váš tým."
 labelAddress = "Adresa firmy či pobočky"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -96,11 +96,14 @@ titleParticipation = "S kým se budete výzvy účastnit?"
 hintPariticipation = "I pokud plánujete soutěžit sám/sama, zvolte skupinu, z které by se k vám případně mohl někdo pak přidat do týmu."
 
 [form.company]
+buttonAddAddress = "Přidat novou"
+buttonAddBranch = "Přidat pobočku"
+buttonAddCompany = "Přidat firmu"
+hintAddress = "Na tuto adresu doručíme startovní balíček pro váš tým."
 labelAddress = "Adresa firmy či pobočky"
 labelCompany = "Název firmy"
+titleAddAddress = "Přidat vaši pobočku"
 titleAddCompany = "Přidat firmu"
-buttonAddCompany = "Přidat firmu"
-buttonAddAddress = "Přidat novou"
 
 [index]
 title = "Domov"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -98,13 +98,13 @@ hintPariticipation = "If you plan to compete alone, choose a group from which so
 
 [form.company]
 buttonAddAddress = "Add new"
-buttonAddBranch = "Add branch"
+buttonAddSubdivision = "Add subdivision"
 buttonAddCompany = "Add company"
 hintAddress = "We will deliver a starter pack for your team to this address."
-labelAddress = "Company or branch address"
+labelAddress = "Company or subdivision address"
 labelCompany = "Company name"
 titleAddCompany = "Add company"
-titleAddAddress = "Add your branch"
+titleAddAddress = "Add your subdivision"
 
 [index]
 title = "Home"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -96,11 +96,14 @@ titleParticipation = "With whom will you participate in the challenge?"
 hintPariticipation = "If you plan to compete alone, choose a group from which someone could possibly join your team later."
 
 [form.company]
+buttonAddAddress = "Add new"
+buttonAddBranch = "Add branch"
+buttonAddCompany = "Add company"
+hintAddress = "We will deliver a starter pack for your team to this address."
 labelAddress = "Company or branch address"
 labelCompany = "Company name"
 titleAddCompany = "Add company"
-buttonAddCompany = "Add company"
-buttonAddAddress = "Add new"
+titleAddAddress = "Add your branch"
 
 [index]
 title = "Home"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -43,6 +43,7 @@ selected = "Selected"
 [form]
 hintPassword = "It must contain at least 6 characters and at least 1 letter."
 hintNickname = "It will appear in the public results instead of your name"
+labelAddress = "Address"
 labelCompany = "The company you want to be a coordinator for"
 labelCompanyShort = "Company"
 labelEmail = "E-mail"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -63,6 +63,7 @@ linkTerms = "Data Protection and Processing Policy"
 messageEmailInvalid = "Please fill in a valid email"
 messageFieldRequired = "{fieldName} is required"
 messageNoCompany = "We couldn't find any company. Try searching again or create a new company."
+messageNoResult = "Not found"
 messageOptionRequired = "Please select an option"
 messagePhoneInvalid = "Please fill in a valid phone number"
 messagePasswordStrong = "Password must contain at least 6 characters and at least 1 letter."
@@ -95,9 +96,11 @@ titleParticipation = "With whom will you participate in the challenge?"
 hintPariticipation = "If you plan to compete alone, choose a group from which someone could possibly join your team later."
 
 [form.company]
+labelAddress = "Company or branch address"
 labelCompany = "Company name"
 titleAddCompany = "Add company"
 buttonAddCompany = "Add company"
+buttonAddAddress = "Add new"
 
 [index]
 title = "Home"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -96,11 +96,14 @@ titleParticipation = "S kým sa zúčastníte tejto výzvy?"
 hintPariticipation = "Aj keď plánujete súťažiť sami, vyberte si skupinu, z ktorej by sa niekto mohol neskôr pridať k vášmu tímu."
 
 [form.company]
+buttonAddAddress = "Pridať novú"
+buttonAddBranch = "Pridať pobočku"
+buttonAddCompany = "Pridať spoločnosť"
+hintAddress = "Na túto adresu vám doručíme štartovací balíček pre váš tím."
 labelAddress = "Adresa společnosti nebo pobočky"
 labelCompany = "Názov spoločnosti"
 titleAddCompany = "Pridať spoločnosť"
-buttonAddCompany = "Pridať spoločnosť"
-buttonAddAddress = "Pridať novú"
+titleAddAddress = "Pridajte svoju pobočku"
 
 [index]
 title = "Domovská stránka"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -63,6 +63,7 @@ linkTerms = "Zásad ochrany a spracovania údajov"
 messageEmailInvalid = "Vyplňte prosím platný e-mail"
 messageFieldRequired = "Pole {fieldName} je povinné"
 messageNoCompany = "Nenašli sme žiadnu spoločnosť. Skúste hľadať znova alebo vytvorte novú spoločnosť."
+messageNoResult = "Nenájdené"
 messageOptionRequired = "Vyberte jednu z možností"
 messagePhoneInvalid = "Vyplňte platné telefónne číslo"
 messagePasswordStrong = "Heslo musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
@@ -95,9 +96,11 @@ titleParticipation = "S kým sa zúčastníte tejto výzvy?"
 hintPariticipation = "Aj keď plánujete súťažiť sami, vyberte si skupinu, z ktorej by sa niekto mohol neskôr pridať k vášmu tímu."
 
 [form.company]
+labelAddress = "Adresa společnosti nebo pobočky"
 labelCompany = "Názov spoločnosti"
 titleAddCompany = "Pridať spoločnosť"
 buttonAddCompany = "Pridať spoločnosť"
+buttonAddAddress = "Pridať novú"
 
 [index]
 title = "Domovská stránka"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -43,6 +43,7 @@ selected = "Vybrané"
 [form]
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 hintNickname = "Zobrazí sa vo verejných výsledkoch namiesto vášho mena"
+labelAddress = "Adresa"
 labelCompany = "Spoločnosť, pre ktorú chcete byť koordinátorom"
 labelCompanyShort = "Spoločnosť"
 labelEmail = "E-mail"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -98,7 +98,7 @@ hintPariticipation = "Aj keď plánujete súťažiť sami, vyberte si skupinu, z
 
 [form.company]
 buttonAddAddress = "Pridať novú"
-buttonAddBranch = "Pridať pobočku"
+buttonAddSubdivision = "Pridať pobočku"
 buttonAddCompany = "Pridať spoločnosť"
 hintAddress = "Na túto adresu vám doručíme štartovací balíček pre váš tím."
 labelAddress = "Adresa společnosti nebo pobočky"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -28,6 +28,7 @@ import { QForm, QStepper } from 'quasar';
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // components
+import FormFieldCompanyAddress from 'src/components/form/FormFieldCompanyAddress.vue';
 import FormFieldCompanySelect from 'src/components/form/FormFieldCompanySelect.vue';
 import FormFieldListMerch from 'src/components/form/FormFieldListMerch.vue';
 import FormFieldOptionGroup from 'src/components/form/FormFieldOptionGroup.vue';
@@ -38,11 +39,15 @@ import LoginRegisterHeader from 'components/global/LoginRegisterHeader.vue';
 import { useStepperValidation } from 'src/composables/useStepperValidation';
 
 // types
-import type { FormPersonalDetailsFields } from 'src/components/types/Form';
+import type {
+  FormPersonalDetailsFields,
+  FormCompanyAddressFields,
+} from 'src/components/types/Form';
 
 export default defineComponent({
   name: 'RegisterChallengePage',
   components: {
+    FormFieldCompanyAddress,
     FormFieldCompanySelect,
     FormFieldListMerch,
     FormFieldOptionGroup,
@@ -108,7 +113,12 @@ export default defineComponent({
 
     const participation = ref<string>('');
 
-    const company = ref<string>('');
+    const companyId = ref<string>('');
+    const companyAddress = ref<FormCompanyAddressFields | null>(null);
+
+    const onUpdateAddress = (val: FormCompanyAddressFields) => {
+      companyAddress.value = val;
+    };
 
     const step = ref(1);
     const stepperRef = ref<typeof QStepper | null>(null);
@@ -151,10 +161,12 @@ export default defineComponent({
       activeIconImgSrcStepper7,
       doneIconImgSrcStepper7,
       participation,
-      company,
+      companyAddress,
+      companyId,
       personalDetails,
       onBack,
       onContinue,
+      onUpdateAddress,
     };
   },
 });
@@ -305,7 +317,10 @@ export default defineComponent({
             data-cy="step-4"
           >
             <q-form ref="stepCompanyRef">
-              <form-field-company-select v-model="company" />
+              <form-field-company-select v-model="companyId" />
+              <form-field-company-address
+                @update:form-value="onUpdateAddress"
+              />
             </q-form>
             <q-stepper-navigation>
               <q-btn

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -198,7 +198,26 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
       cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
-      // click when participation is selected
+      // click when address is not selected
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      cy.dataCy('step-1').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-3').find('.q-stepper__step-content').should('not.exist');
+      cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
+      cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
+      // select company and address
+      cy.dataCy('form-company-select-option-group')
+        .find('.q-radio__label')
+        .first()
+        .click();
+      cy.dataCy('form-company-address-input').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
+      // click when address is selected
       cy.dataCy('step-4-continue').should('be.visible').click();
       cy.dataCy('step-1').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-2').find('.q-stepper__step-content').should('not.exist');
@@ -285,6 +304,18 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-7')
         .find('img')
         .should('have.attr', 'src', iconImgSrcStepper7);
+      // select company and address
+      cy.dataCy('form-company-select-option-group')
+        .find('.q-radio__label')
+        .first()
+        .click();
+      cy.dataCy('form-company-address-input').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
       // change step
       cy.dataCy('step-4-continue').should('be.visible').click();
       // active icon 7
@@ -325,6 +356,18 @@ describe('Register Challenge page', () => {
           // select participation option
           cy.dataCy('form-field-option').first().click();
           cy.dataCy('step-3-continue').should('be.visible').click();
+          // select company and address
+          cy.dataCy('form-company-select-option-group')
+            .find('.q-radio__label')
+            .first()
+            .click();
+          cy.dataCy('form-company-address-input').click();
+          // select option
+          cy.get('.q-menu')
+            .should('be.visible')
+            .within(() => {
+              cy.get('.q-item').first().click();
+            });
           cy.dataCy('step-4-continue').should('be.visible').click();
           cy.dataCy('step-7-continue').should('be.visible');
           // test back navigation in the stepper


### PR DESCRIPTION
Add `FormFieldCompanyAddress` component (similar to `FormFieldCompany` but without select lookup).

* Add translations
* Add tests

Rename type `FormAddCompanyFields` to `FormCompanyFields` as it should label general Company model (within forms) not only the case of adding a new company.