### PR TITLE
components/form: add form for new team dialog

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -50,25 +50,23 @@ describe('<FormFieldSelectTable>', () => {
 
     it('renders necessary elements', () => {
       // input label
-      cy.dataCy('form-company-select-query')
+      cy.dataCy('form-select-table-query')
         .should('be.visible')
         .and('contain', i18n.global.t('form.company.labelCompany'));
       // input
-      cy.dataCy('form-company-select-search')
-        .find('input')
-        .should('be.visible');
-      cy.dataCy('form-company-select-search')
+      cy.dataCy('form-select-table-search').find('input').should('be.visible');
+      cy.dataCy('form-select-table-search')
         .find('i')
         .invoke('height')
         .should('eq', 24);
-      cy.dataCy('form-company-select-search')
+      cy.dataCy('form-select-table-search')
         .find('i')
         .invoke('width')
         .should('eq', 24);
       // options
-      cy.dataCy('form-company-select-option-group').should('be.visible');
+      cy.dataCy('form-select-table-option-group').should('be.visible');
       // add new button
-      cy.dataCy('form-company-select-button').should('be.visible');
+      cy.dataCy('form-select-table-button').should('be.visible');
       cy.dataCy('button-add-option').should('be.visible');
       cy.dataCy('button-add-option')
         .find('i')
@@ -82,22 +80,22 @@ describe('<FormFieldSelectTable>', () => {
 
     it('allows to search through options', () => {
       // search for option
-      cy.dataCy('form-company-select-search').find('input').focus();
-      cy.dataCy('form-company-select-search').find('input').type('2');
+      cy.dataCy('form-select-table-search').find('input').focus();
+      cy.dataCy('form-select-table-search').find('input').type('2');
       // show only one option
-      cy.dataCy('form-company-select-option-group')
+      cy.dataCy('form-select-table-option-group')
         .find('.q-radio__label')
         .should('have.length', 1);
-      cy.dataCy('form-company-select-search').find('input').clear();
-      cy.dataCy('form-company-select-search').find('input').blur();
-      cy.dataCy('form-company-select-option-group')
+      cy.dataCy('form-select-table-search').find('input').clear();
+      cy.dataCy('form-select-table-search').find('input').blur();
+      cy.dataCy('form-select-table-option-group')
         .find('.q-radio__label')
         .should('have.length', 7);
     });
 
     it('validates company field correctly', () => {
-      cy.dataCy('form-company-select-search').find('input').focus();
-      cy.dataCy('form-company-select-search').find('input').blur();
+      cy.dataCy('form-select-table-search').find('input').focus();
+      cy.dataCy('form-select-table-search').find('input').blur();
       cy.dataCy('form-select-table-field')
         .find('.q-field__messages')
         .should('be.visible')
@@ -161,7 +159,7 @@ describe('<FormFieldSelectTable>', () => {
     });
 
     it('shows selected option', () => {
-      cy.dataCy('form-company-select-option-group')
+      cy.dataCy('form-select-table-option-group')
         .find('.q-radio__inner')
         .first()
         .should('have.class', 'text-primary');

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -165,4 +165,110 @@ describe('<FormFieldSelectTable>', () => {
         .should('have.class', 'text-primary');
     });
   });
+
+  context('team desktop', () => {
+    beforeEach(() => {
+      cy.fixture('teamOptions').then((options) => {
+        cy.mount(FormFieldSelectTable, {
+          props: {
+            options: options,
+            variant: 'team',
+            label: i18n.global.t('form.team.labelTeam'),
+            labelButton: i18n.global.t('form.team.buttonAddTeam'),
+            labelButtonDialog: i18n.global.t('form.team.buttonAddTeam'),
+            titleDialog: i18n.global.t('form.team.titleAddTeam'),
+          },
+        });
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders HTML elements', () => {
+      // input label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.team.labelTeam'));
+      // input
+      cy.dataCy('form-select-table-search').find('input').should('be.visible');
+      cy.dataCy('form-select-table-search')
+        .find('i')
+        .invoke('height')
+        .should('eq', 24);
+      cy.dataCy('form-select-table-search')
+        .find('i')
+        .invoke('width')
+        .should('eq', 24);
+      // options
+      cy.dataCy('form-select-table-option-group').should('be.visible');
+      // add new button
+      cy.dataCy('form-select-table-button').should('be.visible');
+      cy.dataCy('button-add-option').should('be.visible');
+      cy.dataCy('button-add-option')
+        .find('i')
+        .invoke('height')
+        .should('be.gt', 23);
+      cy.dataCy('button-add-option')
+        .find('i')
+        .invoke('width')
+        .should('be.gt', 23);
+    });
+
+    it('allows to search through options', () => {
+      // search for option
+      cy.dataCy('form-select-table-search').find('input').focus();
+      cy.dataCy('form-select-table-search').find('input').type('z');
+      // show only one option
+      cy.dataCy('form-select-table-option-group')
+        .find('.q-radio__label')
+        .should('have.length', 1);
+      cy.dataCy('form-select-table-search').find('input').clear();
+      cy.dataCy('form-select-table-search').find('input').blur();
+      cy.dataCy('form-select-table-option-group')
+        .find('.q-radio__label')
+        .should('have.length', 2);
+    });
+
+    it('validates company field correctly', () => {
+      cy.dataCy('form-select-table-search').find('input').focus();
+      cy.dataCy('form-select-table-search').find('input').blur();
+      cy.dataCy('form-select-table-field')
+        .find('.q-field__messages')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.messageOptionRequired'));
+    });
+
+    it('renders dialog when for adding a new company', () => {
+      cy.dataCy('button-add-option').click();
+      cy.dataCy('dialog-add-option').should('be.visible');
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('have.css', 'font-size', '20px')
+        .and('have.css', 'font-weight', '500')
+        .and('contain', i18n.global.t('form.team.titleAddTeam'));
+      // scroll to bottom
+      cy.dataCy('dialog-body').scrollTo('bottom', {
+        ensureScrollable: false,
+      });
+      // action buttons are visible
+      cy.dataCy('dialog-button-cancel')
+        .should('be.visible')
+        .and('have.text', i18n.global.t('navigation.discard'));
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('have.text', i18n.global.t('form.team.buttonAddTeam'));
+      // submit empty
+      cy.dataCy('dialog-button-submit').click();
+      cy.dataCy('dialog-add-option').should('be.visible');
+      // scroll to top
+      cy.dataCy('dialog-body').scrollTo('top', {
+        ensureScrollable: false,
+      });
+      // fill in form
+      cy.dataCy('form-add-team-name').find('input').type('Team AutoMat');
+      // submit
+      cy.dataCy('dialog-button-submit').click();
+      cy.dataCy('dialog-add-option').should('not.exist');
+    });
+  });
 });

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -20,7 +20,13 @@ describe('<FormFieldSelectTable>', () => {
       i18n,
     );
     cy.testLanguageStringsInContext(
-      ['buttonAddTeam', 'labelTeam', 'titleAddTeam'],
+      [
+        'buttonAddTeam',
+        'labelTeam',
+        'labelTeamName',
+        'titleAddTeam',
+        'textTeam',
+      ],
       'form.team',
       i18n,
     );

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -10,12 +10,12 @@
  * `FormFieldSelectTable`.
  *
  * @props
- * - `modelValue` (Object, required): The object representing the form state.
+ * - `formValues` (Object, required): The object representing the form state.
  * - `variant` (String as 'default', 'simple'): The variant of the form.
  *   `simple` only shows `name` and `vatId` fields.
  *
  * @events
- * - `update:modelValue`: Emitted as a part of v-model structure.
+ * - `update:formValues`: Emitted as a part of v-model structure.
  *
  * @components
  * - `FormFieldTextRequired`: Component to render required field.

--- a/src/components/form/FormAddTeam.vue
+++ b/src/components/form/FormAddTeam.vue
@@ -1,0 +1,74 @@
+<script lang="ts">
+/**
+ * FormAddTeam Component
+ *
+ * @description * Use this component to render form for registering a new
+ * team.
+ *
+ * Note: This component is commonly used in `FormFieldSelectTable`.
+ *
+ * @props
+ * - `formValues` (Object, required): The object representing the form state.
+ *
+ * @events
+ * - `update:formValues`: Emitted as a part of v-model structure.
+ *
+ * @components
+ * - `FormFieldTextRequired`: Component to render required field.
+ *
+ * @example
+ * <form-add-team />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6691%3A28263&mode=dev)
+ */
+
+import { defineComponent, nextTick, ref } from 'vue';
+
+// components
+import FormFieldTextRequired from '../global/FormFieldTextRequired.vue';
+
+// types
+import type { FormTeamFields } from '../types/Form';
+
+export default defineComponent({
+  name: 'FormAddTeam',
+  components: {
+    FormFieldTextRequired,
+  },
+  props: {
+    formValues: {
+      type: Object as () => FormTeamFields,
+      required: true,
+    },
+  },
+  emits: ['update:formValues'],
+  setup(props, { emit }) {
+    const team = ref(props.formValues);
+
+    const onUpdate = (): void => {
+      // wait for next tick to emit the value after update
+      nextTick((): void => {
+        emit('update:formValues', team.value);
+      });
+    };
+
+    return {
+      team,
+      onUpdate,
+    };
+  },
+});
+</script>
+
+<template>
+  <div>
+    <form-field-text-required
+      v-model="team.name"
+      name="name"
+      :label="$t('form.team.labelTeamName')"
+      :label-short="$t('form.team.labelTeam')"
+      @update:model-value="onUpdate"
+    />
+    <div v-html="$t('form.team.textTeam')" class="q-mt-sm" />
+  </div>
+</template>

--- a/src/components/form/FormAddTeam.vue
+++ b/src/components/form/FormAddTeam.vue
@@ -68,6 +68,7 @@ export default defineComponent({
       :label="$t('form.team.labelTeamName')"
       :label-short="$t('form.team.labelTeam')"
       @update:model-value="onUpdate"
+      data-cy="form-add-team-name"
     />
     <div v-html="$t('form.team.textTeam')" class="q-mt-sm" />
   </div>

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -197,7 +197,7 @@ export default defineComponent({
     <label
       for="form-company"
       class="text-grey-10 text-caption text-bold"
-      data-cy="form-company-select-query"
+      data-cy="form-select-table-query"
     >
       {{ label }}
     </label>
@@ -218,17 +218,17 @@ export default defineComponent({
         bordered
         class="full-width q-mt-sm"
         :style="{ 'border-radius': borderRadius }"
-        data-cy="form-company-select-card"
+        data-cy="form-select-table-card"
       >
         <!-- Search field -->
-        <q-card-section class="q-pa-sm" data-cy="form-company-select-search">
+        <q-card-section class="q-pa-sm" data-cy="form-select-table-search">
           <!-- Input -->
           <q-input
             dense
             outlined
             v-model="query"
             icon
-            id="form-company-select-query"
+            id="form-select-table-query"
           >
             <template v-slot:prepend>
               <q-icon name="search" class="q-pl-sm" />
@@ -238,14 +238,14 @@ export default defineComponent({
         <!-- Separator -->
         <q-separator />
         <!-- Options list -->
-        <q-card-section class="q-pa-xs" data-cy="form-company-select-options">
+        <q-card-section class="q-pa-xs" data-cy="form-select-table-options">
           <q-scroll-area style="height: 250px">
             <q-option-group
               v-model="inputValue"
               :options="filteredOptions"
               color="primary"
               class="q-pr-sm"
-              data-cy="form-company-select-option-group"
+              data-cy="form-select-table-option-group"
             >
               <!-- Slot: Option label -->
               <template v-slot:label="opt">
@@ -283,7 +283,7 @@ export default defineComponent({
         <!-- Button: Add company -->
         <q-card-section
           class="full-width flex items-center justify-center q-pa-sm"
-          data-cy="form-company-select-button"
+          data-cy="form-select-table-button"
         >
           <!-- Button: Add company -->
           <q-btn

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -43,6 +43,7 @@ import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 // components
 import DialogDefault from '../global/DialogDefault.vue';
 import FormAddCompany from '../form/FormAddCompany.vue';
+import FormAddTeam from '../form/FormAddTeam.vue';
 
 // composables
 import { useValidation } from '../../composables/useValidation';
@@ -52,6 +53,7 @@ import {
   FormCompanyFields,
   FormOption,
   FormSelectTableOption,
+  FormTeamFields,
 } from '../types/Form';
 
 export default defineComponent({
@@ -59,6 +61,7 @@ export default defineComponent({
   components: {
     DialogDefault,
     FormAddCompany,
+    FormAddTeam,
   },
   props: {
     modelValue: {
@@ -108,6 +111,9 @@ export default defineComponent({
           department: '',
         },
       ],
+    });
+    const teamNew = ref<FormTeamFields>({
+      name: '',
     });
 
     /**
@@ -176,6 +182,7 @@ export default defineComponent({
       inputValue,
       isDialogOpen,
       query,
+      teamNew,
       isFilled,
       onClose,
       onSubmit,
@@ -306,6 +313,12 @@ export default defineComponent({
                 :form-values="companyNew"
                 @update:form-values="companyNew = $event"
               ></form-add-company>
+              <form-add-team
+                v-if="variant === 'team'"
+                class="q-mb-lg"
+                :form-values="teamNew"
+                @update:form-values="teamNew = $event"
+              ></form-add-team>
             </q-form>
             <!-- Action buttons -->
             <div class="flex justify-end q-mt-sm">

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -37,6 +37,12 @@ export type FormCompanyAddressFields = {
   department: string;
 };
 
+export type FormTeamFields = {
+  name: string;
+  members?: number;
+  maxMembers?: number;
+};
+
 export type FormCardMerchType = {
   author: string;
   dialogDescription: string;

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -129,6 +129,7 @@ buttonAddTeam = "Přidat tým"
 labelMembers = "člen | členů"
 labelTeam = "Název týmu"
 labelTeamName = "Název vašeho týmu"
+textTeam = "<p>V jednom týmu může být max. 5 členů, členy*ky můžete přizvat kdykoliv do konce registračního období výzvy. Firma může mít libovolný počet týmů.</p><p>Jen týmy s více než 1 členem se zapojují do výzev mezi týmy.</p>"
 titleAddTeam = "Přidat tým"
 
 [index]

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -128,6 +128,7 @@ titleSubdivisionAddress = "Adresa vaší pobočky"
 buttonAddTeam = "Přidat tým"
 labelMembers = "člen | členů"
 labelTeam = "Název týmu"
+labelTeamName = "Název vašeho týmu"
 titleAddTeam = "Přidat tým"
 
 [index]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -128,7 +128,7 @@ buttonAddTeam = "Add team"
 labelMembers = "member | members"
 labelTeam = "Team name"
 labelTeamName = "Your team name"
-textTeam = "<p>V jednom týmu může být max. 5 členů, členy*ky můžete přizvat kdykoliv do konce registračního období výzvy. Firma může mít libovolný počet týmů.</p><p>Jen týmy s více než 1 členem se zapojují do výzev mezi týmy.</p>"
+textTeam = "<p>There can be a maximum of 5 members per team, you can invite members at any time until the end of the registration period. A company can have any number of teams.</p><p>Only teams with more than 1 member can join the inter-team challenges.</p"
 titleAddTeam = "Add team"
 
 [index]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -127,6 +127,8 @@ titleSubdivisionAddress = "Your branch address"
 buttonAddTeam = "Add team"
 labelMembers = "member | members"
 labelTeam = "Team name"
+labelTeamName = "Your team name"
+textTeam = "<p>V jednom týmu může být max. 5 členů, členy*ky můžete přizvat kdykoliv do konce registračního období výzvy. Firma může mít libovolný počet týmů.</p><p>Jen týmy s více než 1 členem se zapojují do výzev mezi týmy.</p>"
 titleAddTeam = "Add team"
 
 [index]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -127,6 +127,7 @@ titleSubdivisionAddress = "Adresa vašej pobočky"
 buttonAddTeam = "Pridať tím"
 labelMembers = "člen | členov"
 labelTeam = "Názov tímu"
+labelTeamName = "Názov vášho tímu"
 titleAddTeam = "Pridať tím"
 
 [index]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -128,6 +128,7 @@ buttonAddTeam = "Pridať tím"
 labelMembers = "člen | členov"
 labelTeam = "Názov tímu"
 labelTeamName = "Názov vášho tímu"
+textTeam = "<p>V jednom tíme môže byť maximálne 5 členov, pričom členky môžete pozvať kedykoľvek do konca registračného obdobia. Spoločnosť môže mať ľubovoľný počet tímov.</p><p>Výziev medzi tímami sa zúčastňujú len tímy s viac ako 1 členom.</p"
 titleAddTeam = "Pridať tím"
 
 [index]

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -222,7 +222,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-5').find('.q-stepper__step-content').should('not.exist');
       cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
       // select company and address
-      cy.dataCy('form-company-select-option-group')
+      cy.dataCy('form-select-table-option-group')
         .find('.q-radio__label')
         .first()
         .click();
@@ -250,7 +250,7 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-5').find('.q-stepper__step-content').should('be.visible');
       cy.dataCy('step-7').find('.q-stepper__step-content').should('not.exist');
       // click when team is selected
-      cy.dataCy('form-company-select-option-group')
+      cy.dataCy('form-select-table-option-group')
         .find('.q-radio')
         .first()
         .click();

--- a/test/cypress/fixtures/teamOptions.json
+++ b/test/cypress/fixtures/teamOptions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "Zelený team",
+    "value": "team-1",
+    "members": 2,
+    "maxMembers": 5
+  },
+  {
+    "label": "Modrý team",
+    "value": "team-2",
+    "members": 5,
+    "maxMembers": 5
+  }
+]


### PR DESCRIPTION
Registration challenge - Step 6 "Team"

Add `FormAddTeam` to display the contents of the "new team" dialog.
This component is used within `FormFieldSelectTable` in its `team` variant.

* Add tests for the `team` context in `FormFieldSelectTable.cy.js`.
* Add teamOptions fixture.
* Add translations.