### PR TITLE
components/global: add bar component with challenge start countdown

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -29,4 +29,5 @@ urlAppStore = "https://apps.apple.com/cz/app/do-pr%C3%A1ce-na-kole/id1564442780"
 urlGooglePlay = "https://play.google.com/store/apps/details?id=cz.dopracenakole"
 
 challengeMonth = "may"
+challengeStartDate = "2024-10-01T12:00:00"
 containerWidth = "752px"

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -8,6 +8,7 @@ colorGrayMiddle = "#DCE1ED"
 colorWhite = "#FFFFFF"
 colorWhiteOpacity = "rgba(255, 255, 255, 0.5)"
 colorBlack = "#000000"
+colorRed = "#F15857"
 
 image = "image.png"
 width = "850px"

--- a/src/boot/global_vars.ts
+++ b/src/boot/global_vars.ts
@@ -15,6 +15,7 @@ const initVars = (): void => {
   setCssVar('primary', rideToWorkByBikeConfig.colorPrimary);
   setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
   setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
+  setCssVar('red', rideToWorkByBikeConfig.colorRed);
 };
 
 export { rideToWorkByBikeConfig, initVars };

--- a/src/components/__tests__/TopBarCountdown.cy.js
+++ b/src/components/__tests__/TopBarCountdown.cy.js
@@ -1,0 +1,175 @@
+import { colors } from 'quasar';
+
+import TopBarCountdown from '../global/TopBarCountdown.vue';
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
+const white = getPaletteColor('white');
+const red = getPaletteColor('red');
+
+const { challengeMonth, challengeStartDate } = rideToWorkByBikeConfig;
+
+describe('TopBarCountdown', () => {
+  const releaseDate = new Date(challengeStartDate);
+  const currentTime = new Date(challengeStartDate);
+  currentTime.setDate(releaseDate.getDate() - 1);
+
+  beforeEach(() => {
+    cy.mount(TopBarCountdown, {
+      props: {
+        releaseDate,
+      },
+    });
+  });
+
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['textCountdownSeptember', 'textCountdownOctober', 'textCountdownMay'],
+      'register.challenge',
+      i18n,
+    );
+  });
+
+  it('displays internationalized labels', () => {
+    cy.clock(currentTime.getTime()).then(() => {
+      cy.dataCy('top-bar-countdown')
+        .should('be.visible')
+        .and('have.css', 'font-size', '14px')
+        .and('have.css', 'font-weight', '700')
+        .and('have.color', white)
+        .and('have.backgroundColor', red);
+      if (challengeMonth === 'may') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+      }
+      if (challengeMonth === 'september') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownSeptember', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+      }
+      if (challengeMonth === 'october') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownOctober', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+      }
+    });
+  });
+
+  it('counts down correctly', () => {
+    cy.clock(currentTime.getTime()).then(() => {
+      if (challengeMonth === 'may') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+        cy.tick(1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '0',
+            hours: '23',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+        cy.tick(60 * 60 * 1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '0',
+            hours: '22',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+      }
+      if (challengeMonth === 'september') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownSeptember', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+        cy.tick(1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownSeptember', {
+            days: '0',
+            hours: '23',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+        cy.tick(60 * 60 * 1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '0',
+            hours: '22',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+      }
+      if (challengeMonth === 'october') {
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownOctober', {
+            days: '1',
+            hours: '0',
+            minutes: '0',
+            seconds: '0',
+          }),
+        );
+        cy.tick(1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownOctober', {
+            days: '0',
+            hours: '23',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+        cy.tick(60 * 60 * 1000);
+        cy.dataCy('top-bar-countdown').should(
+          'contain.text',
+          i18n.global.t('register.challenge.textCountdownMay', {
+            days: '0',
+            hours: '22',
+            minutes: '59',
+            seconds: '59',
+          }),
+        );
+      }
+    });
+  });
+});

--- a/src/components/__tests__/TopBarCountdown.cy.js
+++ b/src/components/__tests__/TopBarCountdown.cy.js
@@ -31,7 +31,7 @@ describe('TopBarCountdown', () => {
     );
   });
 
-  it('displays internationalized labels', () => {
+  it('displays internationalized labels based on month', () => {
     cy.clock(currentTime.getTime()).then(() => {
       cy.dataCy('top-bar-countdown')
         .should('be.visible')

--- a/src/components/global/TopBarCountdown.vue
+++ b/src/components/global/TopBarCountdown.vue
@@ -1,0 +1,73 @@
+<script lang="ts">
+/**
+ * TopBarCountdown Component
+ *
+ * @description * Use this component to display a top bar with countdown.
+ *
+ * Note: This component is commonly used in `RegisterChallengePage`.
+ *
+ * @example
+ * <top-bar-countdown />
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=6485%3A29122&mode=dev)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+// composables
+import { useCountdown } from 'src/composables/useCountdown';
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
+const releaseDate = '2024-10-01T12:00:00';
+
+export default defineComponent({
+  name: 'TopBarCountdown',
+  setup() {
+    const { countdown } = useCountdown(releaseDate);
+    const challengeMonth = rideToWorkByBikeConfig.challengeMonth;
+
+    return {
+      challengeMonth,
+      countdown,
+    };
+  },
+});
+</script>
+
+<template>
+  <div
+    class="top-bar justify-center text-white text-weight-bold text-subtitle2 bg-red q-py-sm q-px-sm flex justify-sm-center"
+  >
+    <span v-if="challengeMonth === 'may'">
+      {{
+        $t('register.challenge.textCountdownMay', {
+          days: countdown.days,
+          hours: countdown.hours,
+          minutes: countdown.minutes,
+          seconds: countdown.seconds,
+        })
+      }}
+    </span>
+    <span v-if="challengeMonth === 'september'">
+      {{
+        $t('register.challenge.textCountdownSeptember', {
+          days: countdown.days,
+          hours: countdown.hours,
+          minutes: countdown.minutes,
+          seconds: countdown.seconds,
+        })
+      }}
+    </span>
+    <span v-if="challengeMonth === 'october'">
+      {{
+        $t('register.challenge.textCountdownOctober', {
+          days: countdown.days,
+          hours: countdown.hours,
+          minutes: countdown.minutes,
+          seconds: countdown.seconds,
+        })
+      }}
+    </span>
+  </div>
+</template>

--- a/src/components/global/TopBarCountdown.vue
+++ b/src/components/global/TopBarCountdown.vue
@@ -36,6 +36,7 @@ export default defineComponent({
 <template>
   <div
     class="top-bar justify-center text-white text-weight-bold text-subtitle2 bg-red q-py-sm q-px-sm flex justify-sm-center"
+    data-cy="top-bar-countdown"
   >
     <span v-if="challengeMonth === 'may'">
       {{

--- a/src/components/global/TopBarCountdown.vue
+++ b/src/components/global/TopBarCountdown.vue
@@ -19,13 +19,11 @@ import { defineComponent } from 'vue';
 import { useCountdown } from 'src/composables/useCountdown';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
-const releaseDate = '2024-10-01T12:00:00';
-
 export default defineComponent({
   name: 'TopBarCountdown',
   setup() {
-    const { countdown } = useCountdown(releaseDate);
-    const challengeMonth = rideToWorkByBikeConfig.challengeMonth;
+    const { challengeMonth, challengeStartDate } = rideToWorkByBikeConfig;
+    const { countdown } = useCountdown(challengeStartDate);
 
     return {
       challengeMonth,

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -6,6 +6,7 @@ export interface ConfigGlobal {
   colorWhite: string;
   colorWhiteOpacity: string;
   colorBlack: string;
+  colorRed: string;
   image: string;
   width: string;
   title: string;

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -20,6 +20,7 @@ export interface ConfigGlobal {
   urlYoutube: string;
   urlGooglePlay: string;
   urlAppStore: string;
-  challengeMonth: 'may' | 'october';
+  challengeMonth: 'may' | 'october' | 'september';
   containerWidth: string;
+  challengeStartDate: string;
 }

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -300,6 +300,9 @@ buttonGoogle = "Registrovat přes Facebook"
 buttonFacebook = "Registrovat přes Google"
 
 [register.challenge]
+textCountdownSeptember = "Do Záříjové výzvy zbývá {days} dní a {hours}:{minutes}:{seconds} hodin!"
+textCountdownOctober = "Do Říjnové výzvy zbývá {days} dní a {hours}:{minutes}:{seconds} hodin!"
+textCountdownMay = "Do Květnové výzvy zbývá {days} dní a {hours}:{minutes}:{seconds} hodin!"
 titleRegisterToChallenge.may = "Registrace do Květnové výzvy"
 titleRegisterToChallenge.october = "Registrace do Říjnové výzvy"
 titleStepPersonalDetails = "Osobní údaje"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -299,6 +299,9 @@ buttonGoogle = "Register via Facebook"
 buttonFacebook = "Register via Google"
 
 [register.challenge]
+textCountdownSeptember = "{days} days and {hours}:{minutes}:{seconds} hours left to September Challenge!"
+textCountdownOctober = "{days} days and {hours}:{minutes}:{seconds} hours left to October Challenge!"
+textCountdownMay = "{days} days and {hours}:{minutes}:{seconds} hours left to May Challenge!"
 titleRegisterToChallenge.may = "Register for May challenge"
 titleRegisterToChallenge.october = "Register for October challenge"
 titleStepPersonalDetails = "Personal details"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -299,6 +299,9 @@ buttonGoogle = "Registrácia cez Facebook"
 buttonFacebook = "Registrácia cez Google"
 
 [register.challenge]
+textCountdownSeptember = "Do septembrovej výzvy zostáva {days} dní a {hours}:{minutes}:{seconds} hodín!"
+textCountdownOctober = "Do októbrovej výzvy zostáva {days} dní a {hours}:{minutes}:{seconds} hodín!"
+textCountdownMay = "Do májovej výzvy zostáva {days} dní a {hours}:{minutes}:{seconds} hodín!"
 titleRegisterToChallenge.may = "Registrácia na májovú výzvu"
 titleRegisterToChallenge.october = "Registrácia na októbrovú výzvu"
 titleStepPersonalDetails = "Osobné údaje"

--- a/src/mocks/homepage.ts
+++ b/src/mocks/homepage.ts
@@ -16,8 +16,6 @@ import {
   CardOffer,
 } from 'components/types';
 
-export const releaseDate = '2024-10-01T12:00:00';
-
 export const headingBgTitle =
   'Zapojte se do komunity Do práce na kole ve svém městě';
 

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -119,6 +119,9 @@
 // libraries
 import { defineComponent } from 'vue';
 
+// composables
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
 // import components
 import BadgeAchievement from 'components/homepage/BadgeAchievement.vue';
 import BannerApp from 'components/homepage/BannerApp.vue';
@@ -163,8 +166,10 @@ export default defineComponent({
     CardStats,
   },
   setup() {
+    const { challengeStartDate } = rideToWorkByBikeConfig;
+
     return {
-      releaseDate: homepage.releaseDate,
+      releaseDate: challengeStartDate,
       cardsChallenge: homepage.cardsChallenge,
       badgeList: homepage.badgeList,
       bannerImageData: homepage.bannerImage,

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -241,7 +241,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <top-bar-countdown />
+  <top-bar-countdown data-cy="top-bar-countdown" />
   <q-page padding class="bg-secondary">
     <div class="q-px-lg">
       <!-- Page header -->

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -13,6 +13,7 @@
  * - `FormFieldOptionGroup`: Component to render radio buttons.
  * - `FormPersonalDetails`: Component to render personal details form.
  * - `LoginRegisterHeader`: Component to render page header.
+ * - `TopBarCountdown`: Component to display countdown.
  *
  * @layout
  * - `LoginRegisterLayout`: Displayed within the `LoginLayout` template.
@@ -34,6 +35,7 @@ import FormFieldListMerch from 'src/components/form/FormFieldListMerch.vue';
 import FormFieldOptionGroup from 'src/components/form/FormFieldOptionGroup.vue';
 import FormPersonalDetails from 'src/components/form/FormPersonalDetails.vue';
 import LoginRegisterHeader from 'components/global/LoginRegisterHeader.vue';
+import TopBarCountdown from 'src/components/global/TopBarCountdown.vue';
 
 // composables
 import { useStepperValidation } from 'src/composables/useStepperValidation';
@@ -55,6 +57,7 @@ export default defineComponent({
     FormFieldOptionGroup,
     FormPersonalDetails,
     LoginRegisterHeader,
+    TopBarCountdown,
   },
   setup() {
     const challengeMonth = rideToWorkByBikeConfig.challengeMonth;
@@ -238,11 +241,11 @@ export default defineComponent({
 </script>
 
 <template>
+  <top-bar-countdown />
   <q-page padding class="bg-secondary">
     <div class="q-px-lg">
       <!-- Page header -->
       <login-register-header data-cy="login-register-header" />
-
       <!-- Container -->
       <div class="q-mx-auto q-mt-xl" :style="{ 'max-width': containerWidth }">
         <!-- Page title -->

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -20,6 +20,8 @@ const getAppConfig = (process) => {
     config['colorWhiteOpacity'] = process.env.COLOR_WHITE_OPACITY;
   } else if (process.env.COLOR_BLACK) {
     config['colorBlack'] = process.env.COLOR_BLACK;
+  } else if (process.env.COLOR_RED) {
+    config['colorRed'] = process.env.COLOR_RED;
   } else if (process.env.IMAGE) {
     config['image'] = process.env.IMAGE;
   } else if (process.env.WIDTH) {

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -48,6 +48,8 @@ const getAppConfig = (process) => {
     config['urlGooglePlay'] = process.env.URL_GOOGLE_PLAY;
   } else if (process.env.CHALLENGE_MONTH) {
     config['challengeMonth'] = process.env.CHALLENGE_MONTH;
+  } else if (process.env.CHALLENGE_START_DATE) {
+    config['challengeStartDate'] = process.env.CHALLENGE_START_DATE;
   } else if (process.env.CONTAINER_WIDTH) {
     config['containerWidth'] = process.env.CONTAINER_WIDTH;
   }

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -78,7 +78,7 @@ describe('Register Challenge page', () => {
     // switching between languages can only be tested in E2E context
     testLanguageSwitcher();
 
-    it('renders page title', () => {
+    it('renders page elements', () => {
       let i18n;
       cy.task('getAppConfig', process).then((config) => {
         cy.window().should('have.property', 'i18n');
@@ -87,6 +87,7 @@ describe('Register Challenge page', () => {
             i18n = win.i18n;
           })
           .then(() => {
+            cy.dataCy('top-bar-countdown').should('be.visible');
             cy.dataCy('login-register-title')
               .should('be.visible')
               .and('have.color', config.colorWhite)


### PR DESCRIPTION
To display countdown to start of a challenge in top bar this PR introduces following updates:

* Set challengeStartDate as a variable in `ride_to_work_by_bike_config.toml`
* Use this variable in components supporting countdown (makes use of `useCountdown` composable)
* Remove previously used mock data for the challenge start date
* Create new component `src/components/global/TopBarCountdown.vue` to display top bar
* Show the component on `src/pages/RegisterChallengePage.vue`
* Add translations (depending on the month of the challenge - also set in global config)