### PR TITLE
components/form: fix link behavior within checkbox label

### DIFF
--- a/src/components/__tests__/FormPersonalDetails.cy.js
+++ b/src/components/__tests__/FormPersonalDetails.cy.js
@@ -82,6 +82,9 @@ describe('<FormPersonalDetails>', () => {
 
     it('renders checkbox terms', () => {
       cy.dataCy('form-personal-details-terms').should('be.visible');
+      cy.dataCy('form-terms-input').should('have.attr', 'aria-checked', 'true');
+      cy.dataCy('form-terms-link').should('be.visible').click();
+      cy.dataCy('form-terms-input').should('have.attr', 'aria-checked', 'true');
     });
   });
 });

--- a/src/components/form/FormPersonalDetails.vue
+++ b/src/components/form/FormPersonalDetails.vue
@@ -223,8 +223,7 @@ export default defineComponent({
                 class="text-primary"
                 @click.stop
                 data-cy="form-terms-link"
-              >
-                {{ $t('form.linkTerms') }} </a
+                >{{ $t('form.linkTerms') }}</a
               >.
             </span>
           </q-checkbox>

--- a/src/components/form/FormPersonalDetails.vue
+++ b/src/components/form/FormPersonalDetails.vue
@@ -217,9 +217,14 @@ export default defineComponent({
               {{ $t('form.labelTerms') }}
               <!-- Link: terms -->
               <!-- TODO: Link to terms page -->
-              <a href="#" target="_blank" class="text-primary">{{
-                $t('form.linkTerms')
-              }}</a
+              <a
+                href="#"
+                target="_blank"
+                class="text-primary"
+                @click.stop
+                data-cy="form-terms-link"
+              >
+                {{ $t('form.linkTerms') }} </a
               >.
             </span>
           </q-checkbox>


### PR DESCRIPTION
Solves issue #322 - Clicking on the checkbox label text link triggers checkbox widget event instead of opening link.

Solution:

* In `FormPersonalDetails` add `@click.stop` to stop event propagation.
* Add test which checks for checkbox value before and after link click.