### PR TITLE
src/pages: add Results Page with variants of content

### DIFF
--- a/src/components/__tests__/ResultsChallengeOngoing.cy.js
+++ b/src/components/__tests__/ResultsChallengeOngoing.cy.js
@@ -1,0 +1,88 @@
+import ResultsChallengeOngoing from 'components/results/ResultsChallengeOngoing.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<ResultsChallengeOngoing>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      [
+        'buttonPastChallenges',
+        'titleBadges',
+        'titleCurrentResults',
+        'titleOngoingChallenges',
+        'titlePastChallenges',
+        'titleRecentChallenges',
+        'titleUpcomingChallenges',
+      ],
+      'results',
+      i18n,
+    );
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(ResultsChallengeOngoing, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(ResultsChallengeOngoing, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    // component
+    cy.dataCy('results-challenge-ongoing').should('be.visible');
+    // current results title
+    cy.dataCy('current-results-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleCurrentResults'));
+    // current results list
+    cy.dataCy('current-results-list').should('be.visible');
+    // ongoing challenges title
+    cy.dataCy('ongoing-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleOngoingChallenges'));
+    // TODO: ongoing challenges list
+    // cy.dataCy('ongoing-challenges-list')
+    //   .should('be.visible');
+    // badges title
+    cy.dataCy('badges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleBadges'));
+    // badges list
+    cy.dataCy('badges-list').should('be.visible');
+    // title challenges upcoming
+    cy.dataCy('upcoming-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleUpcomingChallenges'));
+    // list challenges upcoming
+    cy.dataCy('upcoming-challenges').should('be.visible');
+    // title challenges recent
+    cy.dataCy('recent-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleRecentChallenges'));
+    // list challenges recent
+    cy.dataCy('recent-challenges').should('be.visible');
+    // title past challenges
+    cy.dataCy('past-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titlePastChallenges'));
+    // button past challenges
+    cy.dataCy('past-challenges-button')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.buttonPastChallenges'));
+  });
+}

--- a/src/components/__tests__/ResultsChallengeUpcoming.cy.js
+++ b/src/components/__tests__/ResultsChallengeUpcoming.cy.js
@@ -52,7 +52,7 @@ function coreTests() {
       .should('be.visible')
       .and('contain', i18n.global.t('results.titleBadges'));
     // list badges
-    cy.dataCy('list-badges').should('be.visible');
+    cy.dataCy('badges-list').should('be.visible');
     // title past challenges
     cy.dataCy('past-challenges-title')
       .should('be.visible')

--- a/src/components/__tests__/ResultsChallengeUpcoming.cy.js
+++ b/src/components/__tests__/ResultsChallengeUpcoming.cy.js
@@ -1,0 +1,65 @@
+import ResultsChallengeUpcoming from 'components/results/ResultsChallengeUpcoming.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<ResultsChallengeUpcoming>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      [
+        'buttonPastChallenges',
+        'titleBadges',
+        'titlePastChallenges',
+        'titleUpcomingChallenges',
+      ],
+      'results',
+      i18n,
+    );
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(ResultsChallengeUpcoming, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(ResultsChallengeUpcoming, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy('results-challenge-upcoming').should('be.visible');
+    // title challenges
+    cy.dataCy('upcoming-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleUpcomingChallenges'));
+    // list challenges
+    cy.dataCy('upcoming-challenges').should('be.visible');
+    // title badges
+    cy.dataCy('badges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleBadges'));
+    // list badges
+    cy.dataCy('list-badges').should('be.visible');
+    // title past challenges
+    cy.dataCy('past-challenges-title')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titlePastChallenges'));
+    // button past challenges
+    cy.dataCy('past-challenges-button')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.buttonPastChallenges'));
+  });
+}

--- a/src/components/homepage/CardChallenge.vue
+++ b/src/components/homepage/CardChallenge.vue
@@ -9,7 +9,7 @@
  * initiative. The card may contain an image, title, and other details.
  * Border radius can be controlled by `config` parameter.
  *
- * Note: This component is commonly used within the `ListCardChallenge`
+ * Note: This component is commonly used within the `SectionColumns`
  * component.
  *
  * @props

--- a/src/components/results/ResultsChallengeOngoing.vue
+++ b/src/components/results/ResultsChallengeOngoing.vue
@@ -1,0 +1,193 @@
+<script lang="ts">
+/**
+ * ResultsChallengeOngoing Component
+ *
+ * @description * Use this component to render content of Results page when
+ * a challenge is ongoing.
+ * Commonly used in `ResultsPage`.
+ *
+ * @components
+ * - `BadgeAchievement`: Component to render a badge.
+ * - `CardChallenge`: Component to challenge card.
+ * - `CardProgress`: Component to progress card.
+ * - `CardProgressSlider`: Component to progress slider card.
+ * - `CardStats`: Component to render a stat card.
+ * - `SectionColumns`: Component to render content in columns.
+ *
+ * @example
+ * <results-challenge-ongoing />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?m=dev&node-id=4858%3A104242)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+// components
+import BadgeAchievement from '../homepage/BadgeAchievement.vue';
+import CardChallenge from '../homepage/CardChallenge.vue';
+import CardProgress from '../homepage/CardProgress.vue';
+import CardProgressSlider from '../homepage/CardProgressSlider.vue';
+import CardStats from '../homepage/CardStats.vue';
+import SectionColumns from '../homepage/SectionColumns.vue';
+
+// mocks
+import {
+  badgeList,
+  cardsChallenge,
+  cardsProgressSlider,
+  cardsStats,
+} from '../../mocks/homepage';
+
+export default defineComponent({
+  name: 'ResultsChallengeOngoing',
+  components: {
+    BadgeAchievement,
+    CardChallenge,
+    CardProgress,
+    CardProgressSlider,
+    CardStats,
+    SectionColumns,
+  },
+  setup() {
+    return {
+      badgeList,
+      cardsChallenge,
+      cardsProgressSlider,
+      cardsStats,
+    };
+  },
+});
+</script>
+
+<template>
+  <div data-cy="results-challenge-ongoing">
+    <!-- Section: Current results -->
+    <section>
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="current-results-title"
+      >
+        {{ $t('results.titleCurrentResults') }}
+      </h2>
+      <!-- Stats: Current results -->
+      <section-columns
+        :columns="3"
+        class="q-col-gutter-lg q-mt-lg"
+        data-cy="current-results-list"
+      >
+        <card-stats v-for="card in cardsStats" :key="card.title" :card="card" />
+      </section-columns>
+    </section>
+
+    <!-- Section: Ongoing challenges -->
+    <section class="q-mt-xl">
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="ongoing-challenges-title"
+      >
+        {{ $t('results.titleOngoingChallenges') }}
+      </h2>
+      <!-- Card: Featured challenge -->
+      <div class="q-mt-lg">
+        <card-progress-slider :card="cardsProgressSlider[0]" data-cy="card" />
+      </div>
+      <!-- TODO: Cards: challenges -->
+    </section>
+
+    <!-- Section: Badges -->
+    <section class="q-pt-xl">
+      <!-- Title -->
+      <h2 class="text-h6 q-my-none text-weight-bold" data-cy="badges-title">
+        {{ $t('results.titleBadges') }}
+      </h2>
+      <!-- Button -->
+      <section-columns
+        :columns="3"
+        class="q-col-gutter-lg q-mt-lg"
+        data-cy="badges-list"
+      >
+        <badge-achievement
+          v-for="badge in badgeList"
+          :key="badge.title"
+          :badge="badge"
+          class="full-width"
+          data-cy="badge-item"
+        />
+      </section-columns>
+    </section>
+
+    <!-- Section: Upcoming challenges -->
+    <section class="q-mt-xl">
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="upcoming-challenges-title"
+      >
+        {{ $t('results.titleUpcomingChallenges') }}
+      </h2>
+      <!-- Cards: Challenge -->
+      <section-columns
+        :columns="3"
+        class="q-col-gutter-lg q-mt-sm"
+        data-cy="upcoming-challenges"
+      >
+        <card-challenge
+          v-for="card in cardsChallenge.slice(0, 1)"
+          :key="card.title"
+          :card="card"
+          data-cy="card-challenge"
+        />
+      </section-columns>
+    </section>
+
+    <!-- Section: Recent challenges -->
+    <section class="q-mt-xl">
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="recent-challenges-title"
+      >
+        {{ $t('results.titleRecentChallenges') }}
+      </h2>
+      <!-- Cards: Recent challenge -->
+      <section-columns
+        :columns="3"
+        class="q-col-gutter-lg q-mt-sm"
+        data-cy="recent-challenges"
+      >
+        <card-progress
+          v-for="card in cardsProgressSlider.slice(1)"
+          :key="card.title"
+          :card="card"
+        />
+      </section-columns>
+    </section>
+
+    <!-- Section: Past challenges -->
+    <section class="q-pt-xl">
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="past-challenges-title"
+      >
+        {{ $t('results.titlePastChallenges') }}
+      </h2>
+      <!-- Button -->
+      <div class="q-mt-lg">
+        <q-btn
+          rounded
+          unelevated
+          outline
+          color="primary"
+          data-cy="past-challenges-button"
+        >
+          {{ $t('results.buttonPastChallenges') }}
+          <q-icon name="arrow_forward" size="18px" class="q-ml-sm" />
+        </q-btn>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/results/ResultsChallengeUpcoming.vue
+++ b/src/components/results/ResultsChallengeUpcoming.vue
@@ -1,0 +1,117 @@
+<script lang="ts">
+/**
+ * ResultsChallengeUpcoming Component
+ *
+ * @description * Use this component to render content of Results page when
+ * there are no active challenges.
+ * Commonly used in `ResultsPage`.
+ *
+ * @components
+ * - `BadgeAchievement`: Component to render a badge.
+ * - `CardChallenge`: Component to challenge card.
+ * - `SectionColumns`: Component to render content in columns.
+ *
+ * @example
+ * <results-challenge-upcoming />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?m=dev&node-id=4858%3A106374)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+// components
+import BadgeAchievement from '../homepage/BadgeAchievement.vue';
+import CardChallenge from '../homepage/CardChallenge.vue';
+import SectionColumns from '../homepage/SectionColumns.vue';
+
+// mocks
+import { badgeList, cardsChallenge } from '../../mocks/homepage';
+
+export default defineComponent({
+  name: 'ResultsChallengeUpcoming',
+  components: {
+    BadgeAchievement,
+    CardChallenge,
+    SectionColumns,
+  },
+  setup() {
+    return {
+      badgeList,
+      cardsChallenge,
+    };
+  },
+});
+</script>
+
+<template>
+  <div data-cy="results-challenge-upcoming">
+    <!-- Section: Upcoming challenges -->
+    <section>
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="upcoming-challenges-title"
+      >
+        {{ $t('results.titleUpcomingChallenges') }}
+      </h2>
+      <!-- Cards: Challenge -->
+      <section-columns
+        :columns="3"
+        class="q-col-gutter-lg q-mt-sm"
+        data-cy="upcoming-challenges"
+      >
+        <card-challenge
+          v-for="card in cardsChallenge"
+          :key="card.title"
+          :card="card"
+          data-cy="card-challenge"
+        />
+      </section-columns>
+    </section>
+    <!-- Section: Badges -->
+    <section class="q-pt-xl">
+      <!-- Title -->
+      <h2 class="text-h6 q-my-none text-weight-bold" data-cy="badges-title">
+        {{ $t('results.titleBadges') }}
+      </h2>
+      <!-- Badges: Achievement -->
+      <section-columns
+        :columns="4"
+        class="q-col-gutter-lg q-mt-sm"
+        data-cy="list-badges"
+      >
+        <badge-achievement
+          v-for="badge in badgeList"
+          :key="badge.title"
+          :badge="badge"
+          class="full-width"
+          data-cy="badge-item"
+        />
+      </section-columns>
+    </section>
+    <!-- Section: Past challenges -->
+    <section class="q-pt-xl">
+      <!-- Title -->
+      <h2
+        class="text-h6 q-my-none text-weight-bold"
+        data-cy="past-challenges-title"
+      >
+        {{ $t('results.titlePastChallenges') }}
+      </h2>
+      <!-- Button -->
+      <div class="q-mt-lg">
+        <q-btn
+          rounded
+          unelevated
+          outline
+          color="primary"
+          data-cy="past-challenges-button"
+        >
+          {{ $t('results.buttonPastChallenges') }}
+          <q-icon name="arrow_forward" size="18px" class="q-ml-sm" />
+        </q-btn>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/results/ResultsChallengeUpcoming.vue
+++ b/src/components/results/ResultsChallengeUpcoming.vue
@@ -69,6 +69,7 @@ export default defineComponent({
         />
       </section-columns>
     </section>
+
     <!-- Section: Badges -->
     <section class="q-pt-xl">
       <!-- Title -->
@@ -79,7 +80,7 @@ export default defineComponent({
       <section-columns
         :columns="4"
         class="q-col-gutter-lg q-mt-sm"
-        data-cy="list-badges"
+        data-cy="badges-list"
       >
         <badge-achievement
           v-for="badge in badgeList"
@@ -90,6 +91,7 @@ export default defineComponent({
         />
       </section-columns>
     </section>
+
     <!-- Section: Past challenges -->
     <section class="q-pt-xl">
       <!-- Title -->

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -383,6 +383,9 @@ messageTermsRequired = "Musíte souhlasit se zpracováním osobních údajů"
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
 
 [results]
+buttonPastChallenges = "Výsledky z dřívějších výzev"
+titleBadges = "Odznaky"
+titlePastChallenges = "Dřívější výzvy"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadcházející výzvy"
 

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -382,6 +382,10 @@ messageResponsibilityRequired = "Musíte souhlasit se zajištěním startovného
 messageTermsRequired = "Musíte souhlasit se zpracováním osobních údajů"
 hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
 
+[results]
+titleResults = "Výsledky"
+titleUpcomingChallenges = "Nadcházející výzvy"
+
 [routes]
 actionInputDistance = "Zadat vzdálenost"
 actionTraceMap = "Zakreslit do mapy"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -385,7 +385,10 @@ hintPassword = "Musí obsahovat alespoň 6 znaků a alespoň 1 písmeno."
 [results]
 buttonPastChallenges = "Výsledky z dřívějších výzev"
 titleBadges = "Odznaky"
+titleCurrentResults = "Dosavadní výsledky"
+titleOngoingChallenges = "Probíhající výzvy"
 titlePastChallenges = "Dřívější výzvy"
+titleRecentChallenges = "Uplynulé výzvy za toto období"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadcházející výzvy"
 

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -381,6 +381,10 @@ messageResponsibilityRequired = "You must agree to provide an entry fee."
 messageTermsRequired = "You must consent to the processing of personal data"
 hintPassword = "It must contain at least 6 characters and at least 1 letter."
 
+[results]
+titleResults = "Results"
+titleUpcomingChallenges = "Upcoming challenges"
+
 [routes]
 actionInputDistance = "Input distance"
 actionTraceMap = "Trace route"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -382,6 +382,9 @@ messageTermsRequired = "You must consent to the processing of personal data"
 hintPassword = "It must contain at least 6 characters and at least 1 letter."
 
 [results]
+buttonPastChallenges = "View previous challenges"
+titleBadges = "Badges"
+titlePastChallenges = "Previous challenges"
 titleResults = "Results"
 titleUpcomingChallenges = "Upcoming challenges"
 

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -384,7 +384,10 @@ hintPassword = "It must contain at least 6 characters and at least 1 letter."
 [results]
 buttonPastChallenges = "View previous challenges"
 titleBadges = "Badges"
+titleCurrentResults = "Current results"
+titleOngoingChallenges = "Ongoing challenges"
 titlePastChallenges = "Previous challenges"
+titleRecentChallenges = "Recent completed challenges"
 titleResults = "Results"
 titleUpcomingChallenges = "Upcoming challenges"
 

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -382,6 +382,9 @@ messageTermsRequired = "Musíte súhlasiť so spracovaním osobných údajov"
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 
 [results]
+buttonPastChallenges = "Výsledky predošlých výziev"
+titleBadges = "Odznaky"
+titlePastChallenges = "predošlé výzvy"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -384,7 +384,7 @@ hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 [results]
 buttonPastChallenges = "Výsledky predošlých výziev"
 titleBadges = "Odznaky"
-titlePastChallenges = "predošlé výzvy"
+titlePastChallenges = "Predošlé výzvy"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -384,7 +384,10 @@ hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 [results]
 buttonPastChallenges = "Výsledky predošlých výziev"
 titleBadges = "Odznaky"
+titleCurrentResults = "Doterajšie výsledky"
+titleOngoingChallenges = "Prebiehajúce výzvy"
 titlePastChallenges = "Predošlé výzvy"
+titleRecentChallenges = "Predošlé výzvy na toto obdobie"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -381,6 +381,10 @@ messageResponsibilityRequired = "Musíte súhlasiť s poskytnutím štartovného
 messageTermsRequired = "Musíte súhlasiť so spracovaním osobných údajov"
 hintPassword = "Musí obsahovať aspoň 6 znakov a aspoň 1 písmeno."
 
+[results]
+titleResults = "Výsledky"
+titleUpcomingChallenges = "Nadchádzajúce výzvy"
+
 [routes]
 actionInputDistance = "Zadať vzdialenosť"
 actionTraceMap = "Zakreslit"

--- a/src/mocks/layout.ts
+++ b/src/mocks/layout.ts
@@ -22,7 +22,7 @@ export const menuTop: Link[] = [
     name: 'routes',
   },
   {
-    url: '/vysledky',
+    url: '/results',
     icon: 'emoji_events',
     name: 'results',
   },

--- a/src/pages/ResultsPage.vue
+++ b/src/pages/ResultsPage.vue
@@ -5,6 +5,8 @@
  * Shows upcoming challenges, badges, user progress, and other results.
  *
  * @components
+ * - `ResultsChallengeOngoing`: Component to render content in
+ * the "challenge-ongoing" state.
  * - `ResultsChallengeUpcoming`: Component to render content in
  * the "challenge-upcoming" state.
  *
@@ -14,11 +16,14 @@
 // libraries
 import { defineComponent } from 'vue';
 
+// components
+import ResultsChallengeOngoing from 'components/results/ResultsChallengeOngoing.vue';
 import ResultsChallengeUpcoming from 'components/results/ResultsChallengeUpcoming.vue';
 
 export default defineComponent({
   name: 'ResultsPage',
   components: {
+    ResultsChallengeOngoing,
     ResultsChallengeUpcoming,
   },
   setup() {
@@ -43,6 +48,11 @@ export default defineComponent({
       <results-challenge-upcoming
         v-if="state === 'challenge-upcoming'"
         data-cy="results-challenge-upcoming"
+      />
+
+      <results-challenge-ongoing
+        v-if="state === 'challenge-ongoing'"
+        data-cy="results-challenge-ongoing"
       />
     </div>
   </q-page>

--- a/src/pages/ResultsPage.vue
+++ b/src/pages/ResultsPage.vue
@@ -4,31 +4,26 @@
  *
  * Shows upcoming challenges, badges, user progress, and other results.
  *
+ * @components
+ * - `ResultsChallengeUpcoming`: Component to render content in
+ * the "challenge-upcoming" state.
+ *
  * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=4948%3A125553&mode=dev)
  **/
 
 // libraries
 import { defineComponent } from 'vue';
 
-// components
-import BadgeAchievement from 'src/components/homepage/BadgeAchievement.vue';
-import CardChallenge from 'src/components/homepage/CardChallenge.vue';
-import SectionColumns from 'src/components/homepage/SectionColumns.vue';
-
-// mocks
-import { badgeList, cardsChallenge } from '../mocks/homepage';
+import ResultsChallengeUpcoming from 'components/results/ResultsChallengeUpcoming.vue';
 
 export default defineComponent({
   name: 'ResultsPage',
   components: {
-    BadgeAchievement,
-    CardChallenge,
-    SectionColumns,
+    ResultsChallengeUpcoming,
   },
   setup() {
     return {
-      badgeList,
-      cardsChallenge,
+      state: 'challenge-upcoming',
     };
   },
 });
@@ -44,75 +39,11 @@ export default defineComponent({
       >
         {{ $t('results.titleResults') }}
       </h1>
-      <!-- Section: Upcoming challenges -->
-      <div>
-        <!-- Title -->
-        <h2
-          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
-          data-cy="upcoming-challenges-title"
-        >
-          {{ $t('results.titleUpcomingChallenges') }}
-        </h2>
-        <!-- Cards: Challenge -->
-        <section-columns
-          :columns="3"
-          class="q-col-gutter-lg q-pb-xl"
-          data-cy="upcoming-challenges"
-        >
-          <card-challenge
-            v-for="card in cardsChallenge"
-            :key="card.title"
-            :card="card"
-            data-cy="card-challenge"
-          />
-        </section-columns>
-      </div>
-      <!-- Section: Badges -->
-      <div>
-        <!-- Title -->
-        <h2
-          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
-          data-cy="badges-title"
-        >
-          {{ $t('results.titleBadges') }}
-        </h2>
-        <!-- Badges: Achievement -->
-        <section-columns
-          :columns="4"
-          class="q-col-gutter-lg q-pt-xl q-pb-xl"
-          data-cy="list-badges"
-        >
-          <badge-achievement
-            v-for="badge in badgeList"
-            :key="badge.title"
-            :badge="badge"
-            class="full-width"
-            data-cy="badge-item"
-          />
-        </section-columns>
-      </div>
-      <!-- Section: Past challenges -->
-      <div>
-        <!-- Title -->
-        <h2
-          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
-          data-cy="past-challenges-title"
-        >
-          {{ $t('results.titlePastChallenges') }}
-        </h2>
-        <!-- Button -->
-        <q-btn
-          rounded
-          unelevated
-          outline
-          color="primary"
-          class="q-mt-lg"
-          data-cy="past-challenges-button"
-        >
-          {{ $t('results.buttonPastChallenges') }}
-          <q-icon name="arrow_forward" size="18px" class="q-ml-sm" />
-        </q-btn>
-      </div>
+
+      <results-challenge-upcoming
+        v-if="state === 'challenge-upcoming'"
+        data-cy="results-challenge-upcoming"
+      />
     </div>
   </q-page>
 </template>

--- a/src/pages/ResultsPage.vue
+++ b/src/pages/ResultsPage.vue
@@ -11,20 +11,23 @@
 import { defineComponent } from 'vue';
 
 // components
+import BadgeAchievement from 'src/components/homepage/BadgeAchievement.vue';
 import CardChallenge from 'src/components/homepage/CardChallenge.vue';
 import SectionColumns from 'src/components/homepage/SectionColumns.vue';
 
 // mocks
-import { cardsChallenge } from '../mocks/homepage';
+import { badgeList, cardsChallenge } from '../mocks/homepage';
 
 export default defineComponent({
   name: 'ResultsPage',
   components: {
+    BadgeAchievement,
     CardChallenge,
     SectionColumns,
   },
   setup() {
     return {
+      badgeList,
       cardsChallenge,
     };
   },
@@ -33,7 +36,7 @@ export default defineComponent({
 
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
-    <div class="q-px-lg bg-white">
+    <div class="q-px-lg bg-white q-pb-xl">
       <!-- Heading -->
       <h1
         class="text-h5 q-mt-none q-pt-lg text-weight-bold"
@@ -50,6 +53,7 @@ export default defineComponent({
         >
           {{ $t('results.titleUpcomingChallenges') }}
         </h2>
+        <!-- Cards: Challenge -->
         <section-columns
           :columns="3"
           class="q-col-gutter-lg q-pb-xl"
@@ -62,6 +66,52 @@ export default defineComponent({
             data-cy="card-challenge"
           />
         </section-columns>
+      </div>
+      <!-- Section: Badges -->
+      <div>
+        <!-- Title -->
+        <h2
+          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
+          data-cy="badges-title"
+        >
+          {{ $t('results.titleBadges') }}
+        </h2>
+        <!-- Badges: Achievement -->
+        <section-columns
+          :columns="4"
+          class="q-col-gutter-lg q-pt-xl q-pb-xl"
+          data-cy="list-badges"
+        >
+          <badge-achievement
+            v-for="badge in badgeList"
+            :key="badge.title"
+            :badge="badge"
+            class="full-width"
+            data-cy="badge-item"
+          />
+        </section-columns>
+      </div>
+      <!-- Section: Past challenges -->
+      <div>
+        <!-- Title -->
+        <h2
+          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
+          data-cy="past-challenges-title"
+        >
+          {{ $t('results.titlePastChallenges') }}
+        </h2>
+        <!-- Button -->
+        <q-btn
+          rounded
+          unelevated
+          outline
+          color="primary"
+          class="q-mt-lg"
+          data-cy="past-challenges-button"
+        >
+          {{ $t('results.buttonPastChallenges') }}
+          <q-icon name="arrow_forward" size="18px" class="q-ml-sm" />
+        </q-btn>
       </div>
     </div>
   </q-page>

--- a/src/pages/ResultsPage.vue
+++ b/src/pages/ResultsPage.vue
@@ -1,0 +1,68 @@
+<script lang="ts">
+/**
+ * Results Page
+ *
+ * Shows upcoming challenges, badges, user progress, and other results.
+ *
+ * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=4948%3A125553&mode=dev)
+ **/
+
+// libraries
+import { defineComponent } from 'vue';
+
+// components
+import CardChallenge from 'src/components/homepage/CardChallenge.vue';
+import SectionColumns from 'src/components/homepage/SectionColumns.vue';
+
+// mocks
+import { cardsChallenge } from '../mocks/homepage';
+
+export default defineComponent({
+  name: 'ResultsPage',
+  components: {
+    CardChallenge,
+    SectionColumns,
+  },
+  setup() {
+    return {
+      cardsChallenge,
+    };
+  },
+});
+</script>
+
+<template>
+  <q-page class="overflow-hidden" data-cy="q-main">
+    <div class="q-px-lg bg-white">
+      <!-- Heading -->
+      <h1
+        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
+        data-cy="results-page-title"
+      >
+        {{ $t('results.titleResults') }}
+      </h1>
+      <!-- Section: Upcoming challenges -->
+      <div>
+        <!-- Title -->
+        <h2
+          class="text-h6 q-mt-none text-weight-bold q-pt-xl"
+          data-cy="upcoming-challenges-title"
+        >
+          {{ $t('results.titleUpcomingChallenges') }}
+        </h2>
+        <section-columns
+          :columns="3"
+          class="q-col-gutter-lg q-pb-xl"
+          data-cy="upcoming-challenges"
+        >
+          <card-challenge
+            v-for="card in cardsChallenge"
+            :key="card.title"
+            :card="card"
+            data-cy="card-challenge"
+          />
+        </section-columns>
+      </div>
+    </div>
+  </q-page>
+</template>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -105,6 +105,17 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  {
+    path: routesConf['results']['path'],
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['results']['children']['name'],
+        component: () => import('pages/ResultsPage.vue'),
+      },
+    ],
+  },
 
   // Always leave this as last one,
   // but you can also remove it

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -68,6 +68,12 @@ const routesConf: RoutesConf = {
       name: 'register-challenge',
     },
   },
+  results: {
+    path: '/results',
+    children: {
+      name: 'results',
+    },
+  },
 };
 
 export { routesConf };

--- a/test/cypress/e2e/results.spec.cy.js
+++ b/test/cypress/e2e/results.spec.cy.js
@@ -1,0 +1,51 @@
+import { routesConf } from '../../../src/router/routes_conf';
+
+describe('Results page', () => {
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.visit('#' + routesConf['results']['path']);
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+
+    it('renders left drawer', () => {
+      cy.dataCy('q-drawer').should('be.visible');
+      cy.dataCy('drawer-header').should('be.visible');
+      cy.dataCy('user-select').should('be.visible');
+      cy.dataCy('drawer-toggle-buttons').should('be.visible');
+      cy.dataCy('drawer-menu').should('be.visible');
+    });
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.visit('#' + routesConf['results']['path']);
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders page heading section', () => {
+    let i18n;
+    cy.window().should('have.property', 'i18n');
+    cy.window()
+      .then((win) => {
+        i18n = win.i18n;
+      })
+      .then(() => {
+        // title
+        cy.dataCy('results-page-title')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.titleResults'));
+      });
+  });
+
+  it('renders upcoming challenges section', () => {
+    cy.dataCy('upcoming-challenges-title').should('be.visible');
+    cy.dataCy('upcoming-challenges').should('be.visible');
+  });
+}

--- a/test/cypress/e2e/results.spec.cy.js
+++ b/test/cypress/e2e/results.spec.cy.js
@@ -45,37 +45,7 @@ function coreTests() {
   });
 
   it('renders upcoming challenges section', () => {
-    let i18n;
-    cy.window().should('have.property', 'i18n');
-    cy.window()
-      .then((win) => {
-        i18n = win.i18n;
-      })
-      .then(() => {
-        cy.dataCy('upcoming-challenges-title').should('be.visible');
-        cy.dataCy('upcoming-challenges').should('be.visible');
-
-        // State: Before challenge
-        // title challenges
-        cy.dataCy('upcoming-challenges-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.titleUpcomingChallenges'));
-        // list challenges
-        cy.dataCy('upcoming-challenges').should('be.visible');
-        // title badges
-        cy.dataCy('badges-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.titleBadges'));
-        // list badges
-        cy.dataCy('list-badges').should('be.visible');
-        // title past challenges
-        cy.dataCy('past-challenges-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.titlePastChallenges'));
-        // button past challenges
-        cy.dataCy('past-challenges-button')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.buttonPastChallenges'));
-      });
+    // upcoming challenges
+    cy.dataCy('results-challenge-upcoming').should('be.visible');
   });
 }

--- a/test/cypress/e2e/results.spec.cy.js
+++ b/test/cypress/e2e/results.spec.cy.js
@@ -45,7 +45,37 @@ function coreTests() {
   });
 
   it('renders upcoming challenges section', () => {
-    cy.dataCy('upcoming-challenges-title').should('be.visible');
-    cy.dataCy('upcoming-challenges').should('be.visible');
+    let i18n;
+    cy.window().should('have.property', 'i18n');
+    cy.window()
+      .then((win) => {
+        i18n = win.i18n;
+      })
+      .then(() => {
+        cy.dataCy('upcoming-challenges-title').should('be.visible');
+        cy.dataCy('upcoming-challenges').should('be.visible');
+
+        // State: Before challenge
+        // title challenges
+        cy.dataCy('upcoming-challenges-title')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.titleUpcomingChallenges'));
+        // list challenges
+        cy.dataCy('upcoming-challenges').should('be.visible');
+        // title badges
+        cy.dataCy('badges-title')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.titleBadges'));
+        // list badges
+        cy.dataCy('list-badges').should('be.visible');
+        // title past challenges
+        cy.dataCy('past-challenges-title')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.titlePastChallenges'));
+        // button past challenges
+        cy.dataCy('past-challenges-button')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.buttonPastChallenges'));
+      });
   });
 }


### PR DESCRIPTION
Adds `/results` route as `src/pages/ResultsPage.vue`

ResultsPage will be displaying different variants of content based on the challenge state. State variable source is to be implemented.

* Create `ResultsChallengeOngoing.vue`
* Create `ResultsChallengeUpcoming.vue`

These store the content for the variants.

* E2E results spec tests the "challenge upcoming" variant.
* Mocks (same as on homepage) are used to render content.