### PR TITLE
src/pages: add ResultsDetailPage with tabs component

### DIFF
--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -1,0 +1,36 @@
+import ResultsTabs from 'components/results/ResultsTabs.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<ResultsTabs>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(ResultsTabs, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(ResultsTabs, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy('component').should('be.visible');
+  });
+}

--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -31,6 +31,6 @@ describe('<ResultsTabs>', () => {
 
 function coreTests() {
   it('renders component', () => {
-    cy.dataCy('component').should('be.visible');
+    cy.dataCy('results-tabs').should('be.visible');
   });
 }

--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -3,7 +3,16 @@ import { i18n } from '../../boot/i18n';
 
 describe('<ResultsTabs>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'index.component', i18n);
+    cy.testLanguageStringsInContext(
+      [
+        // Not tested - identical
+        // 'tabReport',
+        'tabConsistency',
+        'tabPerformance',
+      ],
+      'results',
+      i18n,
+    );
   });
 
   context('desktop', () => {

--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -8,7 +8,7 @@ describe('<ResultsTabs>', () => {
       [
         // Not tested - identical
         // 'tabReport',
-        'tabConsistency',
+        'tabRegularity',
         'tabPerformance',
       ],
       'results',
@@ -44,12 +44,12 @@ describe('<ResultsTabs>', () => {
     });
 
     it('does not switch to locked tab', () => {
-      cy.dataCy('results-tabs-button-consistency').click();
-      cy.dataCy('results-tabs-panel-consistency').should('be.visible');
+      cy.dataCy('results-tabs-button-regularity').click();
+      cy.dataCy('results-tabs-panel-regularity').should('be.visible');
 
       cy.dataCy('results-tabs-button-report').click();
       cy.dataCy('results-tabs-panel-report').should('not.exist');
-      cy.dataCy('results-tabs-panel-consistency').should('be.visible');
+      cy.dataCy('results-tabs-panel-regularity').should('be.visible');
     });
   });
 
@@ -71,16 +71,16 @@ function coreTests() {
     cy.dataCy('results-tabs-button-report')
       .should('be.visible')
       .and('contain', i18n.global.t('results.tabReport'));
-    cy.dataCy('results-tabs-button-consistency')
+    cy.dataCy('results-tabs-button-regularity')
       .should('be.visible')
-      .and('contain', i18n.global.t('results.tabConsistency'));
+      .and('contain', i18n.global.t('results.tabRegularity'));
     cy.dataCy('results-tabs-button-performance')
       .should('be.visible')
       .and('contain', i18n.global.t('results.tabPerformance'));
 
     cy.dataCy('results-tabs-button-report').click();
     cy.dataCy('results-tabs-panel-report').should('be.visible');
-    cy.dataCy('results-tabs-panel-consistency').should('not.exist');
+    cy.dataCy('results-tabs-panel-regularity').should('not.exist');
     cy.dataCy('results-tabs-panel-performance').should('not.exist');
   });
 
@@ -89,10 +89,10 @@ function coreTests() {
     cy.dataCy('results-tabs-button-report').click();
     cy.dataCy('results-tabs-panel-report').should('be.visible');
     cy.dataCy('results-tabs-title-report').should('be.visible');
-    // display consistency
-    cy.dataCy('results-tabs-button-consistency').click();
-    cy.dataCy('results-tabs-panel-consistency').should('be.visible');
-    cy.dataCy('results-tabs-title-consistency').should('be.visible');
+    // display regularity
+    cy.dataCy('results-tabs-button-regularity').click();
+    cy.dataCy('results-tabs-panel-regularity').should('be.visible');
+    cy.dataCy('results-tabs-title-regularity').should('be.visible');
     // display performance
     cy.dataCy('results-tabs-button-performance').click();
     cy.dataCy('results-tabs-panel-performance').should('be.visible');
@@ -104,16 +104,16 @@ function coreTests() {
     cy.dataCy('results-tabs-button-report').click();
     cy.url().should('include', routesConf['results_report'].path);
     // switch to list tab
-    cy.dataCy('results-tabs-button-consistency').click();
+    cy.dataCy('results-tabs-button-regularity').click();
     cy.url().should('not.include', routesConf['results_report'].path);
-    cy.url().should('include', routesConf['results_consistency'].path);
+    cy.url().should('include', routesConf['results_regularity'].path);
     // switch to map tab
     cy.dataCy('results-tabs-button-performance').click();
-    cy.url().should('not.include', routesConf['results_consistency'].path);
+    cy.url().should('not.include', routesConf['results_regularity'].path);
     cy.url().should('include', routesConf['results_performance'].path);
     // popstate
     cy.go('back');
-    cy.url().should('include', routesConf['results_consistency'].path);
+    cy.url().should('include', routesConf['results_regularity'].path);
     cy.dataCy('results-tabs-panel-performance').should('be.visible');
   });
 }

--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -1,5 +1,6 @@
 import ResultsTabs from 'components/results/ResultsTabs.vue';
 import { i18n } from '../../boot/i18n';
+import { routesConf } from 'src/router/routes_conf';
 
 describe('<ResultsTabs>', () => {
   it('has translation for all strings', () => {
@@ -26,6 +27,32 @@ describe('<ResultsTabs>', () => {
     coreTests();
   });
 
+  context('desktop - locked tabs', () => {
+    beforeEach(() => {
+      cy.mount(ResultsTabs, {
+        props: {
+          locked: ['report'],
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders tabs as locked', () => {
+      cy.dataCy('results-tabs-button-report')
+        .find('i')
+        .should('have.class', 'mdi-lock');
+    });
+
+    it('does not switch to locked tab', () => {
+      cy.dataCy('results-tabs-button-consistency').click();
+      cy.dataCy('results-tabs-panel-consistency').should('be.visible');
+
+      cy.dataCy('results-tabs-button-report').click();
+      cy.dataCy('results-tabs-panel-report').should('not.exist');
+      cy.dataCy('results-tabs-panel-consistency').should('be.visible');
+    });
+  });
+
   context('mobile', () => {
     beforeEach(() => {
       cy.mount(ResultsTabs, {
@@ -41,5 +68,52 @@ describe('<ResultsTabs>', () => {
 function coreTests() {
   it('renders component', () => {
     cy.dataCy('results-tabs').should('be.visible');
+    cy.dataCy('results-tabs-button-report')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.tabReport'));
+    cy.dataCy('results-tabs-button-consistency')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.tabConsistency'));
+    cy.dataCy('results-tabs-button-performance')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.tabPerformance'));
+
+    cy.dataCy('results-tabs-button-report').click();
+    cy.dataCy('results-tabs-panel-report').should('be.visible');
+    cy.dataCy('results-tabs-panel-consistency').should('not.exist');
+    cy.dataCy('results-tabs-panel-performance').should('not.exist');
+  });
+
+  it('allows to switch tabs', () => {
+    // display report
+    cy.dataCy('results-tabs-button-report').click();
+    cy.dataCy('results-tabs-panel-report').should('be.visible');
+    cy.dataCy('results-tabs-title-report').should('be.visible');
+    // display consistency
+    cy.dataCy('results-tabs-button-consistency').click();
+    cy.dataCy('results-tabs-panel-consistency').should('be.visible');
+    cy.dataCy('results-tabs-title-consistency').should('be.visible');
+    // display performance
+    cy.dataCy('results-tabs-button-performance').click();
+    cy.dataCy('results-tabs-panel-performance').should('be.visible');
+    cy.dataCy('results-tabs-title-performance').should('be.visible');
+  });
+
+  it('syncs tab navigation with URL', () => {
+    // initial state
+    cy.dataCy('results-tabs-button-report').click();
+    cy.url().should('include', routesConf['results_report'].path);
+    // switch to list tab
+    cy.dataCy('results-tabs-button-consistency').click();
+    cy.url().should('not.include', routesConf['results_report'].path);
+    cy.url().should('include', routesConf['results_consistency'].path);
+    // switch to map tab
+    cy.dataCy('results-tabs-button-performance').click();
+    cy.url().should('not.include', routesConf['results_consistency'].path);
+    cy.url().should('include', routesConf['results_performance'].path);
+    // popstate
+    cy.go('back');
+    cy.url().should('include', routesConf['results_consistency'].path);
+    cy.dataCy('results-tabs-panel-performance').should('be.visible');
   });
 }

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -2,38 +2,117 @@
 /**
  * ResultsTabs Component
  *
- * @description * Use this component to ... .
- * You can adjust its appearance by ... .
- *
- * @props
- * - `NAME` (TYPE, required): The object representing ... .
- *   It should be of type `TYPE`.
- *
- * @events
- * - `update:modelValue`: Emitted as a part of v-model structure.
- *
- * @slots
- * - `content`: For ... .
- *   exposed props and methods:
- *     - `state`
+ * @description * Use this component to render tabs on the ResultsDetailPage.
  *
  * @components
- * - `CHILD`: Component to ... .
+ * - `ResultsGrid`: Component to render a data report in a grid.
+ * - `ResultsTable`: Component to render rankings in a table.`
  *
  * @example
- * <ResultsTabs></ResultsTabs>
+ * <results-tabs />
  *
- * @see [Figma Design](...)
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858%3A105197&t=4cALO2fsjKI90AW1-1)
  */
 
 // libraries
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
+
+// routes
+import { routesConf } from 'src/router/routes_conf';
+
+type ResultsTabsOption = 'report' | 'consistency' | 'performance';
 
 export default defineComponent({
   name: 'ResultsTabs',
+  props: {
+    locked: {
+      type: Array as () => ResultsTabsOption[],
+      default: () => [],
+    },
+  },
+  setup(props) {
+    // list of available tabs
+    const tabs: ResultsTabsOption[] = ['report', 'consistency', 'performance'];
+    const activeTab = ref('' as ResultsTabsOption);
+
+    // locked tabs - exposed for testing and further logic
+    const lockedTabs = props.locked;
+
+    /**
+     * Checks if the given tab is locked.
+     * @param tab the tab to check
+     */
+    const isLocked = (tab: ResultsTabsOption): boolean => {
+      if (!lockedTabs.length) return false;
+      return lockedTabs.includes(tab);
+    };
+
+    return {
+      activeTab,
+      routesConf,
+      tabs,
+      isLocked,
+    };
+  },
 });
 </script>
 
 <template>
-  <div></div>
+  <div data-cy="results-tabs">
+    <!-- Tab buttons -->
+    <q-tabs
+      inline-label
+      v-model="activeTab"
+      class="text-grey"
+      active-color="primary"
+      indicator-color="primary"
+      align="center"
+      data-cy="results-tabs-buttons"
+    >
+      <q-route-tab
+        :to="routesConf['results'].path"
+        name="report"
+        alert-icon="mdi-lock"
+        :alert="isLocked('report')"
+        :disable="isLocked('report')"
+        :label="$t('results.tabReport')"
+        data-cy="results-tabs-button-report"
+      />
+      <q-route-tab
+        :to="routesConf['results_consistency'].path"
+        name="consistency"
+        alert-icon="mdi-lock"
+        :alert="isLocked('consistency')"
+        :disable="isLocked('consistency')"
+        :label="$t('results.tabConsistency')"
+        data-cy="results-tabs-button-consistency"
+      />
+      <q-route-tab
+        :to="routesConf['results_performance'].path"
+        name="performance"
+        alert-icon="mdi-lock"
+        :alert="isLocked('performance')"
+        :disable="isLocked('performance')"
+        :label="$t('results.tabPerformance')"
+        data-cy="results-tabs-button-performance"
+      />
+    </q-tabs>
+    <!-- Separator -->
+    <q-separator />
+    <!-- Tab panels -->
+    <q-tab-panels v-model="activeTab" animated>
+      <!-- Panel: Report -->
+      <q-tab-panel name="report" data-cy="resulst-tabs-panel-report">
+        <div class="text-h6">{{ $t('results.tabReport') }}</div>
+      </q-tab-panel>
+      <!-- Panel: Consistency -->
+      <q-tab-panel name="consistency" data-cy="resulst-tabs-panel-consistency">
+        <div class="text-h6">{{ $t('results.tabConsistency') }}</div>
+      </q-tab-panel>
+      <!-- Panel: Performance -->
+      <q-tab-panel name="performance" data-cy="resulst-tabs-panel-performance">
+        <div class="text-h6">{{ $t('results.tabPerformance') }}</div>
+      </q-tab-panel>
+    </q-tab-panels>
+  </div>
 </template>

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -20,7 +20,7 @@ import { defineComponent, ref } from 'vue';
 // routes
 import { routesConf } from 'src/router/routes_conf';
 
-type ResultsTabsOption = 'report' | 'consistency' | 'performance';
+type ResultsTabsOption = 'report' | 'regularity' | 'performance';
 
 export default defineComponent({
   name: 'ResultsTabs',
@@ -32,7 +32,7 @@ export default defineComponent({
   },
   setup(props) {
     // list of available tabs
-    const tabs: ResultsTabsOption[] = ['report', 'consistency', 'performance'];
+    const tabs: ResultsTabsOption[] = ['report', 'regularity', 'performance'];
     const activeTab = ref('' as ResultsTabsOption);
 
     // locked tabs - exposed for testing and further logic
@@ -79,13 +79,13 @@ export default defineComponent({
         data-cy="results-tabs-button-report"
       />
       <q-route-tab
-        :to="routesConf['results_consistency'].path"
-        name="consistency"
+        :to="routesConf['results_regularity'].path"
+        name="regularity"
         alert-icon="mdi-lock"
-        :alert="isLocked('consistency')"
-        :disable="isLocked('consistency')"
-        :label="$t('results.tabConsistency')"
-        data-cy="results-tabs-button-consistency"
+        :alert="isLocked('regularity')"
+        :disable="isLocked('regularity')"
+        :label="$t('results.tabRegularity')"
+        data-cy="results-tabs-button-regularity"
       />
       <q-route-tab
         :to="routesConf['results_performance'].path"
@@ -108,11 +108,11 @@ export default defineComponent({
           {{ $t('results.tabReport') }}
         </div>
       </q-tab-panel>
-      <!-- Panel: Consistency -->
-      <q-tab-panel name="consistency" data-cy="results-tabs-panel-consistency">
+      <!-- Panel: Regularity -->
+      <q-tab-panel name="regularity" data-cy="results-tabs-panel-regularity">
         <!-- Title -->
-        <div class="text-h6" data-cy="results-tabs-title-consistency">
-          {{ $t('results.tabConsistency') }}
+        <div class="text-h6" data-cy="results-tabs-title-regularity">
+          {{ $t('results.tabRegularity') }}
         </div>
       </q-tab-panel>
       <!-- Panel: Performance -->

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -43,8 +43,7 @@ export default defineComponent({
      * @param tab the tab to check
      */
     const isLocked = (tab: ResultsTabsOption): boolean => {
-      if (!lockedTabs.length) return false;
-      return lockedTabs.includes(tab);
+      return lockedTabs.length ? lockedTabs.includes(tab) : false;
     };
 
     return {

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -102,16 +102,25 @@ export default defineComponent({
     <!-- Tab panels -->
     <q-tab-panels v-model="activeTab" animated>
       <!-- Panel: Report -->
-      <q-tab-panel name="report" data-cy="resulst-tabs-panel-report">
-        <div class="text-h6">{{ $t('results.tabReport') }}</div>
+      <q-tab-panel name="report" data-cy="results-tabs-panel-report">
+        <!-- Title -->
+        <div class="text-h6" data-cy="results-tabs-title-report">
+          {{ $t('results.tabReport') }}
+        </div>
       </q-tab-panel>
       <!-- Panel: Consistency -->
-      <q-tab-panel name="consistency" data-cy="resulst-tabs-panel-consistency">
-        <div class="text-h6">{{ $t('results.tabConsistency') }}</div>
+      <q-tab-panel name="consistency" data-cy="results-tabs-panel-consistency">
+        <!-- Title -->
+        <div class="text-h6" data-cy="results-tabs-title-consistency">
+          {{ $t('results.tabConsistency') }}
+        </div>
       </q-tab-panel>
       <!-- Panel: Performance -->
-      <q-tab-panel name="performance" data-cy="resulst-tabs-panel-performance">
-        <div class="text-h6">{{ $t('results.tabPerformance') }}</div>
+      <q-tab-panel name="performance" data-cy="results-tabs-panel-performance">
+        <!-- Title -->
+        <div class="text-h6" data-cy="results-tabs-title-performance">
+          {{ $t('results.tabPerformance') }}
+        </div>
       </q-tab-panel>
     </q-tab-panels>
   </div>

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       data-cy="results-tabs-buttons"
     >
       <q-route-tab
-        :to="routesConf['results'].path"
+        :to="routesConf['results_report'].path"
         name="report"
         alert-icon="mdi-lock"
         :alert="isLocked('report')"

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -1,0 +1,39 @@
+<script lang="ts">
+/**
+ * ResultsTabs Component
+ *
+ * @description * Use this component to ... .
+ * You can adjust its appearance by ... .
+ *
+ * @props
+ * - `NAME` (TYPE, required): The object representing ... .
+ *   It should be of type `TYPE`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @slots
+ * - `content`: For ... .
+ *   exposed props and methods:
+ *     - `state`
+ *
+ * @components
+ * - `CHILD`: Component to ... .
+ *
+ * @example
+ * <ResultsTabs></ResultsTabs>
+ *
+ * @see [Figma Design](...)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ResultsTabs',
+});
+</script>
+
+<template>
+  <div></div>
+</template>

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -393,7 +393,7 @@ titleRecentChallenges = "Uplynulé výzvy za toto období"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadcházející výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
-tabConsistency = "Pravidelnost"
+tabRegularity = "Pravidelnost"
 tabPerformance = "Výkonnost"
 tabReport = "Data report"
 

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -393,6 +393,9 @@ titleRecentChallenges = "Uplynulé výzvy za toto období"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadcházející výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
+tabConsistency = "Pravidelnost"
+tabPerformance = "Výkonnost"
+tabReport = "Data report"
 
 [routes]
 actionInputDistance = "Zadat vzdálenost"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -392,7 +392,7 @@ titleRecentChallenges = "Recent completed challenges"
 titleResults = "Results"
 titleUpcomingChallenges = "Upcoming challenges"
 titleYourResultsSince = "Your results since {date}"
-tabConsistency = "Consistency"
+tabRegularity = "Regularity"
 tabPerformance = "Performance"
 tabReport = "Data report"
 

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -392,6 +392,9 @@ titleRecentChallenges = "Recent completed challenges"
 titleResults = "Results"
 titleUpcomingChallenges = "Upcoming challenges"
 titleYourResultsSince = "Your results since {date}"
+tabConsistency = "Consistency"
+tabPerformance = "Performance"
+tabReport = "Data report"
 
 [routes]
 actionInputDistance = "Input distance"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -392,6 +392,9 @@ titleRecentChallenges = "Predošlé výzvy na toto obdobie"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
+tabConsistency = "Pravidelnosť"
+tabPerformance = "Výkonnosť"
+tabReport = "Data report"
 
 [routes]
 actionInputDistance = "Zadať vzdialenosť"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -392,7 +392,7 @@ titleRecentChallenges = "Predošlé výzvy na toto obdobie"
 titleResults = "Výsledky"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
-tabConsistency = "Pravidelnosť"
+tabRegularity = "Pravidelnosť"
 tabPerformance = "Výkonnosť"
 tabReport = "Data report"
 

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 
       <results-list />
 
-      <results-tabs data-cy="results-tabs" />
+      <results-tabs class="q-pt-xl" data-cy="results-tabs" />
     </div>
   </q-page>
 </template>

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -33,9 +33,15 @@ export default defineComponent({
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
     <div class="q-px-lg bg-white q-pb-xl">
-      <!-- TODO: Breadcrumb Heading -->
+      <!-- TODO: Breadcrumb-style Heading -->
+      <h1
+        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
+        data-cy="results-detail-page-title"
+      >
+        {{ $t('results.titleResults') }}
+      </h1>
 
-      <results-list />
+      <results-list data-cy="results-list" />
 
       <results-tabs class="q-pt-xl" data-cy="results-tabs" />
     </div>

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -15,11 +15,13 @@
 import { defineComponent } from 'vue';
 
 // components
+import ResultsList from 'components/results/ResultsList.vue';
 import ResultsTabs from 'components/results/ResultsTabs.vue';
 
 export default defineComponent({
   name: 'ResultsDetailPage',
   components: {
+    ResultsList,
     ResultsTabs,
   },
   setup() {
@@ -33,7 +35,7 @@ export default defineComponent({
     <div class="q-px-lg bg-white q-pb-xl">
       <!-- TODO: Breadcrumb Heading -->
 
-      <!-- TODO: Results List -->
+      <results-list />
 
       <results-tabs data-cy="results-tabs" />
     </div>

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -1,0 +1,41 @@
+<script lang="ts">
+/**
+ * Results Detail Page
+ *
+ * Shows results for a single user.
+ *
+ * @components
+ * - `ResultsList`: Component to list of user's results.
+ * - `ResultsTabs`: Component to render tabs with results views.
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858%3A105197&t=4cALO2fsjKI90AW1-1)
+ **/
+
+// libraries
+import { defineComponent } from 'vue';
+
+// components
+import ResultsTabs from 'components/results/ResultsTabs.vue';
+
+export default defineComponent({
+  name: 'ResultsDetailPage',
+  components: {
+    ResultsTabs,
+  },
+  setup() {
+    return {};
+  },
+});
+</script>
+
+<template>
+  <q-page class="overflow-hidden" data-cy="q-main">
+    <div class="q-px-lg bg-white q-pb-xl">
+      <!-- TODO: Breadcrumb Heading -->
+
+      <!-- TODO: Results List -->
+
+      <results-tabs data-cy="results-tabs" />
+    </div>
+  </q-page>
+</template>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -132,12 +132,12 @@ const routes: RouteRecordRaw[] = [
     ],
   },
   {
-    path: routesConf['results_consistency']['path'],
+    path: routesConf['results_regularity']['path'],
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {
         path: '',
-        name: routesConf['results_consistency']['children']['name'],
+        name: routesConf['results_regularity']['children']['name'],
         component: () => import('pages/ResultsDetailPage.vue'),
       },
     ],

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -116,6 +116,43 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  {
+    path: routesConf['results_detail']['path'],
+    redirect: routesConf['results_report']['path'],
+  },
+  {
+    path: routesConf['results_report']['path'],
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['results_report']['children']['name'],
+        component: () => import('pages/ResultsDetailPage.vue'),
+      },
+    ],
+  },
+  {
+    path: routesConf['results_consistency']['path'],
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['results_consistency']['children']['name'],
+        component: () => import('pages/ResultsDetailPage.vue'),
+      },
+    ],
+  },
+  {
+    path: routesConf['results_performance']['path'],
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['results_performance']['children']['name'],
+        component: () => import('pages/ResultsDetailPage.vue'),
+      },
+    ],
+  },
 
   // Always leave this as last one,
   // but you can also remove it

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -74,6 +74,24 @@ const routesConf: RoutesConf = {
       name: 'results',
     },
   },
+  results_report: {
+    path: '/results/report',
+    children: {
+      name: 'results/report',
+    },
+  },
+  results_consistency: {
+    path: '/results/consistency',
+    children: {
+      name: 'results/consistency',
+    },
+  },
+  results_performance: {
+    path: '/results/performance',
+    children: {
+      name: 'results/performance',
+    },
+  },
 };
 
 export { routesConf };

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -74,22 +74,28 @@ const routesConf: RoutesConf = {
       name: 'results',
     },
   },
-  results_report: {
-    path: '/results/report',
+  results_detail: {
+    path: '/results/detail',
     children: {
-      name: 'results/report',
+      name: 'results/detail',
+    },
+  },
+  results_report: {
+    path: '/results/detail/report',
+    children: {
+      name: 'results/detail/report',
     },
   },
   results_consistency: {
-    path: '/results/consistency',
+    path: '/results/detail/consistency',
     children: {
-      name: 'results/consistency',
+      name: 'results/detail/consistency',
     },
   },
   results_performance: {
-    path: '/results/performance',
+    path: '/results/detail/performance',
     children: {
-      name: 'results/performance',
+      name: 'results/detail/performance',
     },
   },
 };

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -86,10 +86,10 @@ const routesConf: RoutesConf = {
       name: 'results/detail/report',
     },
   },
-  results_consistency: {
-    path: '/results/detail/consistency',
+  results_regularity: {
+    path: '/results/detail/regularity',
     children: {
-      name: 'results/detail/consistency',
+      name: 'results/detail/regularity',
     },
   },
   results_performance: {

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -1,0 +1,53 @@
+import { routesConf } from '../../../src/router/routes_conf';
+
+describe('Results page', () => {
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.visit('#' + routesConf['results_detail']['path']);
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+
+    it('renders left drawer', () => {
+      cy.dataCy('q-drawer').should('be.visible');
+      cy.dataCy('drawer-header').should('be.visible');
+      cy.dataCy('user-select').should('be.visible');
+      cy.dataCy('drawer-toggle-buttons').should('be.visible');
+      cy.dataCy('drawer-menu').should('be.visible');
+    });
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.visit('#' + routesConf['results_detail']['path']);
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders page heading section', () => {
+    let i18n;
+    cy.window().should('have.property', 'i18n');
+    cy.window()
+      .then((win) => {
+        i18n = win.i18n;
+      })
+      .then(() => {
+        // title
+        // TODO: Add results detail heading (breadcrumb variant)
+        cy.dataCy('results-detail-page-title')
+          .should('be.visible')
+          .and('contain', i18n.global.t('results.titleResults'));
+      });
+  });
+
+  it('renders upcoming challenges section', () => {
+    // upcoming challenges
+    cy.dataCy('results-list').should('be.visible');
+    cy.dataCy('results-tabs').should('be.visible');
+  });
+}


### PR DESCRIPTION
Adding a results detail page:

* `ResultsDetailPage` to show results for an individual user
* `RoutesTabs` component to switch between different tabs on results page
* new routes for different tabs to `routes_conf`
* translations
