### PR TITLE
test/cypress/e2e: update test for routes

### DIFF
--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -3,7 +3,7 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Routes page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['routes']['path']);
+      cy.visit('#' + routesConf['routes_calendar']['path']);
       cy.viewport('macbook-16');
     });
 
@@ -48,8 +48,9 @@ function coreTests() {
   });
 
   it('renders route tabs', () => {
-    cy.dataCy('route-tabs').should('be.visible');
-    cy.dataCy('route-tabs-button-calendar').click();
-    cy.dataCy('route-tabs-panel-calendar').should('be.visible');
+    cy.window().then(() => {
+      cy.dataCy('route-tabs').should('be.visible');
+      cy.dataCy('route-tabs-panel-calendar').should('be.visible');
+    });
   });
 }

--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -49,6 +49,7 @@ function coreTests() {
 
   it('renders route tabs', () => {
     cy.dataCy('route-tabs').should('be.visible');
+    cy.dataCy('route-tabs-button-calendar').click();
     cy.dataCy('route-tabs-panel-calendar').should('be.visible');
   });
 }


### PR DESCRIPTION
Steps to fix failing test in `routes` E2E test.

* Test route `/routes/calendar` as the default view for the tab component (identical content - avoids redirection).
* Wrap test into `cy.window().then()` callback to allow for window to load before running tests.