### PR TITLE
test/cypress/support/commands: fix inconsistency in width test

### DIFF
--- a/src/components/__tests__/CardOffer.cy.js
+++ b/src/components/__tests__/CardOffer.cy.js
@@ -204,8 +204,8 @@ describe('<CardOffer>', () => {
     it('shows modal with one column', () => {
       cy.window().then(() => {
         cy.dataCy('card-offer').click();
-        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 95);
-        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 95);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-left'), 100);
+        cy.testElementPercentageWidth(cy.dataCy('dialog-col-right'), 100);
       });
     });
   });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -74,12 +74,18 @@ Cypress.Commands.add(
   ($element, expectedPercentage) => {
     $element.then(($el) => {
       // fix bug where scrollbar is modifying child width
-      cy.wrap($el.parent()).invoke('attr', 'style', 'overflow: hidden');
-      const actualWidth = $el.outerWidth();
-      const parentWidth = $el.parent().outerWidth();
-      const calculatedPercentage = (actualWidth / parentWidth) * 100;
+      cy.wrap($el.parent())
+        .invoke('attr', 'style', 'overflow: hidden')
+        .then(() => {
+          const actualWidth = $el.outerWidth();
+          const parentWidth = $el.parent().outerWidth();
+          const calculatedPercentage = (actualWidth / parentWidth) * 100;
 
-      expect(calculatedPercentage).to.be.closeTo(Number(expectedPercentage), 2);
+          expect(calculatedPercentage).to.be.closeTo(
+            Number(expectedPercentage),
+            2,
+          );
+        });
     });
   },
 );

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -73,6 +73,8 @@ Cypress.Commands.add(
   'testElementPercentageWidth',
   ($element, expectedPercentage) => {
     $element.then(($el) => {
+      // fix bug where scrollbar is modifying child width
+      cy.wrap($el.parent()).invoke('attr', 'style', 'overflow: hidden');
       const actualWidth = $el.outerWidth();
       const parentWidth = $el.parent().outerWidth();
       const calculatedPercentage = (actualWidth / parentWidth) * 100;


### PR DESCRIPTION
Fix issue where width test incorrectly subtracts scroll sidebar width from children percentage width.

This allows to correctly pass 100% width in cases where content overflows.
Needed to make PR #408 pass.