### PR TITLE
test/cypress/e2e: update translation testing with cy.wrap to ensure translation evaluation

### DIFF
--- a/test/cypress/e2e/community.spec.cy.js
+++ b/test/cypress/e2e/community.spec.cy.js
@@ -56,7 +56,13 @@ function coreTests() {
       // title
       cy.dataCy('community-page-title')
         .should('be.visible')
-        .and('contain', i18n.global.t('community.titleCommunity'));
+        .then(($el) => {
+          cy.wrap(i18n.global.t('community.titleCommunity')).then(
+            (translation) => {
+              expect($el.text()).to.equal(translation);
+            },
+          );
+        });
       // cy.dataCy('community-select-city').should('be.visible');
     });
   });
@@ -65,7 +71,13 @@ function coreTests() {
     cy.get('@i18n').then((i18n) => {
       cy.dataCy('local-events-title')
         .should('be.visible')
-        .and('contain', i18n.global.t('community.titleLocalEvents'));
+        .then(($el) => {
+          cy.wrap(i18n.global.t('community.titleLocalEvents')).then(
+            (translation) => {
+              expect($el.text()).to.equal(translation);
+            },
+          );
+        });
       cy.dataCy('local-events-list').should('be.visible');
       cy.dataCy('local-events-item').should('be.visible').and('have.length', 2);
     });

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -11,30 +11,20 @@ describe('Home page', () => {
     beforeEach(() => {
       cy.visit(Cypress.config('baseUrl'));
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
-    it('renders all components', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('q-main').should('be.visible');
-          cy.dataCy('index-title')
-            .should('be.visible')
-            .and('have.css', 'font-size', '24px')
-            .and('have.css', 'font-weight', '700')
-            .and('contain', i18n.global.t('index.title'));
-          cy.dataCy('countdown-event').should('be.visible');
-          cy.dataCy('list-challenge').should('be.visible');
-          cy.dataCy('banner-image').should('be.visible');
-          cy.dataCy('heading-background').should('be.visible');
-          cy.dataCy('list-event').should('be.visible');
-        });
-    });
+    coreTests();
 
     it('renders left drawer', () => {
       cy.dataCy('q-drawer').should('be.visible');
@@ -45,133 +35,124 @@ describe('Home page', () => {
     });
 
     it('allows user to display and submit contact form', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('button-help').last().should('be.visible').click();
+      // open help modal
+      cy.dataCy('button-help').last().should('be.visible').click();
+      cy.dataCy('dialog-header').should('be.visible');
+      // scroll to center of modal
+      cy.dataCy('dialog-body').scrollTo(0, 1200);
+      // switch to contact state
+      cy.dataCy('button-contact').should('be.visible').click();
+      // contact title
+      cy.dataCy('dialog-header').find('h3').should('be.visible');
+      // input subject
+      cy.dataCy('contact-form-subject')
+        .find('input')
+        .should('be.visible')
+        .type('question');
+      // input message
+      cy.dataCy('contact-form-message-input')
+        .should('be.visible')
+        .type('what is the minimum distance to ride to work?');
+      // input email
+      cy.dataCy('contact-form-email')
+        .find('input')
+        .should('be.visible')
+        .type('P7LlQ@example.com');
+      // submit
+      cy.dataCy('contact-form-submit').should('be.visible').click();
 
-          cy.dataCy('dialog-header').should('be.visible');
-
-          cy.dataCy('dialog-body').scrollTo(0, 1200);
-
-          cy.dataCy('button-contact').should('be.visible').click();
-
-          cy.dataCy('dialog-header').find('h3').should('be.visible');
-
-          cy.dataCy('contact-form-subject')
-            .find('input')
-            .should('be.visible')
-            .type('question');
-
-          cy.dataCy('contact-form-message-input')
-            .should('be.visible')
-            .type('what is the minimum distance to ride to work?');
-
-          cy.dataCy('contact-form-email')
-            .find('input')
-            .should('be.visible')
-            .type('P7LlQ@example.com');
-
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-
-          // TODO: test successful submission
-        });
+      // TODO: test successful submission
     });
 
     it('validates contact form if there are errors', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('button-help').last().should('be.visible').click();
-          cy.dataCy('dialog-header').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo(0, 1200);
-          cy.dataCy('button-contact').should('be.visible').click();
-          cy.dataCy('dialog-header').find('h3').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
-          });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and(
-              'contain',
+      cy.get('@i18n').then((i18n) => {
+        // open contact form
+        cy.dataCy('button-help').last().should('be.visible').click();
+        cy.dataCy('dialog-header').should('be.visible');
+        cy.dataCy('dialog-body').scrollTo(0, 1200);
+        cy.dataCy('button-contact').should('be.visible').click();
+        cy.dataCy('dialog-header').find('h3').should('be.visible');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        // submit empty form
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        // check for error
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(
               i18n.global.t('form.messageFieldRequired', {
                 fieldName: i18n.global.t('index.contact.subject'),
               }),
+            ).then((translation) => {
+              expect($el.text()).to.equal(translation);
+            });
+          });
+        // check for error
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+        cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
+        // fill in subject field
+        cy.dataCy('contact-form-subject')
+          .find('input')
+          .should('be.visible')
+          .type('question');
+        cy.dataCy('contact-form-subject').find('input').blur();
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__messages')
+          .should('be.empty');
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__control')
+          .should('not.have.class', 'text-negative');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        // submit for with missing message
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
+        // check for error
+        cy.dataCy('contact-form-message')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(i18n.global.t('index.contact.messageRequired')).then(
+              (translation) => {
+                expect($el.text()).to.equal(translation);
+              },
             );
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-          cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
-          cy.dataCy('contact-form-subject')
-            .find('input')
-            .should('be.visible')
-            .type('question');
-          cy.dataCy('contact-form-subject').find('input').blur();
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__messages')
-            .should('be.empty');
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__control')
-            .should('not.have.class', 'text-negative');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
           });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
-          cy.dataCy('contact-form-message')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and('contain', i18n.global.t('index.contact.messageRequired'));
-          cy.dataCy('contact-form-message')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-          cy.dataCy('contact-form-message-input')
-            .should('be.visible')
-            .type('what is the minimum distance to ride to work?');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
-          });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('contact-form-email')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and(
-              'contain',
+        // fill in message
+        cy.dataCy('contact-form-message')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+        cy.dataCy('contact-form-message-input')
+          .should('be.visible')
+          .type('what is the minimum distance to ride to work?');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        // submit for with missing email
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        // check for error
+        cy.dataCy('contact-form-email')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(
               i18n.global.t('form.messageFieldRequired', {
                 fieldName: i18n.global.t('form.labelEmail'),
               }),
-            );
-          cy.dataCy('contact-form-email')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-        });
-    });
-
-    it('allows user to display event modal', () => {
-      cy.dataCy('dialog-card-event').should('not.exist');
-      cy.dataCy('list-event')
-        .should('be.visible')
-        .find('.card-link')
-        .should('be.visible')
-        .click();
-      cy.dataCy('dialog-card-event').should('be.visible');
-    });
-
-    it('allows user to display offer modal', () => {
-      cy.dataCy('dialog-offer').should('not.exist');
-      cy.dataCy('list-card-offer-item').first().should('be.visible').click();
-      cy.dataCy('dialog-offer').should('be.visible');
+            ).then((translation) => {
+              expect($el.text()).to.equal(translation);
+            });
+          });
+        cy.dataCy('contact-form-email')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+      });
     });
 
     it('allows user to see all news items', () => {
@@ -204,41 +185,6 @@ describe('Home page', () => {
         });
     });
 
-    it('allows user to switch language', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('index-title')
-            .should('be.visible')
-            .and('contain', i18n.global.t('index.title'));
-          const locales = i18n.global.availableLocales;
-          locales.forEach((locale) => {
-            let initialActiveLocale = i18n.global.locale;
-            if (locale === initialActiveLocale) {
-              return;
-            }
-            cy.dataCy('switcher-' + locale)
-              .should('exist')
-              .and('be.visible')
-              .find('.q-btn')
-              .click();
-            cy.dataCy('switcher-' + initialActiveLocale)
-              .find('.q-btn')
-              .should('not.have', 'font-weight', '400');
-            cy.dataCy('switcher-' + locale)
-              .find('.q-btn')
-              .should('have.css', 'font-weight', '700');
-            cy.dataCy('index-title')
-              .should('be.visible')
-              .and('contain', i18n.global.messages[locale].index.title);
-          });
-        });
-    });
-
     it(failTestTitle, () => {
       cy.dataCy('footer-top-button').should('be.visible').click();
       cy.window().its('scrollY').should('equal', 0);
@@ -251,27 +197,7 @@ describe('Home page', () => {
       cy.viewport('iphone-6');
     });
 
-    it('renders all components', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('q-main').should('be.visible');
-          cy.dataCy('index-title')
-            .should('be.visible')
-            .and('have.css', 'font-size', '24px')
-            .and('have.css', 'font-weight', '700')
-            .and('contain', i18n.global.t('index.title'));
-          cy.dataCy('countdown-event').should('be.visible');
-          cy.dataCy('list-challenge').should('be.visible');
-          cy.dataCy('banner-image').should('be.visible');
-          cy.dataCy('heading-background').should('be.visible');
-          cy.dataCy('list-event').should('be.visible');
-        });
-    });
+    coreTests();
 
     it('allows user to show and hide bottom panel on mobile', () => {
       cy.dataCy('footer-panel-menu').should('be.visible');
@@ -288,34 +214,31 @@ describe('Home page', () => {
     });
 
     it('allows user to display and submit contact form', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('button-help').first().should('be.visible').click();
-          cy.dataCy('dialog-header').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo(0, 1200);
-          cy.dataCy('button-contact').should('be.visible').click();
-          cy.dataCy('dialog-header').find('h3').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo(0, 0);
-          cy.dataCy('contact-form-subject')
-            .find('input')
-            .should('be.visible')
-            .type('question');
-          cy.dataCy('contact-form-message-input')
-            .should('be.visible')
-            .type('what is the minimum distance to ride to work?');
-          cy.dataCy('contact-form-email')
-            .find('input')
-            .should('be.visible')
-            .type('P7LlQ@example.com');
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          // TODO: test successful submission
-        });
+      // open help modal
+      cy.dataCy('button-help').first().should('be.visible').click();
+      cy.dataCy('dialog-header').should('be.visible');
+      // scroll to center of modal
+      cy.dataCy('dialog-body').scrollTo(0, 1200);
+      // switch to contact state
+      cy.dataCy('button-contact').should('be.visible').click();
+      cy.dataCy('dialog-header').find('h3').should('be.visible');
+      cy.dataCy('dialog-body').scrollTo(0, 0);
+      // input subject
+      cy.dataCy('contact-form-subject')
+        .find('input')
+        .should('be.visible')
+        .type('question');
+      // input message
+      cy.dataCy('contact-form-message-input')
+        .should('be.visible')
+        .type('what is the minimum distance to ride to work?');
+      // input email
+      cy.dataCy('contact-form-email')
+        .find('input')
+        .should('be.visible')
+        .type('P7LlQ@example.com');
+      cy.dataCy('contact-form-submit').should('be.visible').click();
+      // TODO: test successful submission
     });
 
     it('validates contact form if there are errors', () => {
@@ -394,57 +317,6 @@ describe('Home page', () => {
         });
     });
 
-    it('allows user to display event modal', () => {
-      cy.dataCy('dialog-card-event').should('not.exist');
-      cy.dataCy('list-event')
-        .should('be.visible')
-        .find('.card-link')
-        .should('be.visible')
-        .click();
-      cy.dataCy('dialog-card-event').should('be.visible');
-    });
-
-    it('allows user to display offer modal', () => {
-      cy.dataCy('dialog-offer').should('not.exist');
-      cy.dataCy('list-card-offer-item').first().should('be.visible').click();
-      cy.dataCy('dialog-offer').should('be.visible');
-    });
-
-    it('allows user to switch language', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('index-title')
-            .should('be.visible')
-            .and('contain', i18n.global.t('index.title'));
-          const locales = i18n.global.availableLocales;
-          locales.forEach((locale) => {
-            let initialActiveLocale = i18n.global.locale;
-            if (locale === initialActiveLocale) {
-              return;
-            }
-            cy.dataCy('switcher-' + locale)
-              .should('exist')
-              .and('be.visible')
-              .find('.q-btn')
-              .click();
-            cy.dataCy('switcher-' + initialActiveLocale)
-              .find('.q-btn')
-              .should('not.have', 'font-weight', '400');
-            cy.dataCy('switcher-' + locale)
-              .find('.q-btn')
-              .should('have.css', 'font-weight', '700');
-            cy.dataCy('index-title')
-              .should('be.visible')
-              .and('contain', i18n.global.messages[locale].index.title);
-          });
-        });
-    });
-
     it(failTestTitle, () => {
       cy.window().its('scrollY').should('equal', 0);
     });
@@ -474,3 +346,73 @@ describe('Home page', () => {
 
   // TODO: test outbound links to social media
 });
+
+function coreTests() {
+  it('renders all components', () => {
+    cy.get('@i18n').then((i18n) => {
+      cy.dataCy('q-main').should('be.visible');
+      cy.dataCy('index-title')
+        .should('be.visible')
+        .and('have.css', 'font-size', '24px')
+        .and('have.css', 'font-weight', '700')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('index.title')).then((translation) => {
+            expect($el.text()).to.equal(translation);
+          });
+        });
+      cy.dataCy('countdown-event').should('be.visible');
+      cy.dataCy('list-challenge').should('be.visible');
+      cy.dataCy('banner-image').should('be.visible');
+      cy.dataCy('heading-background').should('be.visible');
+      cy.dataCy('list-event').should('be.visible');
+    });
+  });
+
+  it('allows user to display event modal', () => {
+    cy.dataCy('dialog-card-event').should('not.exist');
+    cy.dataCy('list-event')
+      .should('be.visible')
+      .find('.card-link')
+      .should('be.visible')
+      .click();
+    cy.dataCy('dialog-card-event').should('be.visible');
+  });
+
+  it('allows user to display offer modal', () => {
+    cy.dataCy('dialog-offer').should('not.exist');
+    cy.dataCy('list-card-offer-item').first().should('be.visible').click();
+    cy.dataCy('dialog-offer').should('be.visible');
+  });
+
+  it('allows user to switch language', () => {
+    cy.get('@i18n').then((i18n) => {
+      const locales = i18n.global.availableLocales;
+      locales.forEach((locale) => {
+        let initialActiveLocale = i18n.global.locale;
+        if (locale === initialActiveLocale) {
+          return;
+        }
+        cy.dataCy('switcher-' + locale)
+          .should('exist')
+          .and('be.visible')
+          .find('.q-btn')
+          .click();
+        cy.dataCy('switcher-' + initialActiveLocale)
+          .find('.q-btn')
+          .should('not.have', 'font-weight', '400');
+        cy.dataCy('switcher-' + locale)
+          .find('.q-btn')
+          .should('have.css', 'font-weight', '700');
+        cy.dataCy('index-title')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(i18n.global.messages[locale].index.title).then(
+              (translation) => {
+                expect($el.text()).to.equal(translation);
+              },
+            );
+          });
+      });
+    });
+  });
+}

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -6,6 +6,17 @@ describe('Login page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['login']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     it('renders page header', () => {
@@ -34,100 +45,110 @@ describe('Login page', () => {
     });
 
     it('validates contact form if there are errors', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('button-help').last().should('be.visible').click();
-          cy.dataCy('dialog-header').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo(0, 1200, {
-            ensureScrollable: false,
-          });
-          cy.dataCy('button-contact').should('be.visible').click();
-          cy.dataCy('dialog-header').find('h3').should('be.visible');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
-          });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and(
-              'contain',
-              i18n.global.t('form.messageFieldRequired', {
-                fieldName: i18n.global.t('index.contact.subject'),
-              }),
+      cy.get('@i18n').then((i18n) => {
+        cy.dataCy('button-help').last().should('be.visible').click();
+        cy.dataCy('dialog-header').should('be.visible');
+        cy.dataCy('dialog-body').scrollTo(0, 1200, {
+          ensureScrollable: false,
+        });
+        cy.dataCy('button-contact').should('be.visible').click();
+        cy.dataCy('dialog-header').find('h3').should('be.visible');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(i18n.global.t('index.contact.subject')).then(
+              (fieldName) => {
+                cy.wrap(
+                  i18n.global.t('form.messageFieldRequired', {
+                    fieldName,
+                  }),
+                ).then((translation) => {
+                  expect($el.text()).to.contain(translation);
+                });
+              },
             );
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-          cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
-          cy.dataCy('contact-form-subject')
-            .find('input')
-            .should('be.visible')
-            .type('question');
-          cy.dataCy('contact-form-subject').find('input').blur();
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__messages')
-            .should('be.empty');
-          cy.dataCy('contact-form-subject')
-            .find('.q-field__control')
-            .should('not.have.class', 'text-negative');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
           });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
-          cy.dataCy('contact-form-message')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and('contain', i18n.global.t('index.contact.messageRequired'));
-          cy.dataCy('contact-form-message')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-          cy.dataCy('contact-form-message-input')
-            .should('be.visible')
-            .type('what is the minimum distance to ride to work?');
-          cy.dataCy('dialog-body').scrollTo('bottom', {
-            ensureScrollable: false,
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+        cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
+        cy.dataCy('contact-form-subject')
+          .find('input')
+          .should('be.visible')
+          .type('question');
+        cy.dataCy('contact-form-subject').find('input').blur();
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__messages')
+          .should('be.empty');
+        cy.dataCy('contact-form-subject')
+          .find('.q-field__control')
+          .should('not.have.class', 'text-negative');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        cy.dataCy('dialog-body').scrollTo('top', { ensureScrollable: false });
+        cy.dataCy('contact-form-message')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(i18n.global.t('index.contact.messageRequired')).then(
+              (translation) => {
+                expect($el.text()).to.contain(translation);
+              },
+            );
           });
-          cy.dataCy('contact-form-submit').should('be.visible').click();
-          cy.dataCy('contact-form-email')
-            .find('.q-field__messages')
-            .should('be.visible')
-            .and(
-              'contain',
+        cy.dataCy('contact-form-message')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+        cy.dataCy('contact-form-message-input')
+          .should('be.visible')
+          .type('what is the minimum distance to ride to work?');
+        cy.dataCy('dialog-body').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.dataCy('contact-form-submit').should('be.visible').click();
+        cy.dataCy('contact-form-email')
+          .find('.q-field__messages')
+          .should('be.visible')
+          .then(($el) => {
+            cy.wrap(
               i18n.global.t('form.messageFieldRequired', {
                 fieldName: i18n.global.t('form.labelEmail'),
               }),
-            );
-          cy.dataCy('contact-form-email')
-            .find('.q-field__control')
-            .should('have.class', 'text-negative');
-        });
+            ).then((translation) => {
+              expect($el.text()).to.contain(translation);
+            });
+          });
+        cy.dataCy('contact-form-email')
+          .find('.q-field__control')
+          .should('have.class', 'text-negative');
+      });
     });
 
     // switching between languages can only be tested in E2E context
     testLanguageSwitcher();
 
     it('renders form title', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('form-title-login')
-            .should('be.visible')
-            .and('have.class', 'grey-10')
-            .and('have.css', 'font-size', '24px')
-            .and('have.css', 'font-weight', '700')
-            .and('contain', i18n.global.t('login.form.titleLogin'));
-        });
+      cy.get('@i18n').then((i18n) => {
+        cy.dataCy('form-title-login')
+          .should('be.visible')
+          .and('have.class', 'grey-10')
+          .and('have.css', 'font-size', '24px')
+          .and('have.css', 'font-weight', '700')
+          .then(($el) => {
+            cy.wrap(i18n.global.t('login.form.titleLogin')).then(
+              (translation) => {
+                expect($el.text()).to.contain(translation);
+              },
+            );
+          });
+      });
     });
   });
 });

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -6,6 +6,17 @@ describe('Login page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['register']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     it('renders page header', () => {
@@ -20,19 +31,19 @@ describe('Login page', () => {
     });
 
     it('renders page title', () => {
-      let i18n;
-      cy.window().should('have.property', 'i18n');
-      cy.window()
-        .then((win) => {
-          i18n = win.i18n;
-        })
-        .then(() => {
-          cy.dataCy('form-register-title')
-            .should('be.visible')
-            .and('have.css', 'font-size', '24px')
-            .and('have.css', 'font-weight', '700')
-            .and('contain', i18n.global.t('register.form.titleRegister'));
-        });
+      cy.get('@i18n').then((i18n) => {
+        cy.dataCy('form-register-title')
+          .should('be.visible')
+          .and('have.css', 'font-size', '24px')
+          .and('have.css', 'font-weight', '700')
+          .then(($el) => {
+            cy.wrap(i18n.global.t('register.form.titleRegister')).then(
+              (translation) => {
+                expect($el.text()).to.equal(translation);
+              },
+            );
+          });
+      });
     });
   });
 });

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -7,6 +7,17 @@ describe('Login page', () => {
       // config is defined without hash in the URL
       cy.visit('#' + routesConf['register-coordinator']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     it('renders login register header component', () => {
@@ -19,62 +30,60 @@ describe('Login page', () => {
     testLanguageSwitcher();
 
     it('renders page title', () => {
-      let i18n;
-      cy.task('getAppConfig', process).then((config) => {
-        cy.window().should('have.property', 'i18n');
-        cy.window()
-          .then((win) => {
-            i18n = win.i18n;
-          })
-          .then(() => {
-            cy.dataCy('register-coordinator-title')
-              .should('be.visible')
-              .and('have.color', config.colorWhite)
-              .and('have.css', 'font-size', '24px')
-              .and('have.css', 'font-weight', '700')
-              .then(($el) => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.dataCy('register-coordinator-title')
+            .should('be.visible')
+            .and('have.color', config.colorWhite)
+            .and('have.css', 'font-size', '24px')
+            .and('have.css', 'font-weight', '700')
+            .then(($el) => {
+              cy.wrap(
+                i18n.global.t(
+                  `register.coordinator.title.${config.challengeMonth}`,
+                ),
+              ).then((translation) => {
                 // test v-html content
                 const htmlContent = $el.html();
-                expect(htmlContent).to.equal(
-                  i18n.global.t(
-                    `register.coordinator.title.${config.challengeMonth}`,
-                  ),
-                );
+                expect(htmlContent).to.equal(translation);
               });
-          });
+            });
+        });
       });
     });
 
     it('renders info card', () => {
-      let i18n;
-      cy.task('getAppConfig', process).then((config) => {
-        cy.window().should('have.property', 'i18n');
-        cy.window()
-          .then((win) => {
-            i18n = win.i18n;
-          })
-          .then(() => {
-            cy.dataCy('info-card')
-              .should('be.visible')
-              .and('have.backgroundColor', config.colorSecondary)
-              .and('have.css', 'border-radius', config.borderRadiusCard);
-            cy.dataCy('info-title')
-              .should('be.visible')
-              .and('have.css', 'font-size', '16px')
-              .and('have.css', 'font-weight', '700')
-              .and('contain', i18n.global.t('register.coordinator.titleInfo'));
-            cy.dataCy('info-content')
-              .should('be.visible')
-              .and('have.css', 'font-size', '14px')
-              .and('have.css', 'font-weight', '400')
-              .then(($el) => {
-                // test v-html content
-                const htmlContent = $el.html();
-                expect(htmlContent).to.equal(
-                  i18n.global.t('register.coordinator.info'),
-                );
-              });
-          });
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.dataCy('info-card')
+            .should('be.visible')
+            .and('have.backgroundColor', config.colorSecondary)
+            .and('have.css', 'border-radius', config.borderRadiusCard);
+          cy.dataCy('info-title')
+            .should('be.visible')
+            .and('have.css', 'font-size', '16px')
+            .and('have.css', 'font-weight', '700')
+            .then(($el) => {
+              cy.wrap(i18n.global.t('register.coordinator.titleInfo')).then(
+                (translation) => {
+                  expect($el.text()).to.equal(translation);
+                },
+              );
+            });
+          cy.dataCy('info-content')
+            .should('be.visible')
+            .and('have.css', 'font-size', '14px')
+            .and('have.css', 'font-weight', '400')
+            .then(($el) => {
+              cy.wrap(i18n.global.t('register.coordinator.info')).then(
+                (translation) => {
+                  // test v-html content
+                  const htmlContent = $el.html();
+                  expect(htmlContent).to.equal(translation);
+                },
+              );
+            });
+        });
       });
     });
   });

--- a/test/cypress/e2e/results.spec.cy.js
+++ b/test/cypress/e2e/results.spec.cy.js
@@ -5,6 +5,17 @@ describe('Results page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['results']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -22,6 +33,17 @@ describe('Results page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['results']['path']);
       cy.viewport('iphone-6');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -30,18 +52,17 @@ describe('Results page', () => {
 
 function coreTests() {
   it('renders page heading section', () => {
-    let i18n;
-    cy.window().should('have.property', 'i18n');
-    cy.window()
-      .then((win) => {
-        i18n = win.i18n;
-      })
-      .then(() => {
-        // title
-        cy.dataCy('results-page-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.titleResults'));
-      });
+    cy.get('@i18n').then((i18n) => {
+      // title
+      cy.dataCy('results-page-title')
+        .should('be.visible')
+
+        .then(($el) => {
+          cy.wrap(i18n.global.t('results.titleResults')).then((translation) => {
+            expect($el.text()).to.equal(translation);
+          });
+        });
+    });
   });
 
   it('renders upcoming challenges section', () => {

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -5,6 +5,17 @@ describe('Results page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['results_detail']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -22,6 +33,17 @@ describe('Results page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['results_detail']['path']);
       cy.viewport('iphone-6');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -30,19 +52,17 @@ describe('Results page', () => {
 
 function coreTests() {
   it('renders page heading section', () => {
-    let i18n;
-    cy.window().should('have.property', 'i18n');
-    cy.window()
-      .then((win) => {
-        i18n = win.i18n;
-      })
-      .then(() => {
-        // title
-        // TODO: Add results detail heading (breadcrumb variant)
-        cy.dataCy('results-detail-page-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('results.titleResults'));
-      });
+    cy.get('@i18n').then((i18n) => {
+      // title
+      // TODO: Add results detail heading (breadcrumb variant)
+      cy.dataCy('results-detail-page-title')
+        .should('be.visible')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('results.titleResults')).then((translation) => {
+            expect($el.text()).to.equal(translation);
+          });
+        });
+    });
   });
 
   it('renders upcoming challenges section', () => {

--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -5,6 +5,17 @@ describe('Routes page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['routes_calendar']['path']);
       cy.viewport('macbook-16');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -22,6 +33,17 @@ describe('Routes page', () => {
     beforeEach(() => {
       cy.visit('#' + routesConf['routes']['path']);
       cy.viewport('iphone-6');
+
+      // load config an i18n objects as aliases
+      cy.task('getAppConfig', process).then((config) => {
+        // alias config
+        cy.wrap(config).as('config');
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+      });
     });
 
     coreTests();
@@ -30,21 +52,31 @@ describe('Routes page', () => {
 
 function coreTests() {
   it('renders page heading section', () => {
-    let i18n;
-    cy.window().should('have.property', 'i18n');
-    cy.window()
-      .then((win) => {
-        i18n = win.i18n;
-      })
-      .then(() => {
-        cy.dataCy('routes-page-title')
-          .should('be.visible')
-          .and('contain', i18n.global.t('routes.titleRoutes'));
-        cy.dataCy('routes-page-instructions')
-          .should('be.visible')
-          .and('contain', i18n.global.t('routes.instructionRouteLogTimeframe'))
-          .and('contain', i18n.global.t('routes.instructionRouteCombination'));
+    cy.get('@i18n').then((i18n) => {
+      cy.dataCy('routes-page-title')
+        .should('be.visible')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('routes.titleRoutes')).then((translation) => {
+            expect($el.text()).to.contain(translation);
+          });
+        });
+      cy.dataCy('routes-page-instructions')
+        .should('be.visible')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('routes.instructionRouteLogTimeframe')).then(
+            (translation) => {
+              expect($el.text()).to.contain(translation);
+            },
+          );
+        });
+      cy.dataCy('routes-page-instructions').then(($el) => {
+        cy.wrap(i18n.global.t('routes.instructionRouteCombination')).then(
+          (translation) => {
+            expect($el.text()).to.contain(translation);
+          },
+        );
       });
+    });
   });
 
   it('renders route tabs', () => {


### PR DESCRIPTION
Issue: Translation tests continue to return translation keys instead of translated strings.

Solution: Extends previously used technique with aliases and `cy.wrap` to all E2E tests.
Translation function call is wrapped in `cy.wrap` and value is used in `.then` callback.