### PR TITLE
src/components/global: add component BreadcrumbTitle for rendering titles of subpages

### DIFF
--- a/src/components/__tests__/BreadcrumbTitle.cy.js
+++ b/src/components/__tests__/BreadcrumbTitle.cy.js
@@ -1,0 +1,44 @@
+import BreadcrumbTitle from 'components/global/BreadcrumbTitle.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<BreadcrumbTitle>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(BreadcrumbTitle, {
+        props: {
+          title: i18n.global.t('results.titleResultsYou'),
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(BreadcrumbTitle, {
+        props: {
+          title: i18n.global.t('results.titleResultsYou'),
+        },
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    // within the component test, the breadcrumb renders only current route
+    cy.dataCy('breadcrumb-title').should('be.visible');
+    cy.dataCy('breadcrumb-title-current')
+      .should('be.visible')
+      .and('contain', i18n.global.t('results.titleResultsYou'));
+  });
+}

--- a/src/components/global/BreadcrumbTitle.vue
+++ b/src/components/global/BreadcrumbTitle.vue
@@ -34,15 +34,19 @@ export default defineComponent({
   setup() {
     const route = useRoute();
 
+    /**
+     * Get the list of breadcrumb pages from the route meta object.
+     * An array of matched routes is returned in route.matched.
+     * First item in the array contains data defined in `routes.ts`.
+     * Meta object is used to store breadcrumbs data.
+     * @returns BreadcrumbPage[]
+     */
     const pages = computed((): BreadcrumbPage[] => {
       // get meta object
-      if (!route?.matched.length || !route.matched[0]?.meta?.breadcrumb) {
+      if (!route?.matched.length || !route.matched[0]?.meta?.breadcrumb)
         return [];
-      }
       const breadcrumb = route.matched[0].meta.breadcrumb;
-      if (!Array.isArray(breadcrumb)) {
-        return [];
-      }
+      if (!Array.isArray(breadcrumb)) return [];
       return breadcrumb;
     });
 

--- a/src/components/global/BreadcrumbTitle.vue
+++ b/src/components/global/BreadcrumbTitle.vue
@@ -1,0 +1,80 @@
+<script lang="ts">
+/**
+ * BreadcrumbTitle Component
+ *
+ * @description * Use this component to display page title as a part of
+ * a breadcrumb.
+ *
+ * @props
+ * - `title` (string, required): The object representing title of the
+ * current page.
+ *   It should be of type `string`.
+ *
+ * @example
+ * <breadcrumb-title :title="$t('index.titleHome')" />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-105197&t=UxaDEZYDQu3Og9i6-1)
+ */
+
+// libraries
+import { computed, defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+
+// types
+import type { BreadcrumbPage } from '../types/Breadcrumb';
+
+export default defineComponent({
+  name: 'BreadcrumbTitle',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    const route = useRoute();
+
+    const pages = computed((): BreadcrumbPage[] => {
+      // get meta object
+      if (!route?.matched.length || !route.matched[0]?.meta?.breadcrumb) {
+        return [];
+      }
+      const breadcrumb = route.matched[0].meta.breadcrumb;
+      if (!Array.isArray(breadcrumb)) {
+        return [];
+      }
+      return breadcrumb;
+    });
+
+    return {
+      pages,
+    };
+  },
+});
+</script>
+
+<template>
+  <q-breadcrumbs
+    class="text-h5 text-gray-7 text-weight-regular"
+    active-color="gray-10"
+    data-cy="breadcrumb-title"
+  >
+    <template v-slot:separator>
+      <q-icon size="24px" name="chevron_right" />
+    </template>
+
+    <q-breadcrumbs-el
+      v-for="page in pages"
+      :key="page.path"
+      :label="$t(`breadcrumb.${page.name}`)"
+      :icon="page.icon"
+      :to="page.path"
+      data-cy="breadcrumb-title-el"
+    />
+    <q-breadcrumbs-el
+      class="text-weight-bold"
+      :label="title"
+      data-cy="breadcrumb-title-current"
+    />
+  </q-breadcrumbs>
+</template>

--- a/src/components/types/Breadcrumb.ts
+++ b/src/components/types/Breadcrumb.ts
@@ -1,0 +1,5 @@
+export interface BreadcrumbPage {
+  name: string;
+  path: string;
+  icon?: string;
+}

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -8,6 +8,9 @@ siteTitle = "Do práce na kole"
 period = "Období výzvy"
 transportType = "Způsoby dopravy"
 
+[breadcrumb]
+results = "Výsledky"
+
 [drawerMenu]
 buttonParticipation = "Účast"
 buttonCityAdministration = "Správa města"
@@ -435,6 +438,7 @@ titleOngoingChallenges = "Probíhající výzvy"
 titlePastChallenges = "Dřívější výzvy"
 titleRecentChallenges = "Uplynulé výzvy za toto období"
 titleResults = "Výsledky"
+titleResultsYou = "Vy"
 titleUpcomingChallenges = "Nadcházející výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
 tabRegularity = "Pravidelnost"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -8,6 +8,9 @@ siteTitle = "Ride to Work by Bike"
 period = "Challenge period"
 transportType = "Means of transport"
 
+[breadcrumb]
+results = "Results"
+
 [drawerMenu]
 buttonParticipation = "Participation"
 buttonCityAdministration = "City administration"
@@ -434,6 +437,7 @@ titleOngoingChallenges = "Ongoing challenges"
 titlePastChallenges = "Previous challenges"
 titleRecentChallenges = "Recent completed challenges"
 titleResults = "Results"
+titleResultsYou = "You"
 titleUpcomingChallenges = "Upcoming challenges"
 titleYourResultsSince = "Your results since {date}"
 tabRegularity = "Regularity"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -8,6 +8,9 @@ siteTitle = "Do práce na bicykli"
 period = "Obdobie výzvy"
 transportType = "Spôsoby dopravy"
 
+[breadcrumb]
+results = "Výsledky"
+
 [drawerMenu]
 buttonParticipation = "Účasť"
 buttonCityAdministration = "Správa mesta"
@@ -434,6 +437,7 @@ titleOngoingChallenges = "Prebiehajúce výzvy"
 titlePastChallenges = "Predošlé výzvy"
 titleRecentChallenges = "Predošlé výzvy na toto obdobie"
 titleResults = "Výsledky"
+titleResultsYou = "Vy"
 titleUpcomingChallenges = "Nadchádzajúce výzvy"
 titleYourResultsSince = "Vaše výsledky od {date}"
 tabRegularity = "Pravidelnosť"

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -15,6 +15,7 @@
 import { defineComponent } from 'vue';
 
 // components
+import BreadcrumbTitle from 'src/components/global/BreadcrumbTitle.vue';
 import ListCardSlider from '../components/global/ListCardSlider.vue';
 import ResultsList from '../components/results/ResultsList.vue';
 import ResultsTabs from '../components/results/ResultsTabs.vue';
@@ -28,6 +29,7 @@ import type { CardPrizeType, Link } from '../components/types';
 export default defineComponent({
   name: 'ResultsDetailPage',
   components: {
+    BreadcrumbTitle,
     ListCardSlider,
     ResultsList,
     ResultsTabs,
@@ -50,13 +52,9 @@ export default defineComponent({
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
     <div class="q-px-lg bg-white q-pb-xl">
-      <!-- TODO: Breadcrumb-style Heading -->
-      <h1
-        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
-        data-cy="results-detail-page-title"
-      >
-        {{ $t('results.titleResults') }}
-      </h1>
+      <div class="q-pt-lg">
+        <breadcrumb-title :title="$t('results.titleResultsYou')" />
+      </div>
 
       <results-list data-cy="results-list" />
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -141,6 +141,14 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/ResultsDetailPage.vue'),
       },
     ],
+    meta: {
+      breadcrumb: [
+        {
+          name: routesConf['results']['children']['name'],
+          path: routesConf['results']['path'],
+        },
+      ],
+    },
   },
   {
     path: routesConf['results_regularity']['path'],
@@ -152,6 +160,14 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/ResultsDetailPage.vue'),
       },
     ],
+    meta: {
+      breadcrumb: [
+        {
+          name: routesConf['results']['children']['name'],
+          path: routesConf['results']['path'],
+        },
+      ],
+    },
   },
   {
     path: routesConf['results_performance']['path'],
@@ -163,6 +179,14 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/ResultsDetailPage.vue'),
       },
     ],
+    meta: {
+      breadcrumb: [
+        {
+          name: routesConf['results']['children']['name'],
+          path: routesConf['results']['path'],
+        },
+      ],
+    },
   },
   {
     path: routesConf['community']['path'],

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -54,13 +54,22 @@ function coreTests() {
   it('renders page heading section', () => {
     cy.get('@i18n').then((i18n) => {
       // title
-      // TODO: Add results detail heading (breadcrumb variant)
-      cy.dataCy('results-detail-page-title')
+      cy.dataCy('breadcrumb-title');
+      cy.dataCy('breadcrumb-title')
         .should('be.visible')
         .then(($el) => {
           cy.wrap(i18n.global.t('results.titleResults')).then((translation) => {
-            expect($el.text()).to.equal(translation);
+            expect($el.text()).to.contain(translation);
           });
+        });
+      cy.dataCy('breadcrumb-title-current')
+        .should('be.visible')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('results.titleResultsYou')).then(
+            (translation) => {
+              expect($el.text()).to.contain(translation);
+            },
+          );
         });
     });
   });


### PR DESCRIPTION
Add BreadcrumbTitle component for displaying the title of the current page with breadcrumb.

* Breadcrumb is loaded from `route` object, predefined in `routes` file based on `routes_conf` file data.
* Pages are dynamically added within the component.
* Page titles in breadcrumb are translated based on the route `name` via i18n with translation key `breadcrumb`.

<img width="834" alt="breadcrumb-title" src="https://github.com/auto-mat/ride-to-work-by-bike-frontend/assets/42778183/93a8b34f-d295-4351-b678-8db6c2d4432d">
