### PR TITLE
src/components/global: refactor headings with new component SectionHeading

### DIFF
--- a/src/components/__tests__/ListCardFollow.cy.js
+++ b/src/components/__tests__/ListCardFollow.cy.js
@@ -62,7 +62,7 @@ describe('<ListCardFollow>', () => {
 function coreTests() {
   it('renders title', () => {
     cy.window().then(() => {
-      cy.dataCy('card-list-follow-title')
+      cy.dataCy('section-heading-title')
         .should('have.css', 'font-size', '20px')
         .and('have.css', 'font-weight', '500')
         .and('have.color', black)

--- a/src/components/__tests__/ListCardOffer.cy.js
+++ b/src/components/__tests__/ListCardOffer.cy.js
@@ -32,7 +32,7 @@ describe('<ListCardOffer>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('card-list-post-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)
@@ -82,7 +82,7 @@ describe('<ListCardOffer>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('card-list-post-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)

--- a/src/components/__tests__/ListCardPost.cy.js
+++ b/src/components/__tests__/ListCardPost.cy.js
@@ -126,7 +126,7 @@ describe('<ListCardPost>', () => {
 
 function coreTests() {
   it('renders title', () => {
-    cy.dataCy('card-list-post-title')
+    cy.dataCy('section-heading-title')
       .should('have.css', 'font-size', '20px')
       .and('have.css', 'font-weight', '500')
       .and('have.color', black)

--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -33,7 +33,7 @@ describe('<ListCardProgress>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('card-list-progress-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)

--- a/src/components/__tests__/ListCardSlider.cy.js
+++ b/src/components/__tests__/ListCardSlider.cy.js
@@ -60,11 +60,12 @@ function coreTests() {
       // component
       cy.dataCy('list-card-slider').should('be.visible');
       // title
-      cy.dataCy('list-card-slider-title')
+      cy.dataCy('list-card-slider-title').should('be.visible');
+      cy.dataCy('section-heading-title')
         .should('be.visible')
         .and('contain', listResultsPrizes.title);
       // perex
-      cy.dataCy('list-card-slider-perex')
+      cy.dataCy('section-heading-perex')
         .should('be.visible')
         .and('contain', listResultsPrizes.perex);
       // swiper

--- a/src/components/__tests__/NewsletterFeature.cy.js
+++ b/src/components/__tests__/NewsletterFeature.cy.js
@@ -32,13 +32,13 @@ describe('<NewsletterFeature>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('newsletter-feature-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)
           .and('contain', i18n.global.t('index.newsletterFeature.title'))
           .then(($title) => {
-            expect($title.text()).to.equal(
+            expect($title.text()).to.contain(
               i18n.global.t('index.newsletterFeature.title'),
             );
           });
@@ -47,13 +47,13 @@ describe('<NewsletterFeature>', () => {
 
     it('renders description', () => {
       cy.window().then(() => {
-        cy.dataCy('newsletter-feature-description')
+        cy.dataCy('section-heading-perex')
           .should('have.css', 'font-size', '14px')
           .and('have.css', 'font-weight', '400')
           .and('have.color', black)
           .and('contain', i18n.global.t('index.newsletterFeature.description'))
           .then(($title) => {
-            expect($title.text()).to.equal(
+            expect($title.text()).to.contain(
               i18n.global.t('index.newsletterFeature.description'),
             );
           });
@@ -114,13 +114,13 @@ describe('<NewsletterFeature>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('newsletter-feature-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)
           .and('contain', i18n.global.t('index.newsletterFeature.title'))
           .then(($title) => {
-            expect($title.text()).to.equal(
+            expect($title.text()).to.contain(
               i18n.global.t('index.newsletterFeature.title'),
             );
           });
@@ -129,13 +129,13 @@ describe('<NewsletterFeature>', () => {
 
     it('renders description', () => {
       cy.window().then(() => {
-        cy.dataCy('newsletter-feature-description')
+        cy.dataCy('section-heading-perex')
           .should('have.css', 'font-size', '14px')
           .and('have.css', 'font-weight', '400')
           .and('have.color', black)
           .and('contain', i18n.global.t('index.newsletterFeature.description'))
           .then(($title) => {
-            expect($title.text()).to.equal(
+            expect($title.text()).to.contain(
               i18n.global.t('index.newsletterFeature.description'),
             );
           });

--- a/src/components/__tests__/ResultsList.cy.js
+++ b/src/components/__tests__/ResultsList.cy.js
@@ -46,7 +46,7 @@ function coreTests() {
     // component
     cy.dataCy('results-list').should('be.visible');
     // title
-    cy.dataCy('results-list-title')
+    cy.dataCy('section-heading-title')
       .should('be.visible')
       .and('contain', i18n.global.t('results.titleYourResultsSince'));
     // button

--- a/src/components/__tests__/RoutesApps.cy.js
+++ b/src/components/__tests__/RoutesApps.cy.js
@@ -51,14 +51,16 @@ function coreTests() {
     // component
     cy.dataCy('routes-apps').should('be.visible');
     // title automatic
-    cy.dataCy('section-heading-title')
+    cy.dataCy('routes-apps-title-auto')
+      .find('[data-cy="section-heading-title"]')
       .should('be.visible')
       .and('have.css', 'font-size', '20px')
       .and('have.css', 'font-weight', '500')
       .and('have.color', black)
       .and('contain.text', i18n.global.t('routes.titleAutomaticLogging'));
     // hint automatic
-    cy.dataCy('section-heading-perex')
+    cy.dataCy('routes-apps-title-auto')
+      .find('[data-cy="section-heading-perex"]')
       .should('be.visible')
       .and('have.css', 'font-size', '14px')
       .and('have.css', 'font-weight', '400')
@@ -69,13 +71,15 @@ function coreTests() {
       .should('have.length', 3);
     // title manual
     cy.dataCy('routes-apps-title-manual')
+      .find('[data-cy="section-heading-title"]')
       .should('be.visible')
       .and('have.css', 'font-size', '20px')
       .and('have.css', 'font-weight', '500')
       .and('have.color', black)
       .and('contain.text', i18n.global.t('routes.titleManualLogging'));
     // hint manual
-    cy.dataCy('routes-apps-hint-manual')
+    cy.dataCy('routes-apps-title-manual')
+      .find('[data-cy="section-heading-perex"]')
       .should('be.visible')
       .and('have.css', 'font-size', '14px')
       .and('have.css', 'font-weight', '400')

--- a/src/components/__tests__/RoutesApps.cy.js
+++ b/src/components/__tests__/RoutesApps.cy.js
@@ -51,14 +51,14 @@ function coreTests() {
     // component
     cy.dataCy('routes-apps').should('be.visible');
     // title automatic
-    cy.dataCy('routes-apps-title-automatic')
+    cy.dataCy('section-heading-title')
       .should('be.visible')
       .and('have.css', 'font-size', '20px')
       .and('have.css', 'font-weight', '500')
       .and('have.color', black)
       .and('contain.text', i18n.global.t('routes.titleAutomaticLogging'));
     // hint automatic
-    cy.dataCy('routes-apps-hint-automatic')
+    cy.dataCy('section-heading-perex')
       .should('be.visible')
       .and('have.css', 'font-size', '14px')
       .and('have.css', 'font-weight', '400')

--- a/src/components/__tests__/RoutesBottomPanel.cy.js
+++ b/src/components/__tests__/RoutesBottomPanel.cy.js
@@ -38,7 +38,7 @@ describe('<RoutesBottomPanel>', () => {
 
     it('renders title', () => {
       // title visible
-      cy.dataCy('bottom-panel-title')
+      cy.dataCy('section-heading-title')
         .should('be.visible')
         .and('have.css', 'font-size', '20px')
         .and('have.css', 'font-weight', '500')
@@ -84,7 +84,7 @@ function coreTests() {
 function singleRouteTests() {
   it('renders title', () => {
     // title visible
-    cy.dataCy('bottom-panel-title')
+    cy.dataCy('section-heading-title')
       .should('be.visible')
       .and('have.css', 'font-size', '20px')
       .and('have.css', 'font-weight', '500')

--- a/src/components/__tests__/SectionHeading.cy.js
+++ b/src/components/__tests__/SectionHeading.cy.js
@@ -14,7 +14,7 @@ describe('<SectionHeading>', () => {
       cy.mount(SectionHeading, {
         props: {},
         slots: {
-          title: {
+          default: {
             render: () => title,
           },
           perex: {

--- a/src/components/__tests__/SectionHeading.cy.js
+++ b/src/components/__tests__/SectionHeading.cy.js
@@ -1,0 +1,61 @@
+import SectionHeading from 'components/global/SectionHeading.vue';
+import { i18n } from '../../boot/i18n';
+
+const title = 'Example title';
+const perex = 'Example perex';
+
+describe('<SectionHeading>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(SectionHeading, {
+        props: {},
+        slots: {
+          title: {
+            render: () => title,
+          },
+          perex: {
+            render: () => perex,
+          },
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(SectionHeading, {
+        props: {},
+        slots: {
+          default: {
+            render: () => title,
+          },
+          perex: {
+            render: () => perex,
+          },
+        },
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy('section-heading').should('be.visible');
+    cy.dataCy('section-heading-title')
+      .should('be.visible')
+      .and('contain', title);
+    cy.dataCy('section-heading-perex')
+      .should('be.visible')
+      .and('contain', perex);
+  });
+}

--- a/src/components/__tests__/SliderProgress.cy.js
+++ b/src/components/__tests__/SliderProgress.cy.js
@@ -40,7 +40,7 @@ describe('<SliderProgress>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('progress-slider-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)
@@ -177,7 +177,7 @@ describe('<SliderProgress>', () => {
 
     it('renders title', () => {
       cy.window().then(() => {
-        cy.dataCy('progress-slider-title')
+        cy.dataCy('section-heading-title')
           .should('have.css', 'font-size', '20px')
           .and('have.css', 'font-weight', '500')
           .and('have.color', black)

--- a/src/components/global/ListCardSlider.vue
+++ b/src/components/global/ListCardSlider.vue
@@ -19,6 +19,7 @@
  *
  * @components
  * - `CardPost`: Component to render individual post cards.
+ * - `SectionHeading`: Component to render section heading.
  *
  * @example
  * <list-card-slider
@@ -39,6 +40,7 @@ import { Screen } from 'quasar';
 import CardPost from '../homepage/CardPost.vue';
 import CardLocation from './CardLocation.vue';
 import CardPrize from './CardPrize.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // types
 import {
@@ -54,6 +56,7 @@ export default defineComponent({
     CardLocation,
     CardPost,
     CardPrize,
+    SectionHeading,
   },
   props: {
     title: {
@@ -105,15 +108,12 @@ export default defineComponent({
 <template>
   <div class="relative-position slider" data-cy="list-card-slider">
     <!-- Title -->
-    <h2
-      class="text-h6 q-mt-none text-weight-semibold"
-      data-cy="list-card-slider-title"
-    >
+    <section-heading class="q-mb-md" data-cy="list-card-slider-title">
       {{ title }}
-    </h2>
-    <div v-if="perex" class="q-my-md" data-cy="list-card-slider-perex">
-      <p>{{ perex }}</p>
-    </div>
+      <template #perex>
+        {{ perex }}
+      </template>
+    </section-heading>
     <!-- Swiper for cards -->
     <swiper-container
       :navigation="true"

--- a/src/components/global/SectionHeading.vue
+++ b/src/components/global/SectionHeading.vue
@@ -1,0 +1,49 @@
+<script lang="ts">
+/**
+ * SectionHeading Component
+ *
+ * @description * Use this component to render a heading for a section.
+ *
+ * @slots
+ * - `title`: For the title (optional).
+ * - `perex`: For the perex (optional).
+ *
+ * @example
+ * <section-heading>
+ *   <template #title>
+ *     Example title
+ *   </template>
+ *   <template #perex>
+ *     Example perex
+ *   </template>
+ * </section-heading>
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104327&t=lHmHLElQINQAhE9f-1)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'SectionHeading',
+});
+</script>
+
+<template>
+  <div v-if="$slots.default || $slots.perex" data-cy="section-heading">
+    <h2
+      v-if="$slots.default"
+      class="text-h6 text-black q-my-none"
+      data-cy="section-heading-title"
+    >
+      <slot />
+    </h2>
+    <div
+      v-if="$slots.perex"
+      class="q-mt-md text-subtitle2 text-black"
+      data-cy="section-heading-perex"
+    >
+      <slot name="perex"></slot>
+    </div>
+  </div>
+</template>

--- a/src/components/global/SectionHeading.vue
+++ b/src/components/global/SectionHeading.vue
@@ -40,7 +40,7 @@ export default defineComponent({
     </h2>
     <div
       v-if="$slots.perex"
-      class="q-mt-md text-subtitle2 text-black"
+      class="q-mt-md text-subtitle2 text-weight-regular text-black"
       data-cy="section-heading-perex"
     >
       <slot name="perex"></slot>

--- a/src/components/homepage/ListCardFollow.vue
+++ b/src/components/homepage/ListCardFollow.vue
@@ -15,6 +15,7 @@
  *
  * @components
  * - `CardFollow`: Component to render individual follow cards.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <list-card-follow :cards="followList" />
@@ -27,6 +28,7 @@ import { defineComponent } from 'vue';
 
 // components
 import CardFollow from './CardFollow.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // types
 import { CardFollow as CardFollowType } from '../types';
@@ -35,6 +37,7 @@ export default defineComponent({
   name: 'ListCardFollow',
   components: {
     CardFollow,
+    SectionHeading,
   },
   props: {
     cards: {
@@ -49,12 +52,9 @@ export default defineComponent({
   <div class="row q-col-gutter-lg items-center" data-cy="card-list-follow">
     <div class="col-12 col-lg-4" data-cy="card-list-follow-col-title">
       <!-- Title -->
-      <h2
-        class="text-h6 q-mt-none q-mb-none text-regular"
-        data-cy="card-list-follow-title"
-      >
+      <section-heading>
         {{ $t('index.cardListFollow.title') }}
-      </h2>
+      </section-heading>
     </div>
     <!-- List of folow cards -->
     <div

--- a/src/components/homepage/ListCardOffer.vue
+++ b/src/components/homepage/ListCardOffer.vue
@@ -16,6 +16,7 @@
  *
  * @components
  * - `CardOffer`: Component to render individual follow cards.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <list-card-offer :cards="followList" />
@@ -28,6 +29,7 @@ import { defineComponent, computed } from 'vue';
 
 // components
 import CardOffer from './CardOffer.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // types
 import { CardOffer as CardOfferType } from '../types';
@@ -36,6 +38,7 @@ export default defineComponent({
   name: 'ListCardOffer',
   components: {
     CardOffer,
+    SectionHeading,
   },
   props: {
     title: {
@@ -69,12 +72,9 @@ export default defineComponent({
 <template>
   <div>
     <!-- Title -->
-    <h2
-      class="text-h6 q-mt-none text-weight-semibold"
-      data-cy="card-list-post-title"
-    >
+    <section-heading class="q-mb-md">
       {{ title }}
-    </h2>
+    </section-heading>
     <!-- Cards grid -->
     <div class="row q-col-gutter-lg q-row-gutter-md" data-cy="list-card-offer">
       <div

--- a/src/components/homepage/ListCardPost.vue
+++ b/src/components/homepage/ListCardPost.vue
@@ -17,6 +17,7 @@
  *
  * @components
  * - `CardPost`: Component to render individual post cards.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <list-card-post
@@ -34,6 +35,7 @@ import { Screen } from 'quasar';
 
 // components
 import CardPost from './CardPost.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // types
 import { CardPost as CardPostType, Link } from '../types';
@@ -42,6 +44,7 @@ export default defineComponent({
   name: 'ListCardPost',
   components: {
     CardPost,
+    SectionHeading,
   },
   props: {
     title: {
@@ -76,12 +79,9 @@ export default defineComponent({
 <template>
   <div class="relative-position" data-cy="card-list-post">
     <!-- Title -->
-    <h2
-      class="text-h6 q-mt-none text-weight-semibold"
-      data-cy="card-list-post-title"
-    >
+    <section-heading class="q-mb-md">
       {{ title }}
-    </h2>
+    </section-heading>
     <!-- Swiper for news cards -->
     <swiper-container
       :navigation="true"

--- a/src/components/homepage/ListCardProgress.vue
+++ b/src/components/homepage/ListCardProgress.vue
@@ -20,6 +20,7 @@
  *
  * @components
  * - `CardProgress`: Component to render individual progress cards.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <list-card-progress
@@ -44,6 +45,7 @@ import {
 
 // components
 import CardProgress from './CardProgress.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 export default defineComponent({
   name: 'ListCardProgress',
@@ -66,6 +68,7 @@ export default defineComponent({
   },
   components: {
     CardProgress,
+    SectionHeading,
   },
 });
 </script>
@@ -76,9 +79,9 @@ export default defineComponent({
   <div>
     <div class="row q-col-gutter-lg" data-cy="card-list-progress">
       <!-- Title -->
-      <h2 class="col-sm-5 text-h6" data-cy="card-list-progress-title">
+      <section-heading class="col-sm-5" data-cy="card-list-progress-title">
         {{ title }}
-      </h2>
+      </section-heading>
       <!-- List of statistics -->
       <q-list
         class="col-sm-7 flex flex-wrap items-center justify-end q-pr-md gap-x-40"

--- a/src/components/homepage/NewsletterFeature.vue
+++ b/src/components/homepage/NewsletterFeature.vue
@@ -12,6 +12,7 @@
  *
  * @components
  * - `NewsletterItem`: Component to render individual newsletter details.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <newsletter-feature />
@@ -27,11 +28,13 @@ import { newsletterItems } from '../../mocks/homepage';
 
 // components
 import NewsletterItem from './NewsletterItem.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 export default defineComponent({
   name: 'NewsletterFeature',
   components: {
     NewsletterItem,
+    SectionHeading,
   },
   setup() {
     return {
@@ -64,15 +67,12 @@ export default defineComponent({
     <!-- Section content -->
     <div class="col-12 col-md-9 col-lg-10" data-cy="newsletter-col-content">
       <!-- Title -->
-      <h2 class="q-mb-md q-mt-none text-h6" data-cy="newsletter-feature-title">
+      <section-heading class="q-mb-md">
         {{ $t('index.newsletterFeature.title') }}
-      </h2>
-      <!-- Description -->
-      <p
-        class="q-my-md"
-        v-html="$t('index.newsletterFeature.description')"
-        data-cy="newsletter-feature-description"
-      ></p>
+        <template #perex>
+          {{ $t('index.newsletterFeature.description') }}
+        </template>
+      </section-heading>
       <div v-for="(item, index) in newsletterItems" :key="item.title">
         <!-- Item - subscription variant -->
         <newsletter-item :item="item" data-cy="newsletter-feature-item" />

--- a/src/components/homepage/SliderProgress.vue
+++ b/src/components/homepage/SliderProgress.vue
@@ -19,6 +19,7 @@
  *
  * @components
  * - `CardProgressSlider`: Component to render individual progress cards.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <slider-progress
@@ -37,6 +38,7 @@ import { Screen } from 'quasar';
 
 // components
 import CardProgressSlider from './CardProgressSlider.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // types
 import { CardProgress, Link, ItemStatistics } from '../types';
@@ -45,6 +47,7 @@ export default defineComponent({
   name: 'SliderProgress',
   components: {
     CardProgressSlider,
+    SectionHeading,
   },
   props: {
     title: {
@@ -83,9 +86,9 @@ export default defineComponent({
   <div class="progress-slider relative-position" data-cy="progress-slider">
     <div class="row q-col-gutter-lg">
       <!-- Title -->
-      <h2 class="col-sm-5 text-h6 q-my-none" data-cy="progress-slider-title">
+      <section-heading class="col-sm-5">
         {{ title }}
-      </h2>
+      </section-heading>
       <!-- List of statistics -->
       <q-list
         class="col-sm-7 flex flex-wrap items-center justify-end q-pr-md gap-x-40"

--- a/src/components/results/ResultsChallengeOngoing.vue
+++ b/src/components/results/ResultsChallengeOngoing.vue
@@ -13,6 +13,7 @@
  * - `CardProgressSlider`: Component to progress slider card.
  * - `CardStats`: Component to render a stat card.
  * - `SectionColumns`: Component to render content in columns.
+ * - `SectionHeading` Component to render a heading.
  *
  * @example
  * <results-challenge-ongoing />
@@ -30,6 +31,7 @@ import CardProgress from '../homepage/CardProgress.vue';
 import CardProgressSlider from '../homepage/CardProgressSlider.vue';
 import CardStats from '../homepage/CardStats.vue';
 import SectionColumns from '../homepage/SectionColumns.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // mocks
 import {
@@ -48,6 +50,7 @@ export default defineComponent({
     CardProgressSlider,
     CardStats,
     SectionColumns,
+    SectionHeading,
   },
   setup() {
     return {
@@ -65,12 +68,9 @@ export default defineComponent({
     <!-- Section: Current results -->
     <section>
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="current-results-title"
-      >
+      <section-heading data-cy="current-results-title">
         {{ $t('results.titleCurrentResults') }}
-      </h2>
+      </section-heading>
       <!-- Stats: Current results -->
       <section-columns
         :columns="3"
@@ -84,12 +84,9 @@ export default defineComponent({
     <!-- Section: Ongoing challenges -->
     <section class="q-mt-xl">
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="ongoing-challenges-title"
-      >
+      <section-heading data-cy="ongoing-challenges-title">
         {{ $t('results.titleOngoingChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Card: Featured challenge -->
       <div class="q-mt-lg">
         <card-progress-slider :card="cardsProgressSlider[0]" data-cy="card" />
@@ -100,9 +97,9 @@ export default defineComponent({
     <!-- Section: Badges -->
     <section class="q-pt-xl">
       <!-- Title -->
-      <h2 class="text-h6 q-my-none text-weight-bold" data-cy="badges-title">
+      <section-heading data-cy="badges-title">
         {{ $t('results.titleBadges') }}
-      </h2>
+      </section-heading>
       <!-- Button -->
       <section-columns
         :columns="3"
@@ -122,12 +119,9 @@ export default defineComponent({
     <!-- Section: Upcoming challenges -->
     <section class="q-mt-xl">
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="upcoming-challenges-title"
-      >
+      <section-heading data-cy="upcoming-challenges-title">
         {{ $t('results.titleUpcomingChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Cards: Challenge -->
       <section-columns
         :columns="3"
@@ -146,12 +140,9 @@ export default defineComponent({
     <!-- Section: Recent challenges -->
     <section class="q-mt-xl">
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="recent-challenges-title"
-      >
+      <section-heading data-cy="recent-challenges-title">
         {{ $t('results.titleRecentChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Cards: Recent challenge -->
       <section-columns
         :columns="3"
@@ -169,12 +160,9 @@ export default defineComponent({
     <!-- Section: Past challenges -->
     <section class="q-pt-xl">
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="past-challenges-title"
-      >
+      <section-heading data-cy="past-challenges-title">
         {{ $t('results.titlePastChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Button -->
       <div class="q-mt-lg">
         <q-btn

--- a/src/components/results/ResultsChallengeUpcoming.vue
+++ b/src/components/results/ResultsChallengeUpcoming.vue
@@ -10,6 +10,7 @@
  * - `BadgeAchievement`: Component to render a badge.
  * - `CardChallenge`: Component to challenge card.
  * - `SectionColumns`: Component to render content in columns.
+ * - `SectionHeading` Component to render a heading.
  *
  * @example
  * <results-challenge-upcoming />
@@ -24,6 +25,7 @@ import { defineComponent } from 'vue';
 import BadgeAchievement from '../homepage/BadgeAchievement.vue';
 import CardChallenge from '../homepage/CardChallenge.vue';
 import SectionColumns from '../homepage/SectionColumns.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // mocks
 import { badgeList, cardsChallenge } from '../../mocks/homepage';
@@ -34,6 +36,7 @@ export default defineComponent({
     BadgeAchievement,
     CardChallenge,
     SectionColumns,
+    SectionHeading,
   },
   setup() {
     return {
@@ -49,16 +52,13 @@ export default defineComponent({
     <!-- Section: Upcoming challenges -->
     <section>
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="upcoming-challenges-title"
-      >
+      <section-heading class="q-mb-md" data-cy="upcoming-challenges-title">
         {{ $t('results.titleUpcomingChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Cards: Challenge -->
       <section-columns
         :columns="3"
-        class="q-col-gutter-lg q-mt-sm"
+        class="q-col-gutter-lg"
         data-cy="upcoming-challenges"
       >
         <card-challenge
@@ -73,13 +73,13 @@ export default defineComponent({
     <!-- Section: Badges -->
     <section class="q-pt-xl">
       <!-- Title -->
-      <h2 class="text-h6 q-my-none text-weight-bold" data-cy="badges-title">
+      <section-heading class="q-mb-md" data-cy="badges-title">
         {{ $t('results.titleBadges') }}
-      </h2>
+      </section-heading>
       <!-- Badges: Achievement -->
       <section-columns
         :columns="4"
-        class="q-col-gutter-lg q-mt-sm"
+        class="q-col-gutter-lg"
         data-cy="badges-list"
       >
         <badge-achievement
@@ -95,14 +95,11 @@ export default defineComponent({
     <!-- Section: Past challenges -->
     <section class="q-pt-xl">
       <!-- Title -->
-      <h2
-        class="text-h6 q-my-none text-weight-bold"
-        data-cy="past-challenges-title"
-      >
+      <section-heading class="q-mb-md" data-cy="past-challenges-title">
         {{ $t('results.titlePastChallenges') }}
-      </h2>
+      </section-heading>
       <!-- Button -->
-      <div class="q-mt-lg">
+      <div>
         <q-btn
           rounded
           unelevated

--- a/src/components/results/ResultsList.vue
+++ b/src/components/results/ResultsList.vue
@@ -5,6 +5,9 @@
  * @description * Use this component to render set of results with title
  * and share link.
  *
+ * @components
+ * - `SectionHeading`: Component to render a heading.
+ *
  * @example
  * <results-list :results="results" />
  *
@@ -14,6 +17,9 @@
 // libraries
 import { date } from 'quasar';
 import { defineComponent } from 'vue';
+
+// components
+import SectionHeading from '../global/SectionHeading.vue';
 
 // composables
 import { i18n } from 'src/boot/i18n';
@@ -25,6 +31,9 @@ const { formatDate } = date;
 
 export default defineComponent({
   name: 'ResultsList',
+  components: {
+    SectionHeading,
+  },
   setup() {
     const date = new Date('Ocotober 17, 2024 13:00:00');
     const dateChallengeStart = formatDate(date, 'D. MMM. YYYY');
@@ -63,9 +72,9 @@ export default defineComponent({
     <!-- Section: Top -->
     <div class="row items-center gap-4 justify-between">
       <!-- Title -->
-      <h2 class="col-12 col-sm text-h6" data-cy="results-list-title">
+      <section-heading>
         {{ $t('results.titleYourResultsSince', { date: dateChallengeStart }) }}
-      </h2>
+      </section-heading>
       <!-- Button: Share -->
       <div class="col col-sm-auto text-right">
         <q-btn

--- a/src/components/routes/RoutesApps.vue
+++ b/src/components/routes/RoutesApps.vue
@@ -71,7 +71,7 @@ export default defineComponent({
       </div>
     </section>
     <!-- Section: Apps for manual logging -->
-    <section>
+    <section class="q-mt-md">
       <!-- Title -->
       <section-heading class="q-mb-md" data-cy="routes-apps-title-manual">
         {{ $t('routes.titleManualLogging') }}
@@ -79,13 +79,6 @@ export default defineComponent({
           {{ $t('routes.hintManualLogging') }}
         </template>
       </section-heading>
-      <h2 class="text-h6 text-black" data-cy="routes-apps-title-manual">
-        {{ $t('routes.titleManualLogging') }}
-      </h2>
-      <!-- Hint -->
-      <p class="" data-cy="routes-apps-hint-manual">
-        {{ $t('routes.hintManualLogging') }}
-      </p>
       <div class="flex item-center gap-16" data-cy="routes-apps-buttons">
         <!-- Button: Google Play -->
         <a

--- a/src/components/routes/RoutesApps.vue
+++ b/src/components/routes/RoutesApps.vue
@@ -6,6 +6,7 @@
  *
  * @components
  * - `BannerRoutesApp`: Component to display a banner for an App.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <routes-apps></routes-apps>
@@ -18,6 +19,7 @@ import { defineComponent } from 'vue';
 
 // components
 import BannerRoutesApp from './BannerRoutesApp.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -32,6 +34,7 @@ export default defineComponent({
   name: 'RoutesApps',
   components: {
     BannerRoutesApp,
+    SectionHeading,
   },
   setup() {
     const urlAppStore = rideToWorkByBikeConfig.urlAppStore;
@@ -51,13 +54,12 @@ export default defineComponent({
     <!-- Section: Apps for automatic logging -->
     <section>
       <!-- Title -->
-      <h2 class="text-h6 text-black" data-cy="routes-apps-title-automatic">
+      <section-heading class="q-mb-md">
         {{ $t('routes.titleAutomaticLogging') }}
-      </h2>
-      <!-- Hint -->
-      <p class="" data-cy="routes-apps-hint-automatic">
-        {{ $t('routes.hintAutomaticLogging') }}
-      </p>
+        <template #perex>
+          {{ $t('routes.hintAutomaticLogging') }}
+        </template>
+      </section-heading>
       <!-- App banners -->
       <div class="flex column gap-16">
         <banner-routes-app

--- a/src/components/routes/RoutesApps.vue
+++ b/src/components/routes/RoutesApps.vue
@@ -50,7 +50,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div data-cy="routes-apps">
+  <div data-cy="routes-apps" class="q-my-xl">
     <!-- Section: Apps for automatic logging -->
     <section>
       <!-- Title -->

--- a/src/components/routes/RoutesApps.vue
+++ b/src/components/routes/RoutesApps.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     <!-- Section: Apps for automatic logging -->
     <section>
       <!-- Title -->
-      <section-heading class="q-mb-md">
+      <section-heading class="q-mb-md" data-cy="routes-apps-title-auto">
         {{ $t('routes.titleAutomaticLogging') }}
         <template #perex>
           {{ $t('routes.hintAutomaticLogging') }}
@@ -73,6 +73,12 @@ export default defineComponent({
     <!-- Section: Apps for manual logging -->
     <section>
       <!-- Title -->
+      <section-heading class="q-mb-md" data-cy="routes-apps-title-manual">
+        {{ $t('routes.titleManualLogging') }}
+        <template #perex>
+          {{ $t('routes.hintManualLogging') }}
+        </template>
+      </section-heading>
       <h2 class="text-h6 text-black" data-cy="routes-apps-title-manual">
         {{ $t('routes.titleManualLogging') }}
       </h2>

--- a/src/components/routes/RoutesBottomPanel.vue
+++ b/src/components/routes/RoutesBottomPanel.vue
@@ -12,6 +12,7 @@
  *
  * @components
  * - `RouteItemEdit`: Component to display an editable route.
+ * - `SectionHeading`: Component to render a heading.
  *
  * @example
  * <routes-bottom-panel></routes-bottom-panel>
@@ -25,6 +26,7 @@ import { Screen } from 'quasar';
 
 // components
 import RouteItemEdit from './RouteItemEdit.vue';
+import SectionHeading from '../global/SectionHeading.vue';
 
 // fixtures
 import routeList from '../../../test/cypress/fixtures/routeList.json';
@@ -36,6 +38,7 @@ export default defineComponent({
   name: 'RoutesBottomPanel',
   components: {
     RouteItemEdit,
+    SectionHeading,
   },
   props: {
     isOpen: {
@@ -84,14 +87,11 @@ export default defineComponent({
       <!-- Section: Header -->
       <div class="row justify-between">
         <!-- Title -->
-        <h2
-          class="q-my-none text-h6 font-weight-normal"
-          data-cy="bottom-panel-title"
-        >
+        <section-heading>
           {{
             $tc('routes.titleBottomPanel', routeCount, { count: routeCount })
           }}
-        </h2>
+        </section-heading>
         <!-- Button: Close -->
         <q-btn
           dense

--- a/src/pages/CommunityPage.vue
+++ b/src/pages/CommunityPage.vue
@@ -23,6 +23,7 @@ import ForumPostList from 'src/components/community/ForumPostList.vue';
 import ListCardFollow from '../components/homepage/ListCardFollow.vue';
 import ListCardPost from 'src/components/homepage/ListCardPost.vue';
 import ListCardSlider from '../components/global/ListCardSlider.vue';
+import SectionHeading from 'src/components/global/SectionHeading.vue';
 
 // composables
 import { i18n } from 'src/boot/i18n';
@@ -48,6 +49,7 @@ export default defineComponent({
     ListCardFollow,
     ListCardPost,
     ListCardSlider,
+    SectionHeading,
   },
   setup() {
     const optionsCity: FormOption[] = [
@@ -125,9 +127,9 @@ export default defineComponent({
 
       <!-- Section: Local events -->
       <div class="q-mt-lg">
-        <h2 class="text-h6 q-my-none" data-cy="local-events-title">
+        <section-heading data-cy="local-events-title">
           {{ $t('community.titleLocalEvents') }}
-        </h2>
+        </section-heading>
         <div data-cy="local-events-list">
           <card-event
             v-for="card in events"

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -9,12 +9,9 @@
       </h1>
       <countdown-event :release-date="releaseDate" data-cy="countdown-event" />
       <!-- Title -->
-      <h2
-        class="text-h6 q-mt-none text-weight-bold q-pt-xl"
-        data-cy="card-list-title"
-      >
+      <section-heading class="q-pt-xl q-mb-md" data-cy="card-list-title">
         {{ $t('index.cardListChallenge.title') }}
-      </h2>
+      </section-heading>
       <section-columns
         :columns="3"
         class="q-col-gutter-lg q-pb-xl"
@@ -139,6 +136,7 @@ import ListCardPost from 'components/homepage/ListCardPost.vue';
 import ListCardProgress from 'components/homepage/ListCardProgress.vue';
 import NewsletterFeature from 'components/homepage/NewsletterFeature.vue';
 import SectionColumns from 'components/homepage/SectionColumns.vue';
+import SectionHeading from 'src/components/global/SectionHeading.vue';
 import SliderProgress from 'components/homepage/SliderProgress.vue';
 
 // mocks
@@ -157,17 +155,18 @@ export default defineComponent({
     BannerRoutes,
     CardChallenge,
     CardEvent,
+    CardStats,
     CountdownChallenge,
     CountdownEvent,
     HeadingBackground,
     ListCardFollow,
     ListCardOffer,
-    ListCardProgress,
-    SliderProgress,
     ListCardPost,
+    ListCardProgress,
     NewsletterFeature,
     SectionColumns,
-    CardStats,
+    SectionHeading,
+    SliderProgress,
   },
   setup() {
     const { challengeStartDate } = rideToWorkByBikeConfig;

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -18,6 +18,7 @@ import { defineComponent, ref } from 'vue';
 import CardOffer from '../components/homepage/CardOffer.vue';
 import CardPrize from 'src/components/global/CardPrize.vue';
 import SectionColumns from '../components/homepage/SectionColumns.vue';
+import SectionHeading from '../components/global/SectionHeading.vue';
 
 // fixtures
 import listCardsPrizes from '../../test/cypress/fixtures/listCardsPrizes.json';
@@ -33,6 +34,7 @@ export default defineComponent({
     CardOffer,
     CardPrize,
     SectionColumns,
+    SectionHeading,
   },
   setup() {
     const optionsCity: FormOption[] = [
@@ -102,23 +104,25 @@ export default defineComponent({
       </div>
 
       <!-- Section: Special offers -->
-      <div class="q-mt-lg">
-        <h2 class="text-h6 q-my-none" data-cy="discount-offers-title">
+      <div class="q-mt-xl">
+        <section-heading data-cy="discount-offers-title">
           {{ $t('prizes.titleSpecialOffers') }}
-        </h2>
-        <div class="q-mt-sm">
-          {{ $t('prizes.textSpecialOffers') }}
-        </div>
-        <div class="q-mt-lg" data-cy="discount-offers-list">
-          <section-columns :columns="3" class="q-col-gutter-lg">
-            <card-offer
-              v-for="card in prizesList"
-              :key="card.title"
-              :card="card"
-              data-cy="discount-offers-item"
-            />
-          </section-columns>
-        </div>
+          <template #perex>
+            {{ $t('prizes.textSpecialOffers') }}
+          </template>
+        </section-heading>
+        <section-columns
+          :columns="3"
+          class="q-col-gutter-lg q-mt-md"
+          data-cy="discount-offers-list"
+        >
+          <card-offer
+            v-for="card in prizesList"
+            :key="card.title"
+            :card="card"
+            data-cy="discount-offers-item"
+          />
+        </section-columns>
       </div>
 
       <!-- Section: Available prizes -->

--- a/test/cypress/e2e/community.spec.cy.js
+++ b/test/cypress/e2e/community.spec.cy.js
@@ -94,7 +94,8 @@ function coreTests() {
   it('renders a list of new posts', () => {
     cy.get('@i18n').then((i18n) => {
       cy.dataCy('list-card-post').should('be.visible');
-      cy.dataCy('card-list-post-title')
+      cy.dataCy('list-card-post')
+        .find('[data-cy="section-heading-title"]')
         .should('be.visible')
         .then(($el) => {
           cy.wrap(i18n.global.t('index.cardListPost.title')).then(

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -72,7 +72,7 @@ function coreTests() {
         .then(($el) => {
           cy.wrap(i18n.global.t('prizes.titleSpecialOffers')).then(
             (translation) => {
-              expect($el.text()).to.equal(translation);
+              expect($el.text()).to.contain(translation);
             },
           );
         });


### PR DESCRIPTION
Create central setting for a section heading (h2) via a component.

* Replace h2 headings with the same styling by the component across the codebase.
* When needed, update tests to use component CY handles.