### PR TITLE
test/cypress/e2e: fix failing routes test by avoiding redirection

### DIFF
--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -31,7 +31,7 @@ describe('Routes page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['routes']['path']);
+      cy.visit('#' + routesConf['routes_calendar']['path']);
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases


### PR DESCRIPTION
Issue: E2E tests sometimes fail on checking the content of the TabPanel component from Quasar.

This may be caused by the redirection of the `routes` path to `routes_calendar`, which secures the initial state for the tab component.

* Use `routes_calendar` config route to avoid redirection when tests are loaded (already implemented for desktop).