### PR TITLE
src/components/coordinator: add component HeaderOrganization to display info on coordinator page

### DIFF
--- a/src/components/__tests__/HeaderOrganization.cy.js
+++ b/src/components/__tests__/HeaderOrganization.cy.js
@@ -1,0 +1,89 @@
+import HeaderOrganization from 'components/coordinator/HeaderOrganization.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<HeaderOrganization>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.fixture('headerOrganization').then((organization) => {
+        cy.wrap(organization).as('organization');
+        cy.mount(HeaderOrganization, {
+          props: {
+            organization,
+          },
+        });
+        cy.viewport('macbook-16');
+      });
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.fixture('headerOrganization').then((organization) => {
+        cy.wrap(organization).as('organization');
+        cy.mount(HeaderOrganization, {
+          props: {
+            organization,
+          },
+        });
+        cy.viewport('iphone-6');
+      });
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.get('@organization').then((organization) => {
+      // component
+      cy.dataCy('header-organization').should('be.visible');
+      // image
+      cy.dataCy('header-organization-image').should('be.visible');
+      cy.testImageSrcAlt(
+        'header-organization-image',
+        organization.image.src,
+        organization.image.alt,
+      );
+      // title
+      cy.dataCy('header-organization-title')
+        .should('be.visible')
+        .and('contain', organization.title);
+      // branch count
+      cy.dataCy('header-organization-branch-count')
+        .should('be.visible')
+        .and('contain', organization.branches.length)
+        .and(
+          'contain',
+          i18n.global.tc(
+            'coordinator.labelBranches',
+            organization.branches.length,
+          ),
+        );
+      // member count
+      cy.dataCy('header-organization-member-count')
+        .should('be.visible')
+        .and('contain', organization.members.length)
+        .and(
+          'contain',
+          i18n.global.tc(
+            'coordinator.labelMembers',
+            organization.members.length,
+          ),
+        );
+      // button export
+      cy.dataCy('header-organization-button-export')
+        .should('be.visible')
+        .and('contain', i18n.global.t('coordinator.buttonExportMembers'));
+      cy.dataCy('header-organization-button-export')
+        .find('i')
+        .should('have.class', 'mdi-download');
+    });
+  });
+}

--- a/src/components/coordinator/HeaderOrganization.vue
+++ b/src/components/coordinator/HeaderOrganization.vue
@@ -10,6 +10,10 @@
  * - `organization` (Organization, required): The object representing an
  * organization. It should be of type `Organization`.
  *
+ * @emits
+ * - `export`: Emitted when the user clicks on the export button.
+ *   It should have no payload and be handled in the parent component.
+ *
  * @example
  * <header-organization />
  *
@@ -30,6 +34,7 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['export'],
   setup(props) {
     const countBranches = computed((): number => {
       return props.organization?.branches?.length
@@ -53,6 +58,7 @@ export default defineComponent({
 
 <template>
   <div class="row q-col-gutter-y-md items-center" data-cy="header-organization">
+    <!-- Organization data -->
     <div class="col-12 col-sm row q-col-gutter-x-md">
       <div class="col-auto">
         <!-- Image -->
@@ -115,6 +121,7 @@ export default defineComponent({
         </div>
       </div>
     </div>
+    <!-- Button: Export -->
     <div class="col-12 col-sm-auto">
       <q-btn
         unelevated
@@ -123,6 +130,7 @@ export default defineComponent({
         color="primary"
         class="flex items-center"
         data-cy="header-organization-button-export"
+        @click.prevent="$emit('export')"
       >
         <q-icon name="mdi-download" size="18px" class="q-mr-sm" />
         {{ $t('coordinator.buttonExportMembers') }}

--- a/src/components/coordinator/HeaderOrganization.vue
+++ b/src/components/coordinator/HeaderOrganization.vue
@@ -1,0 +1,132 @@
+<script lang="ts">
+/**
+ * HeaderOrganization Component
+ *
+ * @description * Use this component to display information about an
+ * organization.
+ * Note: This component is commonly used on `CompanyCoordinatorPage`.
+ *
+ * @props
+ * - `organization` (Organization, required): The object representing an
+ * organization. It should be of type `Organization`.
+ *
+ * @example
+ * <header-organization />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104524&t=imgBE8Jw7Jgty90T-1)
+ */
+
+// libraries
+import { computed, defineComponent } from 'vue';
+
+// types
+import type { Organization } from '../types/Organization';
+
+export default defineComponent({
+  name: 'HeaderOrganization',
+  props: {
+    organization: {
+      type: Object as () => Organization,
+      required: true,
+    },
+  },
+  setup(props) {
+    const countBranches = computed((): number => {
+      return props.organization?.branches?.length
+        ? props.organization.branches.length
+        : 0;
+    });
+
+    const countMembers = computed((): number => {
+      return props.organization?.members?.length
+        ? props.organization.members.length
+        : 0;
+    });
+
+    return {
+      countBranches,
+      countMembers,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="row q-col-gutter-y-md items-center" data-cy="header-organization">
+    <div class="col-12 col-sm row q-col-gutter-x-md">
+      <div class="col-auto">
+        <!-- Image -->
+        <q-avatar data-cy="header-organization-image" size="96px">
+          <q-img
+            v-if="organization.image"
+            :src="organization.image.src"
+            ratio="1"
+            width="96"
+            height="96"
+            :alt="organization.image.alt"
+          />
+          <q-icon v-else name="mdi-office-building" size="96px" />
+        </q-avatar>
+      </div>
+      <div class="col">
+        <div class="q-pt-sm">
+          <!-- Title -->
+          <h3
+            class="text-h5 text-weight-bold q-my-none"
+            data-cy="header-organization-title"
+          >
+            {{ organization.title }}
+          </h3>
+          <!-- Metadata -->
+          <div class="row text-subtitle2">
+            <!-- Organization ID -->
+            <q-item dense class="col-auto q-pa-none">
+              <q-item-section v-if="organization.identificationNumber">
+                <!-- Label -->
+                {{ $t('coordinator.labelOrganizationId') }}:
+                {{ organization.identificationNumber }}
+              </q-item-section>
+            </q-item>
+            <!-- Branch -->
+            <q-item dense class="col-auto q-pa-none" v-if="countBranches">
+              <q-item-section avatar>
+                <!-- Icon -->
+                <q-icon name="mdi-office-building" color="grey-6" size="18px" />
+              </q-item-section>
+              <q-item-section data-cy="header-organization-branch-count">
+                <!-- Label -->
+                {{ countBranches }}
+                {{ $tc('coordinator.labelBranches', countBranches) }}
+              </q-item-section>
+            </q-item>
+            <!-- Members -->
+            <q-item dense class="col-auto q-pa-none" v-if="countMembers">
+              <q-item-section avatar>
+                <!-- Icon -->
+                <q-icon name="mdi-account" color="grey-6" size="18px" />
+              </q-item-section>
+              <q-item-section data-cy="header-organization-member-count">
+                <!-- Label -->
+                {{ countMembers }}
+                {{ $tc('coordinator.labelMembers', countMembers) }}
+              </q-item-section>
+            </q-item>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-sm-auto">
+      <q-btn
+        unelevated
+        rounded
+        outline
+        color="primary"
+        class="flex items-center"
+        data-cy="header-organization-button-export"
+      >
+        <q-icon name="mdi-download" size="18px" class="q-mr-sm" />
+        {{ $t('coordinator.buttonExportMembers') }}
+      </q-btn>
+    </div>
+  </div>
+</template>

--- a/src/components/coordinator/HeaderOrganization.vue
+++ b/src/components/coordinator/HeaderOrganization.vue
@@ -61,8 +61,8 @@ export default defineComponent({
     <!-- Organization data -->
     <div class="col-12 col-sm row q-col-gutter-x-md">
       <div class="col-auto">
-        <!-- Image -->
         <q-avatar data-cy="header-organization-image" size="96px">
+          <!-- Image -->
           <q-img
             v-if="organization.image"
             :src="organization.image.src"
@@ -71,6 +71,7 @@ export default defineComponent({
             height="96"
             :alt="organization.image.alt"
           />
+          <!-- Fallback icon -->
           <q-icon v-else name="mdi-office-building" size="96px" />
         </q-avatar>
       </div>

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -1,0 +1,21 @@
+import { Image } from './Image';
+
+export interface OrganizationBranch {
+  id: string;
+  title: string;
+}
+
+export interface OrganizationMember {
+  id: string;
+  name: string;
+}
+
+export interface Organization {
+  branches: OrganizationBranch[];
+  description?: string;
+  id: string;
+  identificationNumber: string;
+  image?: Image;
+  members: OrganizationMember[];
+  title: string;
+}

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -60,6 +60,10 @@ titleBecomeCoordinator = "Stát se firemní*m koordinátorem*kou"
 [coordinator]
 buttonBannerReminderConfirm = "Oznámil"
 buttonBannerReminderDismiss = "Zatím neoznámil"
+buttonExportMembers = "Exportovat členy"
+labelBranches = "pobočka | poboček"
+labelMembers = "člen | členů"
+labelOrganizationId = "IČO"
 textBannerReminder = "Oznámil jste již firmě, že jste kooridnátorem?"
 
 [language]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -60,6 +60,10 @@ titleBecomeCoordinator = "Become a company coordinator"
 [coordinator]
 buttonBannerReminderConfirm = "Yes"
 buttonBannerReminderDismiss = "Not yet"
+buttonExportMembers = "Export members"
+labelBranches = "branch | branches"
+labelMembers = "member | members"
+labelOrganizationId = "ID"
 textBannerReminder = "Have you notified the company that you are a coordinator?"
 
 [language]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -60,6 +60,10 @@ titleBecomeCoordinator = "Staňte sa firemným koordinátorom"
 [coordinator]
 buttonBannerReminderConfirm = "Oznámil"
 buttonBannerReminderDismiss = "Zatiaľ neoznámil"
+buttonExportMembers = "Exportovať členy"
+labelBranches = "pobočka | pobočky"
+labelMembers = "člen | členovia"
+labelOrganizationId = "ID"
 textBannerReminder = "Oznámili ste spoločnosti, že ste koordinátor?"
 
 [language]

--- a/test/cypress/fixtures/headerOrganization.json
+++ b/test/cypress/fixtures/headerOrganization.json
@@ -1,0 +1,28 @@
+{
+  "title": "Auto*Mat, z. s.",
+  "identificationNumber": "22670319",
+  "branches": [
+    {
+      "id": "001",
+      "title": "Pobočka 1"
+    }
+  ],
+  "image": {
+    "src": "https://picsum.photos/id/70/96/96",
+    "alt": "road lined with trees"
+  },
+  "members": [
+    {
+      "id": "001",
+      "name": "Petr"
+    },
+    {
+      "id": "002",
+      "name": "Pavel"
+    },
+    {
+      "id": "003",
+      "name": "Marta"
+    }
+  ]
+}


### PR DESCRIPTION
Add component `HeaderOrganization` with basic information about an organization.

This is shown on the company coordinator page above the team/members table.

* Add fixture
* Add types `Organization`, `OrganizationMember` and `OrganizationBranch` (these may be extended in the future)
* Add translations
* Add tests

<img width="718" alt="Screenshot 2024-06-13 at 18 28 54" src="https://github.com/auto-mat/ride-to-work-by-bike-frontend/assets/42778183/39fbf694-c925-4fe1-82c1-8d4d2b952524">
