### PR TITLE
src/components/global: add component BannerInfo to display general info component

### DIFF
--- a/src/components/__tests__/BannerInfo.cy.js
+++ b/src/components/__tests__/BannerInfo.cy.js
@@ -48,12 +48,9 @@ function coreTests() {
       // component
       cy.dataCy('banner-info').should('be.visible');
       // icon
-      cy.dataCy('banner-info-icon')
-        .should('be.visible')
-        .and(($icon) => {
-          expect($icon[0].naturalWidth).to.be.greaterThan(0);
-          expect($icon[0].naturalHeight).to.be.greaterThan(0);
-        });
+      cy.dataCy('banner-info-icon').should('be.visible');
+      cy.dataCy('banner-info-icon').invoke('height').should('be.equal', 96);
+      cy.dataCy('banner-info-icon').invoke('width').should('be.equal', 96);
       // title
       cy.dataCy('banner-info-title')
         .should('be.visible')

--- a/src/components/__tests__/BannerInfo.cy.js
+++ b/src/components/__tests__/BannerInfo.cy.js
@@ -50,7 +50,10 @@ function coreTests() {
       // icon
       cy.dataCy('banner-info-icon')
         .should('be.visible')
-        .and('have.css', 'font-size', '96px');
+        .and(($icon) => {
+          expect($icon[0].naturalWidth).to.be.greaterThan(0);
+          expect($icon[0].naturalHeight).to.be.greaterThan(0);
+        });
       // title
       cy.dataCy('banner-info-title')
         .should('be.visible')

--- a/src/components/__tests__/BannerInfo.cy.js
+++ b/src/components/__tests__/BannerInfo.cy.js
@@ -1,0 +1,70 @@
+import BannerInfo from 'components/global/BannerInfo.vue';
+
+describe('<BannerInfo>', () => {
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.fixture('bannerInfo').then((bannerInfo) => {
+        cy.wrap(bannerInfo).as('bannerInfo');
+        cy.mount(BannerInfo, {
+          props: {
+            title: bannerInfo.title,
+            icon: bannerInfo.icon,
+          },
+          slots: {
+            default: bannerInfo.content,
+          },
+        });
+        cy.viewport('macbook-16');
+      });
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.fixture('bannerInfo').then((bannerInfo) => {
+        cy.wrap(bannerInfo).as('bannerInfo');
+        cy.mount(BannerInfo, {
+          props: {
+            title: bannerInfo.title,
+            icon: bannerInfo.icon,
+          },
+          slots: {
+            default: bannerInfo.content,
+          },
+        });
+        cy.viewport('iphone-6');
+      });
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.get('@bannerInfo').then((bannerInfo) => {
+      // component
+      cy.dataCy('banner-info').should('be.visible');
+      // icon
+      cy.dataCy('banner-info-icon')
+        .should('be.visible')
+        .and('have.css', 'font-size', '96px');
+      // title
+      cy.dataCy('banner-info-title')
+        .should('be.visible')
+        .and('have.css', 'font-size', '20px')
+        .and('contain', bannerInfo.title);
+      // content
+      cy.dataCy('banner-info-content')
+        .should('be.visible')
+        .then(($el) => {
+          const content = $el.text();
+          cy.stripHtmlTags(bannerInfo.content).then((text) => {
+            expect(content).to.equal(text);
+          });
+        });
+    });
+  });
+}

--- a/src/components/global/BannerInfo.vue
+++ b/src/components/global/BannerInfo.vue
@@ -1,0 +1,77 @@
+<script lang="ts">
+/**
+ * BannerInfo Component
+ *
+ * @description * Use this component to show info banner.
+ *
+ * @props
+ * - `title` (string, required): banner title.
+ * - `icon` (string, required): banner icon.
+ *
+ * @slots
+ * - `content`: For displaying the content of the banner.
+ *
+ * @example
+ * <banner-info />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-105324&t=CGsDXzO5CQmHvfCf-1)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+// config
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
+export default defineComponent({
+  name: 'BannerInfo',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    const { borderRadiusCard: borderRadius } = rideToWorkByBikeConfig;
+
+    return { borderRadius };
+  },
+});
+</script>
+
+<template>
+  <div
+    class="bg-grey-1 q-px-lg q-py-lg"
+    :style="{ 'border-radius': borderRadius }"
+    data-cy="banner-info"
+  >
+    <div class="row q-col-gutter-lg">
+      <div v-if="icon" class="col-12 col-sm-auto">
+        <!-- Icon -->
+        <q-icon
+          :name="icon"
+          size="96px"
+          color="primary"
+          data-cy="banner-info-icon"
+        />
+      </div>
+      <div class="col-12 col-sm">
+        <!-- Title -->
+        <div
+          class="text-h6 text-weight-bold q-my-none"
+          data-cy="banner-info-title"
+        >
+          {{ title }}
+        </div>
+        <!-- Content -->
+        <div class="q-mt-md" data-cy="banner-info-content">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/global/BannerInfo.vue
+++ b/src/components/global/BannerInfo.vue
@@ -4,6 +4,8 @@
  *
  * @description * Use this component to show info banner.
  *
+ * Note: This component is commonly used on `CompanyCoordinatorPage`.
+ *
  * @props
  * - `title` (string, required): banner title.
  * - `icon` (string, required): banner icon.

--- a/test/cypress/fixtures/bannerInfo.json
+++ b/test/cypress/fixtures/bannerInfo.json
@@ -1,0 +1,5 @@
+{
+  "title": "Způsob placení",
+  "icon": "mdi-credit-card",
+  "content": "<p>Při placení startovného postupujte následovně:</p><ol><li>Pro každou fakturu vytvořte samostatný převod.</li><li>Pečlivě z faktury opište <b>číslo účtu</b>.</li><li>Zadejte <b>variabilní symbol</b> z tabulky níže. V opačném případě neručíme za úspěšné přijetí.</li></ol>"
+}


### PR DESCRIPTION
Add component BannerInfo to show info boxes. Used on `CompanyCoordinatorPage`.
Title and icon are passed through props and content through slot for flexibility.

* Add fixture
* Add tests

<img width="610" alt="Screenshot 2024-06-13 at 21 50 45" src="https://github.com/auto-mat/ride-to-work-by-bike-frontend/assets/42778183/2521c3c9-344b-4fdd-9f76-04e0a0e75995">
