### PR TITLE
src/router: refactor the nested routes definition

### DIFF
--- a/src/components/global/BreadcrumbTitle.vue
+++ b/src/components/global/BreadcrumbTitle.vue
@@ -36,18 +36,28 @@ export default defineComponent({
 
     /**
      * Get the list of breadcrumb pages from the route meta object.
-     * An array of matched routes is returned in route.matched.
-     * First item in the array contains data defined in `routes.ts`.
-     * Meta object is used to store breadcrumbs data.
+     * Route matched returns a hierarchy of routes.
+     * If specific breadcrumb structure is defined in route meta, use it.
+     * Otherwise, use the hierarchy of routes.
      * @returns BreadcrumbPage[]
      */
     const pages = computed((): BreadcrumbPage[] => {
-      // get meta object
-      if (!route?.matched.length || !route.matched[0]?.meta?.breadcrumb)
-        return [];
-      const breadcrumb = route.matched[0].meta.breadcrumb;
-      if (!Array.isArray(breadcrumb)) return [];
-      return breadcrumb;
+      // If matched returns a single route or nothing, return an empty array
+      if (!route?.matched.length || route?.matched.length === 1) return [];
+      // Breadcrumbs defined in `routes.ts`
+      const current = route.matched.find((r) => r.path == route.path);
+      if (current && current.meta && current.meta.breadcrumb) {
+        return current.meta.breadcrumb as BreadcrumbPage[];
+      }
+      // Default page hierarchy
+      else {
+        return route.matched.map(
+          (r): BreadcrumbPage => ({
+            path: r.path || '',
+            name: String(r.name) || '',
+          }),
+        );
+      }
     });
 
     return {

--- a/src/components/global/DrawerMenu.vue
+++ b/src/components/global/DrawerMenu.vue
@@ -43,7 +43,7 @@ export default defineComponent({
     <q-item
       v-for="item in menuTop"
       :key="item.name"
-      :to="item.url"
+      :to="{ name: item.name }"
       active-class="menu-active-item"
       class="flex items-center"
       clickable
@@ -51,7 +51,7 @@ export default defineComponent({
       <!-- Link icon -->
       <q-icon :name="item.icon" size="xs" color="blue-grey-4" class="q-mr-sm" />
       <!-- Link text -->
-      {{ $t(`drawerMenu.${item.name}`) }}
+      {{ $t(`drawerMenu.${item.title}`) }}
     </q-item>
 
     <q-separator color="blue-grey-2 q-my-sm" />
@@ -67,7 +67,7 @@ export default defineComponent({
       <!-- Link icon -->
       <q-icon :name="item.icon" size="xs" color="blue-grey-4" class="q-mr-sm" />
       <!-- Link text -->
-      {{ $t(`drawerMenu.${item.name}`) }}
+      {{ $t(`drawerMenu.${item.title}`) }}
     </q-item>
   </q-list>
 </template>

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -55,7 +55,7 @@ export default defineComponent({
       <q-item
         v-for="item in menuPanel"
         :key="item.name"
-        :to="item.url"
+        :to="{ name: item.name }"
         clickable
         v-ripple
         class="q-pa-sm"
@@ -66,7 +66,7 @@ export default defineComponent({
           <q-icon :name="item.icon" size="24px"></q-icon>
           <!-- Label -->
           <q-item-label class="text-caption text-grey-10">{{
-            $t(`drawerMenu.${item.name}`)
+            $t(`drawerMenu.${item.title}`)
           }}</q-item-label>
         </div>
       </q-item>
@@ -102,7 +102,7 @@ export default defineComponent({
       <q-item
         v-for="item in menuTop.slice(4)"
         :key="item.name"
-        :to="item.url"
+        :to="{ name: item.name }"
         clickable
         v-ripple
         class="q-py-sm q-px-md"
@@ -115,7 +115,7 @@ export default defineComponent({
         <!-- Label -->
         <q-item-section>
           <q-item-label class="text-caption text-grey-10">{{
-            $t(`drawerMenu.${item.name}`)
+            $t(`drawerMenu.${item.title}`)
           }}</q-item-label>
         </q-item-section>
       </q-item>
@@ -126,7 +126,7 @@ export default defineComponent({
       <q-item
         v-for="item in menuBottom"
         :key="item.name"
-        :to="item.url"
+        :to="{ name: item.name }"
         clickable
         v-ripple
         class="q-py-sm q-px-md items-center"
@@ -139,7 +139,7 @@ export default defineComponent({
         <!-- Label -->
         <q-item-section>
           <q-item-label class="text-caption text-grey-10">{{
-            $t(`drawerMenu.${item.name}`)
+            $t(`drawerMenu.${item.title}`)
           }}</q-item-label>
         </q-item-section>
       </q-item>

--- a/src/mocks/layout.ts
+++ b/src/mocks/layout.ts
@@ -1,5 +1,6 @@
 import { Link, User } from 'src/components/types';
 import { i18n } from 'src/boot/i18n';
+import { routesConf } from 'src/router/routes_conf';
 
 export const user: User = {
   label: 'User 1',
@@ -12,27 +13,27 @@ export const user: User = {
 
 export const menuTop: Link[] = [
   {
-    url: '/',
+    url: routesConf['home']['path'],
     icon: 'home',
     name: 'home',
   },
   {
-    url: '/routes',
+    url: routesConf['routes']['path'],
     icon: 'route',
     name: 'routes',
   },
   {
-    url: '/results',
+    url: routesConf['results']['path'],
     icon: 'emoji_events',
     name: 'results',
   },
   {
-    url: '/community',
+    url: routesConf['community']['path'],
     icon: 'people',
     name: 'community',
   },
   {
-    url: '/prizes',
+    url: routesConf['prizes']['path'],
     icon: 'verified',
     name: 'discounts',
   },

--- a/src/mocks/layout.ts
+++ b/src/mocks/layout.ts
@@ -1,6 +1,5 @@
 import { Link, User } from 'src/components/types';
 import { i18n } from 'src/boot/i18n';
-import { routesConf } from 'src/router/routes_conf';
 
 export const user: User = {
   label: 'User 1',
@@ -13,52 +12,61 @@ export const user: User = {
 
 export const menuTop: Link[] = [
   {
-    url: routesConf['home']['path'],
+    url: '',
     icon: 'home',
     name: 'home',
+    title: 'home',
   },
   {
-    url: routesConf['routes']['path'],
+    url: '',
     icon: 'route',
     name: 'routes',
+    title: 'routes',
   },
   {
-    url: routesConf['results']['path'],
+    url: '',
     icon: 'emoji_events',
     name: 'results',
+    title: 'results',
   },
   {
-    url: routesConf['community']['path'],
+    url: '',
     icon: 'people',
     name: 'community',
+    title: 'community',
   },
   {
-    url: routesConf['prizes']['path'],
+    url: '',
     icon: 'verified',
-    name: 'discounts',
+    name: 'prizes',
+    title: 'discounts',
   },
   {
-    url: '/company-coordinator',
+    url: '',
     icon: 'business',
-    name: 'coordinator',
+    name: 'company-coordinator',
+    title: 'coordinator',
   },
   {
-    url: '/profil',
+    url: '',
     icon: 'account_circle',
     name: 'profile',
+    title: 'profile',
   },
 ];
 
 export const menuBottom: Link[] = [
   {
-    url: '/invite',
+    url: '',
     icon: 'email',
-    name: 'inviteFriends',
+    name: 'invite',
+    title: 'inviteFriends',
   },
   {
-    url: '/routes',
+    url: '',
     icon: 'volunteer_activism',
     name: 'donate',
+    title: 'donate',
   },
 ];
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -141,7 +141,9 @@ const routes: RouteRecordRaw[] = [
         path: routesConf['results_detail']['path'],
         name: routesConf['results_detail']['children']['name'],
         component: () => import('pages/ResultsDetailPage.vue'),
-        redirect: { name: routesConf['results_report']['children']['name'] },
+        redirect: {
+          name: routesConf['results_report']['children']['name'],
+        },
         children: [
           {
             path: routesConf['results_report']['path'],

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -14,6 +14,28 @@ const routes: RouteRecordRaw[] = [
     ],
   },
   {
+    path: routesConf['community']['path'],
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['community']['children']['name'],
+        component: () => import('pages/CommunityPage.vue'),
+      },
+    ],
+  },
+  {
+    path: routesConf['login']['path'],
+    component: () => import('layouts/LoginRegisterLayout.vue'),
+    children: [
+      {
+        path: '',
+        name: routesConf['login']['children']['name'],
+        component: () => import('pages/LoginPage.vue'),
+      }
+    ]
+  },
+  {
     path: routesConf['company_coordinator']['path'],
     component: () => import('layouts/MainLayout.vue'),
     children: [
@@ -37,60 +59,31 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: routesConf['routes']['path'],
-    redirect: routesConf['routes_calendar']['path'],
-  },
-  {
-    path: routesConf['routes_calendar']['path'],
     component: () => import('layouts/MainLayout.vue'),
+    redirect:
+      routesConf['routes']['path'] +
+      '/' +
+      routesConf['routes_calendar']['path'],
     children: [
       {
-        path: '',
+        path: routesConf['routes_calendar']['path'],
         name: routesConf['routes_calendar']['children']['name'],
         component: () => import('pages/RoutesPage.vue'),
       },
-    ],
-  },
-  {
-    path: routesConf['routes_list']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
       {
-        path: '',
+        path: routesConf['routes_list']['path'],
         name: routesConf['routes_list']['children']['name'],
         component: () => import('pages/RoutesPage.vue'),
       },
-    ],
-  },
-  {
-    path: routesConf['routes_map']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
       {
-        path: '',
+        path: routesConf['routes_map']['path'],
         name: routesConf['routes_map']['children']['name'],
         component: () => import('pages/RoutesPage.vue'),
       },
-    ],
-  },
-  {
-    path: routesConf['routes_app']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
       {
-        path: '',
+        path: routesConf['routes_app']['path'],
         name: routesConf['routes_app']['children']['name'],
         component: () => import('pages/RoutesPage.vue'),
-      },
-    ],
-  },
-  {
-    path: routesConf['login']['path'],
-    component: () => import('layouts/LoginRegisterLayout.vue'),
-    children: [
-      {
-        path: '',
-        name: routesConf['login']['children']['name'],
-        component: () => import('pages/LoginPage.vue'),
       },
     ],
   },
@@ -136,77 +129,57 @@ const routes: RouteRecordRaw[] = [
         name: routesConf['results']['children']['name'],
         component: () => import('pages/ResultsPage.vue'),
       },
-    ],
-  },
-  {
-    path: routesConf['results_detail']['path'],
-    redirect: routesConf['results_report']['path'],
-  },
-  {
-    path: routesConf['results_report']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
       {
-        path: '',
-        name: routesConf['results_report']['children']['name'],
+        path: routesConf['results_detail']['path'],
+        name: routesConf['results_detail']['children']['name'],
         component: () => import('pages/ResultsDetailPage.vue'),
-      },
-    ],
-    meta: {
-      breadcrumb: [
-        {
-          name: routesConf['results']['children']['name'],
-          path: routesConf['results']['path'],
-        },
-      ],
-    },
-  },
-  {
-    path: routesConf['results_regularity']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
-      {
-        path: '',
-        name: routesConf['results_regularity']['children']['name'],
-        component: () => import('pages/ResultsDetailPage.vue'),
-      },
-    ],
-    meta: {
-      breadcrumb: [
-        {
-          name: routesConf['results']['children']['name'],
-          path: routesConf['results']['path'],
-        },
-      ],
-    },
-  },
-  {
-    path: routesConf['results_performance']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
-      {
-        path: '',
-        name: routesConf['results_performance']['children']['name'],
-        component: () => import('pages/ResultsDetailPage.vue'),
-      },
-    ],
-    meta: {
-      breadcrumb: [
-        {
-          name: routesConf['results']['children']['name'],
-          path: routesConf['results']['path'],
-        },
-      ],
-    },
-  },
-  {
-    path: routesConf['community']['path'],
-    component: () => import('layouts/MainLayout.vue'),
-    children: [
-      {
-        path: '',
-        name: routesConf['community']['children']['name'],
-        component: () => import('pages/CommunityPage.vue'),
+        redirect:
+          routesConf['results']['path'] +
+          '/' +
+          routesConf['results_detail']['path'] +
+          '/' +
+          routesConf['results_report']['path'],
+        children: [
+          {
+            path: routesConf['results_report']['path'],
+            name: routesConf['results_report']['children']['name'],
+            component: () => import('pages/ResultsDetailPage.vue'),
+            meta: {
+              breadcrumb: [
+                {
+                  path: routesConf['results']['path'],
+                  name: routesConf['results']['children']['name'],
+                },
+              ],
+            },
+          },
+          {
+            path: routesConf['results_regularity']['path'],
+            name: routesConf['results_regularity']['children']['name'],
+            component: () => import('pages/ResultsDetailPage.vue'),
+            meta: {
+              breadcrumb: [
+                {
+                  path: routesConf['results']['path'],
+                  name: routesConf['results']['children']['name'],
+                },
+              ],
+            },
+          },
+          {
+            path: routesConf['results_performance']['path'],
+            name: routesConf['results_performance']['children']['name'],
+            component: () => import('pages/ResultsDetailPage.vue'),
+            meta: {
+              breadcrumb: [
+                {
+                  path: routesConf['results']['path'],
+                  name: routesConf['results']['children']['name'],
+                },
+              ],
+            },
+          },
+        ],
       },
     ],
   },

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -66,6 +66,7 @@ const routes: RouteRecordRaw[] = [
   {
     path: routesConf['routes']['path'],
     component: () => import('layouts/MainLayout.vue'),
+    name: routesConf['routes']['children']['name'],
     redirect: { name: routesConf['routes_calendar']['children']['name'] },
     children: [
       {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -2,6 +2,7 @@ import type { RouteRecordRaw } from 'vue-router';
 import { routesConf } from './routes_conf';
 
 const routes: RouteRecordRaw[] = [
+  // home
   {
     path: routesConf['home']['path'],
     component: () => import('layouts/MainLayout.vue'),
@@ -13,6 +14,7 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // community
   {
     path: routesConf['community']['path'],
     component: () => import('layouts/MainLayout.vue'),
@@ -24,6 +26,7 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // login
   {
     path: routesConf['login']['path'],
     component: () => import('layouts/LoginRegisterLayout.vue'),
@@ -32,9 +35,10 @@ const routes: RouteRecordRaw[] = [
         path: '',
         name: routesConf['login']['children']['name'],
         component: () => import('pages/LoginPage.vue'),
-      }
-    ]
+      },
+    ],
   },
+  // company coordinator
   {
     path: routesConf['company_coordinator']['path'],
     component: () => import('layouts/MainLayout.vue'),
@@ -46,6 +50,7 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // prizes
   {
     path: routesConf['prizes']['path'],
     component: () => import('layouts/MainLayout.vue'),
@@ -57,13 +62,11 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // routes
   {
     path: routesConf['routes']['path'],
     component: () => import('layouts/MainLayout.vue'),
-    redirect:
-      routesConf['routes']['path'] +
-      '/' +
-      routesConf['routes_calendar']['path'],
+    redirect: { name: routesConf['routes_calendar']['children']['name'] },
     children: [
       {
         path: routesConf['routes_calendar']['path'],
@@ -87,6 +90,7 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // register
   {
     path: routesConf['register']['path'],
     component: () => import('layouts/LoginRegisterLayout.vue'),
@@ -98,28 +102,31 @@ const routes: RouteRecordRaw[] = [
       },
     ],
   },
+  // register coordinator
   {
-    path: routesConf['register-coordinator']['path'],
+    path: routesConf['register_coordinator']['path'],
     component: () => import('layouts/LoginRegisterLayout.vue'),
     children: [
       {
         path: '',
-        name: routesConf['register-coordinator']['children']['name'],
+        name: routesConf['register_coordinator']['children']['name'],
         component: () => import('pages/RegisterCoordinatorPage.vue'),
       },
     ],
   },
+  // register challenge
   {
-    path: routesConf['register-challenge']['path'],
+    path: routesConf['register_challenge']['path'],
     component: () => import('layouts/LoginRegisterLayout.vue'),
     children: [
       {
         path: '',
-        name: routesConf['register-challenge']['children']['name'],
+        name: routesConf['register_challenge']['children']['name'],
         component: () => import('pages/RegisterChallengePage.vue'),
       },
     ],
   },
+  // results
   {
     path: routesConf['results']['path'],
     component: () => import('layouts/MainLayout.vue'),
@@ -133,12 +140,7 @@ const routes: RouteRecordRaw[] = [
         path: routesConf['results_detail']['path'],
         name: routesConf['results_detail']['children']['name'],
         component: () => import('pages/ResultsDetailPage.vue'),
-        redirect:
-          routesConf['results']['path'] +
-          '/' +
-          routesConf['results_detail']['path'] +
-          '/' +
-          routesConf['results_report']['path'],
+        redirect: { name: routesConf['results_report']['children']['name'] },
         children: [
           {
             path: routesConf['results_report']['path'],

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -44,13 +44,13 @@ const routesConf: RoutesConf = {
       name: 'register',
     },
   },
-  'register-coordinator': {
+  register_coordinator: {
     path: '/register-coordinator',
     children: {
       name: 'register-coordinator',
     },
   },
-  'register-challenge': {
+  register_challenge: {
     path: '/register-challenge',
     children: {
       name: 'register-challenge',

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -76,28 +76,28 @@ const routesConf: RoutesConf = {
     path: 'detail',
     children: {
       fullPath: '/results/detail',
-      name: 'results/detail',
+      name: 'results_detail',
     },
   },
   results_report: {
     path: 'report',
     children: {
       fullPath: '/results/detail/report',
-      name: 'results/detail/report',
+      name: 'results_detail_report',
     },
   },
   results_regularity: {
     path: 'regularity',
     children: {
       fullPath: '/results/detail/regularity',
-      name: 'results/detail/regularity',
+      name: 'results_detail_regularity',
     },
   },
   results_performance: {
     path: 'performance',
     children: {
       fullPath: '/results/detail/performance',
-      name: 'results/detail/performance',
+      name: 'results_detail_performance',
     },
   },
   routes: {
@@ -111,28 +111,28 @@ const routesConf: RoutesConf = {
     path: 'calendar',
     children: {
       fullPath: '/routes/calendar',
-      name: 'routes/calendar',
+      name: 'routes_calendar',
     },
   },
   routes_list: {
     path: 'list',
     children: {
       fullPath: '/routes/list',
-      name: 'routes/list',
+      name: 'routes_list',
     },
   },
   routes_map: {
     path: 'map',
     children: {
       fullPath: '/routes/map',
-      name: 'routes/map',
+      name: 'routes_map',
     },
   },
   routes_app: {
     path: 'app',
     children: {
       fullPath: '/routes/app',
-      name: 'routes/app',
+      name: 'routes_app',
     },
   },
 };

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -63,25 +63,25 @@ const routesConf: RoutesConf = {
     },
   },
   results_detail: {
-    path: '/results/detail',
+    path: 'detail',
     children: {
       name: 'results/detail',
     },
   },
   results_report: {
-    path: '/results/detail/report',
+    path: 'report',
     children: {
       name: 'results/detail/report',
     },
   },
   results_regularity: {
-    path: '/results/detail/regularity',
+    path: 'regularity',
     children: {
       name: 'results/detail/regularity',
     },
   },
   results_performance: {
-    path: '/results/detail/performance',
+    path: 'performance',
     children: {
       name: 'results/detail/performance',
     },
@@ -93,25 +93,25 @@ const routesConf: RoutesConf = {
     },
   },
   routes_calendar: {
-    path: '/routes/calendar',
+    path: 'calendar',
     children: {
       name: 'routes/calendar',
     },
   },
   routes_list: {
-    path: '/routes/list',
+    path: 'list',
     children: {
       name: 'routes/list',
     },
   },
   routes_map: {
-    path: '/routes/map',
+    path: 'map',
     children: {
       name: 'routes/map',
     },
   },
   routes_app: {
-    path: '/routes/app',
+    path: 'app',
     children: {
       name: 'routes/app',
     },

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -76,28 +76,28 @@ const routesConf: RoutesConf = {
     path: 'detail',
     children: {
       fullPath: '/results/detail',
-      name: 'results_detail',
+      name: 'results-detail',
     },
   },
   results_report: {
     path: 'report',
     children: {
       fullPath: '/results/detail/report',
-      name: 'results_detail_report',
+      name: 'results-detail-report',
     },
   },
   results_regularity: {
     path: 'regularity',
     children: {
       fullPath: '/results/detail/regularity',
-      name: 'results_detail_regularity',
+      name: 'results-detail-regularity',
     },
   },
   results_performance: {
     path: 'performance',
     children: {
       fullPath: '/results/detail/performance',
-      name: 'results_detail_performance',
+      name: 'results-detail-performance',
     },
   },
   routes: {
@@ -111,28 +111,28 @@ const routesConf: RoutesConf = {
     path: 'calendar',
     children: {
       fullPath: '/routes/calendar',
-      name: 'routes_calendar',
+      name: 'routes-calendar',
     },
   },
   routes_list: {
     path: 'list',
     children: {
       fullPath: '/routes/list',
-      name: 'routes_list',
+      name: 'routes-list',
     },
   },
   routes_map: {
     path: 'map',
     children: {
       fullPath: '/routes/map',
-      name: 'routes_map',
+      name: 'routes-map',
     },
   },
   routes_app: {
     path: 'app',
     children: {
       fullPath: '/routes/app',
-      name: 'routes_app',
+      name: 'routes-app',
     },
   },
 };

--- a/src/router/routes_conf.ts
+++ b/src/router/routes_conf.ts
@@ -2,6 +2,7 @@ type RoutesConf = {
   [key: string]: {
     path: string;
     children: {
+      fullPath?: string;
       name: string;
     };
   };
@@ -11,108 +12,126 @@ const routesConf: RoutesConf = {
   community: {
     path: '/community',
     children: {
+      fullPath: '/community',
       name: 'community',
     },
   },
   company_coordinator: {
     path: '/company-coordinator',
     children: {
+      fullPath: '/company-coordinator',
       name: 'company-coordinator',
     },
   },
   home: {
     path: '/',
     children: {
+      fullPath: '/',
       name: 'home',
     },
   },
   login: {
     path: '/login',
     children: {
+      fullPath: '/login',
       name: 'login',
     },
   },
   prizes: {
     path: '/prizes',
     children: {
+      fullPath: '/prizes',
       name: 'prizes',
     },
   },
   register: {
     path: '/register',
     children: {
+      fullPath: '/register',
       name: 'register',
     },
   },
   register_coordinator: {
     path: '/register-coordinator',
     children: {
+      fullPath: '/register-coordinator',
       name: 'register-coordinator',
     },
   },
   register_challenge: {
     path: '/register-challenge',
     children: {
+      fullPath: '/register-challenge',
       name: 'register-challenge',
     },
   },
   results: {
     path: '/results',
     children: {
+      fullPath: '/results',
       name: 'results',
     },
   },
   results_detail: {
     path: 'detail',
     children: {
+      fullPath: '/results/detail',
       name: 'results/detail',
     },
   },
   results_report: {
     path: 'report',
     children: {
+      fullPath: '/results/detail/report',
       name: 'results/detail/report',
     },
   },
   results_regularity: {
     path: 'regularity',
     children: {
+      fullPath: '/results/detail/regularity',
       name: 'results/detail/regularity',
     },
   },
   results_performance: {
     path: 'performance',
     children: {
+      fullPath: '/results/detail/performance',
       name: 'results/detail/performance',
     },
   },
   routes: {
     path: '/routes',
     children: {
+      fullPath: '/routes',
       name: 'routes',
     },
   },
   routes_calendar: {
     path: 'calendar',
     children: {
+      fullPath: '/routes/calendar',
       name: 'routes/calendar',
     },
   },
   routes_list: {
     path: 'list',
     children: {
+      fullPath: '/routes/list',
       name: 'routes/list',
     },
   },
   routes_map: {
     path: 'map',
     children: {
+      fullPath: '/routes/map',
       name: 'routes/map',
     },
   },
   routes_app: {
     path: 'app',
     children: {
+      fullPath: '/routes/app',
       name: 'routes/app',
     },
   },

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -65,7 +65,7 @@ describe('Register Challenge page', () => {
   context('desktop', () => {
     beforeEach(() => {
       // config is defined without hash in the URL
-      cy.visit('#' + routesConf['register-challenge']['path']);
+      cy.visit('#' + routesConf['register_challenge']['path']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -5,7 +5,7 @@ describe('Login page', () => {
   context('desktop', () => {
     beforeEach(() => {
       // config is defined without hash in the URL
-      cy.visit('#' + routesConf['register-coordinator']['path']);
+      cy.visit('#' + routesConf['register_coordinator']['path']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -3,7 +3,7 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Results page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('#/' + routesConf['results_detail']['children']['name']);
+      cy.visit('#' + routesConf['results_detail']['children']['fullPath']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -31,7 +31,7 @@ describe('Results page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit('#/' + routesConf['results_detail']['children']['name']);
+      cy.visit('#' + routesConf['results_detail']['children']['fullPath']);
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -3,12 +3,7 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Results page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit(
-        '#' +
-          routesConf['results']['path'] +
-          '/' +
-          routesConf['results_detail']['path'],
-      );
+      cy.visit('#/' + routesConf['results_detail']['children']['name']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -36,12 +31,7 @@ describe('Results page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit(
-        '#' +
-          routesConf['results']['path'] +
-          '/' +
-          routesConf['results_detail']['path'],
-      );
+      cy.visit('#/' + routesConf['results_detail']['children']['name']);
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/results_detail.spec.cy.js
+++ b/test/cypress/e2e/results_detail.spec.cy.js
@@ -3,7 +3,12 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Results page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['results_detail']['path']);
+      cy.visit(
+        '#' +
+          routesConf['results']['path'] +
+          '/' +
+          routesConf['results_detail']['path'],
+      );
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -31,7 +36,12 @@ describe('Results page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['results_detail']['path']);
+      cy.visit(
+        '#' +
+          routesConf['results']['path'] +
+          '/' +
+          routesConf['results_detail']['path'],
+      );
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -3,7 +3,12 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Routes page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['routes_calendar']['path']);
+      cy.visit(
+        '#' +
+          routesConf['results']['path'] +
+          '/' +
+          routesConf['routes_calendar']['path'],
+      );
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -31,7 +36,12 @@ describe('Routes page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit('#' + routesConf['routes_calendar']['path']);
+      cy.visit(
+        '#' +
+          routesConf['results']['path'] +
+          '/' +
+          routesConf['routes']['path'],
+      );
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -3,7 +3,7 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Routes page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit('#/' + routesConf['routes_calendar']['children']['name']);
+      cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -31,7 +31,7 @@ describe('Routes page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit('#/' + routesConf['routes_calendar']['children']['name']);
+      cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases

--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -3,12 +3,7 @@ import { routesConf } from '../../../src/router/routes_conf';
 describe('Routes page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.visit(
-        '#' +
-          routesConf['results']['path'] +
-          '/' +
-          routesConf['routes_calendar']['path'],
-      );
+      cy.visit('#/' + routesConf['routes_calendar']['children']['name']);
       cy.viewport('macbook-16');
 
       // load config an i18n objects as aliases
@@ -36,12 +31,7 @@ describe('Routes page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.visit(
-        '#' +
-          routesConf['results']['path'] +
-          '/' +
-          routesConf['routes']['path'],
-      );
+      cy.visit('#/' + routesConf['routes_calendar']['children']['name']);
       cy.viewport('iphone-6');
 
       // load config an i18n objects as aliases


### PR DESCRIPTION
Issue: Definition of routes does not provide a clear hierarchical structure (within the `route.matched` array).
Routes defined within `routes.ts` are duplicated and do not make use of nesting.

Nest routes in `routes.ts` for example:
* results
  * detail
    * report
    * regularity
    * ...

Fix naming inconsistencies in route keys (`-` -> `_`).
Update navigation components to use urls resolved from router using route name.
Update breadcrumb element to use `matched` array in addition to custom breadcrumb.
