### PR TITLE
src/components/routes: enable active calendar routes multivalue

### DIFF
--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -9,9 +9,10 @@ const classSelectorOutsideDay = '.q-outside';
 const classSelectorPastDay = '.q-past-day';
 const dataSelectorItemFromWork = '[data-cy="calendar-item-display-from-work"]';
 const dataSelectorItemFromWorkActive = '[data-cy="calendar-item-icon-fromwork-active"]';
+const dataSelectorItemFromWorkEmpty = '[data-cy="calendar-item-icon-fromwork-empty"]';
 const dataSelectorItemToWork = '[data-cy="calendar-item-display-to-work"]';
 const dataSelectorItemToWorkActive = '[data-cy="calendar-item-icon-towork-active"]';
-const selectorCalendarDay = 'calendar-day';
+const dataSelectorItemToWorkEmpty = '[data-cy="calendar-item-icon-towork-empty"]';
 const selectorCalendarTitle = 'calendar-title';
 
 const dayNames = [
@@ -93,34 +94,48 @@ function coreTests() {
   // First route of the current date is active
   it('renders default active route', () => {
     // check for active background
-    cy.get(classSelectorCurrentDay)
-      .find(dataSelectorItemToWork)
-      .find(dataSelectorItemToWorkActive)
-      .should('be.visible');
+    checkTodayToWorkActive();
   });
 
-  it('allows to switch active route', () => {
-    // switch to today from work
+  it('allows to enable multiple active routes', () => {
+    // enable today's "from work" route
     cy.get(classSelectorCurrentDay)
       .find(dataSelectorItemFromWork)
       .click();
-    // today from work is active
-    cy.get(classSelectorCurrentDay)
-      .find(dataSelectorItemFromWork)
-      .find(dataSelectorItemFromWorkActive)
-      .should('be.visible');
-    cy.dataCy(selectorCalendarDay);
-    // switch to a past day within the current month
+    // both today's routes are active
+    checkTodayFromWorkActive();
+    checkTodayToWorkActive();
+    // enable a past day's to work route
     cy.get(classSelectorPastDay)
-      .find(dataSelectorItemToWork)
       .first()
+      .find(dataSelectorItemFromWork)
       .click();
     // from work is active
-    cy.get(classSelectorPastDay)
+    checkTodayToWorkActive();
+    checkTodayFromWorkActive();
+    checkPastDayToWorkActive();
+    // disable today's "to work" route
+    cy.get(classSelectorCurrentDay)
       .find(dataSelectorItemToWork)
+      .click();
+    checkTodayToWorkInactive();
+    checkTodayFromWorkActive();
+    checkPastDayToWorkActive();
+    // disable today's "from work" route
+    cy.get(classSelectorCurrentDay)
+      .find(dataSelectorItemFromWork)
+      .click();
+    checkTodayToWorkInactive();
+    checkTodayFromWorkInactive();
+    checkPastDayToWorkActive();
+    // distable a past day's to work route
+    cy.get(classSelectorPastDay)
       .first()
-      .find(dataSelectorItemToWorkActive)
-      .should('be.visible');
+      .find(dataSelectorItemFromWork)
+      .click();
+    checkTodayToWorkInactive();
+    checkTodayFromWorkInactive();
+    checkPastDayToWorkInactive();
   });
 
   it('does not allow to select a day outside current month', () => {
@@ -133,7 +148,51 @@ function coreTests() {
     cy.get(classSelectorOutsideDay)
       .find(dataSelectorItemToWork)
       .first()
-      .find(dataSelectorItemFromWorkActive)
+      .find(dataSelectorItemToWorkActive)
       .should('not.exist');
   })
+}
+
+function checkTodayToWorkActive() {
+  cy.get(classSelectorCurrentDay)
+    .find(dataSelectorItemToWork)
+    .find(dataSelectorItemToWorkActive)
+    .should('be.visible');
+}
+
+function checkTodayFromWorkActive() {
+  cy.get(classSelectorCurrentDay)
+    .find(dataSelectorItemFromWork)
+    .find(dataSelectorItemFromWorkActive)
+    .should('be.visible');
+}
+
+function checkPastDayToWorkActive() {
+  cy.get(classSelectorPastDay)
+    .first()
+    .find(dataSelectorItemFromWork)
+    .find(dataSelectorItemFromWorkActive)
+    .should('be.visible');
+}
+
+function checkTodayToWorkInactive() {
+  cy.get(classSelectorCurrentDay)
+    .find(dataSelectorItemToWork)
+    .find(dataSelectorItemToWorkEmpty)
+    .should('be.visible');
+}
+
+function checkTodayFromWorkInactive() {
+  cy.get(classSelectorCurrentDay)
+    .find(dataSelectorItemFromWork)
+    .find(dataSelectorItemFromWorkEmpty)
+    .should('be.visible');
+}
+
+function checkPastDayToWorkInactive() {
+  cy.get(classSelectorPastDay)
+    .first()
+    .find(dataSelectorItemToWork)
+    .find(dataSelectorItemToWorkEmpty)
+    .should('be.visible');
 }

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -130,9 +130,11 @@ export default defineComponent({
 
     /**
      * Finds the index of the active route based on timestamp and direction.
-     * @param {Timestamp} timestamp - The timestamp of the route item.
-     * @param {TransportDirection} direction - The direction of the route item.
-     * @return {number} The index of the active route.
+     * @param {Object} payload - Object containing the timestamp and
+     * the direction of the route item.
+     * - `timestamp` (Timestamp): The timestamp of the route item.
+     * - `direction` (TransportDirection): The direction of the route item.
+     * @return {number} The index of the active route or -1 if route not found.
      */
     function getActiveIndex({
       timestamp,

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -27,7 +27,11 @@ import CalendarNavigation from './CalendarNavigation.vue';
 
 // types
 import type { Timestamp } from '@quasar/quasar-ui-qcalendar';
-import type { RouteCalendarDay, TransportDirection } from '../types/Route';
+import type {
+  TransportDirection,
+  RouteCalendarActive,
+  RouteCalendarDay,
+} from '../types/Route';
 
 // fixtures
 import routesListCalendarFixture from '../../../test/cypress/fixtures/routeListCalendar.json';
@@ -96,12 +100,13 @@ export default defineComponent({
     });
 
     // Active state
-    const activeItem = ref<Timestamp | null>(parsed(today()));
-    const activeDirection = ref<TransportDirection>('toWork');
+    const activeRoutes = ref<RouteCalendarActive[]>([
+      { timestamp: parsed(today()), direction: 'toWork' },
+    ]);
 
     /**
      * Determines if route item is active.
-     * It checks if the timestamp and direction against a stored state.
+     * It checks timestamp and direction against a stored routes.
      * @param {Object} { timestamp: Timestamp; direction: TransportDirection }
      * @return {boolean}
      */
@@ -115,15 +120,41 @@ export default defineComponent({
       if (
         !timestamp ||
         !direction ||
-        !activeItem.value ||
-        !activeDirection.value
+        !activeRoutes.value ||
+        !activeRoutes.value.length
       ) {
         return false;
       }
-      return (
-        activeItem.value.date === timestamp.date &&
-        activeDirection.value === direction
-      );
+      return getActiveIndex({ timestamp, direction }) > -1;
+    }
+
+    /**
+     * Finds the index of the active route based on timestamp and direction.
+     * @param {Timestamp} timestamp - The timestamp of the route item.
+     * @param {TransportDirection} direction - The direction of the route item.
+     * @return {number} The index of the active route.
+     */
+    function getActiveIndex({
+      timestamp,
+      direction,
+    }: {
+      timestamp: Timestamp;
+      direction: TransportDirection;
+    }): number {
+      if (
+        !timestamp ||
+        !direction ||
+        !activeRoutes.value ||
+        !activeRoutes.value.length
+      ) {
+        return -1;
+      }
+      return activeRoutes.value.findIndex((activeRoute) => {
+        return (
+          activeRoute.timestamp?.date === timestamp?.date &&
+          activeRoute.direction === direction
+        );
+      });
     }
 
     /**
@@ -140,12 +171,15 @@ export default defineComponent({
       timestamp: Timestamp;
       direction: TransportDirection;
     }): void {
-      activeItem.value = timestamp;
-      activeDirection.value = direction;
+      if (isActive({ timestamp, direction })) {
+        activeRoutes.value.splice(getActiveIndex({ timestamp, direction }), 1);
+      } else {
+        activeRoutes.value.push({ timestamp, direction });
+      }
     }
 
     return {
-      activeItem,
+      activeRoutes,
       calendar,
       locale,
       monthNameAndYear,

--- a/src/components/types/Route.ts
+++ b/src/components/types/Route.ts
@@ -1,3 +1,6 @@
+// types
+import type { TimestampOrNull } from '@quasar/quasar-ui-qcalendar';
+
 export type RouteItem = {
   id: string;
   date: string;
@@ -25,6 +28,11 @@ export type RouteCalendarDay = {
   date: string;
   toWork: RouteItem;
   fromWork: RouteItem;
+};
+
+export type RouteCalendarActive = {
+  timestamp: TimestampOrNull;
+  direction: TransportDirection;
 };
 
 export type RouteTab = 'calendar' | 'list' | 'map' | 'app';


### PR DESCRIPTION
Currently, only one calendar route can be active at a time.

To enable the option of selecting multiple routes at once:
* store active routes in `activeRoutes` array
* update isActive checks
* update tests so that they check active/inactive state for multiple calendar routes at a time.