### PR TITLE
src/components/form: add component FormFieldCheckboxRequired to refactor forms

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged

--- a/src/components/__tests__/FormFieldCheckboxRequired.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxRequired.cy.js
@@ -3,6 +3,8 @@ import FormFieldTestWrapper from '../global/FormFieldTestWrapper.vue';
 import { i18n } from '../../boot/i18n';
 
 // selectors
+const classSelectorMessages = '.q-field__messages';
+const classSelectorCheckboxBg = '.q-checkbox__bg';
 const selectorCheckboxRequired = 'form-field-checkbox-required';
 const selectorCheckboxRequiredLabel = 'form-field-checkbox-required-label';
 
@@ -33,7 +35,7 @@ describe('<FormFieldCheckboxRequired>', () => {
         ).then((validationMessage) => {
           cy.mount(FormFieldTestWrapper, {
             props: {
-              boolean: true,
+              type: 'boolean',
               component: 'FormFieldCheckboxRequired',
               validationMessage,
             },
@@ -62,16 +64,16 @@ function coreTests() {
       );
     // checkbox border
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-checkbox__bg')
+      .find(classSelectorCheckboxBg)
       .should('have.css', 'border-radius', '4px');
     // checkbox height
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-checkbox__bg')
+      .find(classSelectorCheckboxBg)
       .invoke('height')
       .should('be.equal', checkboxSize);
     // checkbox width
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-checkbox__bg')
+      .find(classSelectorCheckboxBg)
       .invoke('width')
       .should('be.equal', checkboxSize);
   });
@@ -79,11 +81,11 @@ function coreTests() {
   it('validates checkbox', () => {
     cy.dataCy(selectorCheckboxRequired).click();
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-field__messages')
-      .should('not.exist');
+      .find(classSelectorMessages)
+      .should('not.exist')
     cy.dataCy(selectorCheckboxRequired).click();
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-field__messages')
+      .find(classSelectorMessages)
       .should('be.visible')
       .and(
         'contain',
@@ -93,7 +95,7 @@ function coreTests() {
       );
     cy.dataCy(selectorCheckboxRequired).click();
     cy.dataCy(selectorCheckboxRequired)
-      .find('.q-field__messages')
+      .find(classSelectorMessages)
       .should('not.exist');
   });
 }

--- a/src/components/__tests__/FormFieldCheckboxRequired.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxRequired.cy.js
@@ -1,0 +1,36 @@
+import FormFieldCheckboxRequired from 'components/form/FormFieldCheckboxRequired.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<FormFieldCheckboxRequired>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldCheckboxRequired, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldCheckboxRequired, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy('component').should('be.visible');
+  });
+}

--- a/src/components/__tests__/FormFieldCheckboxRequired.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxRequired.cy.js
@@ -32,8 +32,10 @@ describe('<FormFieldCheckboxRequired>', () => {
             props: {
               boolean: true,
               component: 'FormFieldCheckboxRequired',
-              label,
               validationMessage,
+            },
+            slots: {
+              default: label,
             },
           });
         });

--- a/src/components/__tests__/FormFieldCheckboxRequired.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxRequired.cy.js
@@ -15,7 +15,10 @@ const checkboxSize = 16;
 
 describe('<FormFieldCheckboxRequired>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'index.component', i18n);
+    cy.testLanguageStringsInContext([
+      'labelResponsibility',
+      'messageResponsibilityRequired',
+    ], 'register.coordinator.form', i18n);
   });
 
   context('default', () => {

--- a/src/components/__tests__/FormFieldCheckboxRequired.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxRequired.cy.js
@@ -1,26 +1,42 @@
-import FormFieldCheckboxRequired from 'components/form/FormFieldCheckboxRequired.vue';
+import { colors } from 'quasar';
+import FormFieldTestWrapper from '../global/FormFieldTestWrapper.vue';
 import { i18n } from '../../boot/i18n';
+
+// selectors
+const selectorCheckboxRequired = 'form-field-checkbox-required';
+const selectorCheckboxRequiredLabel = 'form-field-checkbox-required-label';
+
+// colors
+const { getPaletteColor } = colors;
+const grey10 = getPaletteColor('grey-10');
+
+// variables
+const checkboxSize = 16;
 
 describe('<FormFieldCheckboxRequired>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext([], 'index.component', i18n);
   });
 
-  context('desktop', () => {
+  context('default', () => {
     beforeEach(() => {
-      cy.mount(FormFieldCheckboxRequired, {
-        props: {},
-      });
-      cy.viewport('macbook-16');
-    });
-
-    coreTests();
-  });
-
-  context('mobile', () => {
-    beforeEach(() => {
-      cy.mount(FormFieldCheckboxRequired, {
-        props: {},
+      cy.wrap(
+        i18n.global.t('register.coordinator.form.labelResponsibility'),
+      ).then((label) => {
+        cy.wrap(
+          i18n.global.t(
+            'register.coordinator.form.messageResponsibilityRequired',
+          ),
+        ).then((validationMessage) => {
+          cy.mount(FormFieldTestWrapper, {
+            props: {
+              boolean: true,
+              component: 'FormFieldCheckboxRequired',
+              label,
+              validationMessage,
+            },
+          });
+        });
       });
       cy.viewport('iphone-6');
     });
@@ -31,6 +47,48 @@ describe('<FormFieldCheckboxRequired>', () => {
 
 function coreTests() {
   it('renders component', () => {
-    cy.dataCy('component').should('be.visible');
+    cy.dataCy(selectorCheckboxRequired).should('be.visible');
+    cy.dataCy(selectorCheckboxRequiredLabel)
+      .should('be.visible')
+      .and('have.color', grey10)
+      .and(
+        'contain',
+        i18n.global.t('register.coordinator.form.labelResponsibility'),
+      );
+    // checkbox border
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-checkbox__bg')
+      .should('have.css', 'border-radius', '4px');
+    // checkbox height
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-checkbox__bg')
+      .invoke('height')
+      .should('be.equal', checkboxSize);
+    // checkbox width
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-checkbox__bg')
+      .invoke('width')
+      .should('be.equal', checkboxSize);
+  });
+
+  it('validates checkbox', () => {
+    cy.dataCy(selectorCheckboxRequired).click();
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-field__messages')
+      .should('not.exist');
+    cy.dataCy(selectorCheckboxRequired).click();
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-field__messages')
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t(
+          'register.coordinator.form.messageResponsibilityRequired',
+        ),
+      );
+    cy.dataCy(selectorCheckboxRequired).click();
+    cy.dataCy(selectorCheckboxRequired)
+      .find('.q-field__messages')
+      .should('not.exist');
   });
 }

--- a/src/components/__tests__/FormFieldCheckboxTeam.cy.js
+++ b/src/components/__tests__/FormFieldCheckboxTeam.cy.js
@@ -6,7 +6,7 @@ describe('<FormFieldCheckboxTeam>', () => {
       cy.mount(FormFieldTestWrapper, {
         props: {
           component: 'FormFieldCheckboxTeam',
-          array: true,
+          type: 'array',
         },
       });
       cy.viewport('macbook-16');
@@ -27,7 +27,7 @@ describe('<FormFieldCheckboxTeam>', () => {
       cy.mount(FormFieldTestWrapper, {
         props: {
           component: 'FormFieldCheckboxTeam',
-          array: true,
+          type: 'array',
         },
       });
       cy.viewport('iphone-6');

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -5,7 +5,6 @@ import { i18n } from '../../boot/i18n';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
-const iconSize = 16;
 
 describe('<FormRegisterCoordinator>', () => {
   it('has translation for all strings', () => {
@@ -146,20 +145,6 @@ describe('<FormRegisterCoordinator>', () => {
           'contain',
           i18n.global.t('register.coordinator.form.labelResponsibility'),
         );
-      // checkbox border
-      cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-checkbox__bg')
-        .should('have.css', 'border-radius', '4px');
-      // checkbox height
-      cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-checkbox__bg')
-        .invoke('height')
-        .should('be.equal', iconSize);
-      // checkbox width
-      cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-checkbox__bg')
-        .invoke('width')
-        .should('be.equal', iconSize);
     });
 
     it('renders checkbox terms', () => {
@@ -172,20 +157,6 @@ describe('<FormRegisterCoordinator>', () => {
           'contain',
           i18n.global.t('register.coordinator.form.labelPrivacyConsent'),
         );
-      // checkbox border
-      cy.dataCy('form-register-coordinator-terms')
-        .find('.q-checkbox__bg')
-        .should('have.css', 'border-radius', '4px');
-      // checkbox height
-      cy.dataCy('form-register-coordinator-terms')
-        .find('.q-checkbox__bg')
-        .invoke('height')
-        .should('be.equal', iconSize);
-      // checkbox width
-      cy.dataCy('form-register-coordinator-terms')
-        .find('.q-checkbox__bg')
-        .invoke('width')
-        .should('be.equal', iconSize);
     });
 
     it('validates checkboxes correctly', () => {

--- a/src/components/form/FormFieldCheckboxRequired.vue
+++ b/src/components/form/FormFieldCheckboxRequired.vue
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
 /**
  * FormFieldCheckboxRequired Component
  *
@@ -50,8 +50,8 @@ export default defineComponent({
     return {
       model,
     };
-  }
-})
+  },
+});
 </script>
 
 <template>
@@ -60,11 +60,8 @@ export default defineComponent({
     borderless
     hide-bottom-space
     :model-value="model"
-    :rules="[
-      (val) =>
-        !!val ||
-        validationMessage,
-    ]"
+    :rules="[(val) => !!val || validationMessage]"
+    data-cy="form-field-checkbox-required"
   >
     <q-checkbox
       dense
@@ -73,8 +70,9 @@ export default defineComponent({
       :true-value="true"
       :false-value="false"
       class="text-grey-10"
+      data-cy="form-field-checkbox-required-input"
     >
-      <span>
+      <span data-cy="form-field-checkbox-required-label">
         {{ label }}
       </span>
     </q-checkbox>

--- a/src/components/form/FormFieldCheckboxRequired.vue
+++ b/src/components/form/FormFieldCheckboxRequired.vue
@@ -4,6 +4,8 @@
  *
  * @description * Use this component to render a required checkbox input field.
  *
+ * Note: This component is used in `FormRegisterCoordinator`.
+ *
  * @props
  * - `modelValue` (boolean, required): Value of the checkbox.
  *   It should be of type `boolean`.

--- a/src/components/form/FormFieldCheckboxRequired.vue
+++ b/src/components/form/FormFieldCheckboxRequired.vue
@@ -7,13 +7,14 @@
  * @props
  * - `modelValue` (boolean, required): Value of the checkbox.
  *   It should be of type `boolean`.
- * - `label` (string, required): Label of the checkbox.
- *   It should be of type `string`.
  * - `validationMessage` (string, required): Validation message of the checkbox.
  *   It should be of type `string`.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @slots
+ * - `default`: Label for the checkbox.
  *
  * @example
  * <form-field-checkbox-required v-model="isChecked" :label="label" :validation-message="validationMessage" />
@@ -29,10 +30,6 @@ export default defineComponent({
   props: {
     modelValue: {
       type: Boolean,
-      required: true,
-    },
-    label: {
-      type: String,
       required: true,
     },
     validationMessage: {
@@ -73,7 +70,7 @@ export default defineComponent({
       data-cy="form-field-checkbox-required-input"
     >
       <span data-cy="form-field-checkbox-required-label">
-        {{ label }}
+        <slot />
       </span>
     </q-checkbox>
   </q-field>

--- a/src/components/form/FormFieldCheckboxRequired.vue
+++ b/src/components/form/FormFieldCheckboxRequired.vue
@@ -1,0 +1,82 @@
+<script lang='ts'>
+/**
+ * FormFieldCheckboxRequired Component
+ *
+ * @description * Use this component to render a required checkbox input field.
+ *
+ * @props
+ * - `modelValue` (boolean, required): Value of the checkbox.
+ *   It should be of type `boolean`.
+ * - `label` (string, required): Label of the checkbox.
+ *   It should be of type `string`.
+ * - `validationMessage` (string, required): Validation message of the checkbox.
+ *   It should be of type `string`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @example
+ * <form-field-checkbox-required v-model="isChecked" :label="label" :validation-message="validationMessage" />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=6417-29946&t=22yqDCEydrJ2RQgL-1)
+ */
+
+// libraries
+import { computed, defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'FormFieldCheckboxRequired',
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    validationMessage: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const model = computed({
+      get: (): boolean => props.modelValue,
+      set: (value: boolean) => emit('update:modelValue', value),
+    });
+
+    return {
+      model,
+    };
+  }
+})
+</script>
+
+<template>
+  <q-field
+    dense
+    borderless
+    hide-bottom-space
+    :model-value="model"
+    :rules="[
+      (val) =>
+        !!val ||
+        validationMessage,
+    ]"
+  >
+    <q-checkbox
+      dense
+      v-model="model"
+      color="primary"
+      :true-value="true"
+      :false-value="false"
+      class="text-grey-10"
+    >
+      <span>
+        {{ label }}
+      </span>
+    </q-checkbox>
+  </q-field>
+</template>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -33,6 +33,9 @@
  * - `FormFieldSelectTable`: Component to render company select field.
  * - `FormFieldTextRequired`: Component to render text input field.
  *
+ * @slots
+ * - `default`: Slot for input fields
+ *
  * @example
  * <form-field-test-wrapper component="FormFieldPassword" :testing="true" />
  */
@@ -124,5 +127,7 @@ export default defineComponent({
     :options="options"
     :required="required"
     :validation-message="validationMessage"
-  />
+  >
+    <slot />
+  </component>
 </template>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -13,8 +13,12 @@
  * - `label` (string): The translation key used for input label in tests.
  * - `name` (string): The name used for id and test selectors.
  * - `options` (array): The options used for radio button tests.
+ * - `required` (boolean): If the input is required.
+ * - `array` (boolean): If the input is an array.
+ * - `boolean` (boolean): If the input is a boolean.
  *
  * @components
+ * - `FormFieldCheckboxRequired`: Component to render checkbox input field.
  * - `FormFieldCheckboxTeam`: Component to render checkbox team widget.
  * - `FormFieldCompany`: Component to render company input field.
  * - `FormFieldDateRequired`: Component to render date input field.
@@ -37,6 +41,7 @@
 import { defineComponent, ref } from 'vue';
 
 // components
+import FormFieldCheckboxRequired from '../form/FormFieldCheckboxRequired.vue';
 import FormFieldCheckboxTeam from '../form/FormFieldCheckboxTeam.vue';
 import FormFieldCompany from './FormFieldCompany.vue';
 import FormFieldDateRequired from '../form/FormFieldDateRequired.vue';
@@ -54,6 +59,7 @@ import FormFieldBusinessId from '../form/FormFieldBusinessId.vue';
 export default defineComponent({
   name: 'FormFieldTestWrapper',
   components: {
+    FormFieldCheckboxRequired,
     FormFieldCheckboxTeam,
     FormFieldCompany,
     FormFieldDateRequired,
@@ -91,9 +97,15 @@ export default defineComponent({
     array: {
       type: Boolean,
     },
+    boolean: {
+      type: Boolean,
+    },
+    validationMessage: {
+      type: String,
+    },
   },
   setup(props) {
-    const inputValue = ref(props.array ? [] : '');
+    const inputValue = ref(props.array ? [] : props.boolean ? false : '');
 
     return {
       inputValue,
@@ -111,5 +123,6 @@ export default defineComponent({
     :compare-value="compareValue"
     :options="options"
     :required="required"
+    :validation-message="validationMessage"
   />
 </template>

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -14,8 +14,8 @@
  * - `name` (string): The name used for id and test selectors.
  * - `options` (array): The options used for radio button tests.
  * - `required` (boolean): If the input is required.
- * - `array` (boolean): If the input is an array.
- * - `boolean` (boolean): If the input is a boolean.
+ * - `type` (boolean): Input type.
+ * - `validationMessage` (string): The message used for validation error.
  *
  * @components
  * - `FormFieldCheckboxRequired`: Component to render checkbox input field.
@@ -97,18 +97,16 @@ export default defineComponent({
     required: {
       type: Boolean,
     },
-    array: {
-      type: Boolean,
-    },
-    boolean: {
-      type: Boolean,
+    type: {
+      type: String as () => 'array' | 'boolean' | 'string',
+      default: 'string',
     },
     validationMessage: {
       type: String,
     },
   },
   setup(props) {
-    const inputValue = ref(props.array ? [] : props.boolean ? false : '');
+    const inputValue = ref(props.type === 'array' ? [] : props.type === 'boolean' ? false : '');
 
     return {
       inputValue,

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -262,13 +262,3 @@ export default defineComponent({
     </q-form>
   </div>
 </template>
-
-<style scoped lang="scss">
-:deep(.q-checkbox__bg) {
-  border: 1px solid $grey-6;
-  border-radius: 4px;
-}
-:deep(.q-checkbox__svg) {
-  padding: 3px;
-}
-</style>

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -9,7 +9,13 @@
  * Note: This component is commonly used in `RegisterCoordinatorPage`.
  *
  * @components
+ * - `FormFieldCheckboxRequired`: Component to render checkbox input.
+ * - `FormFieldCompany`: Component to render company input.
  * - `FormFieldEmail`: Component to render email input.
+ * - `FormFieldPassword`: Component to render password input.
+ * - `FormFieldPasswordConfirm`: Component to render password confirm input.
+ * - `FormFieldPhone`: Component to render phone input.
+ * - `FormFieldTextRequired`: Component to render required field.
  *
  * @example
  * <form-register-coordinator />
@@ -23,12 +29,13 @@ import { defineComponent, reactive } from 'vue';
 import { i18n } from 'src/boot/i18n';
 
 // components
+import FormFieldCheckboxRequired from './../form/FormFieldCheckboxRequired.vue';
 import FormFieldCompany from '../global/FormFieldCompany.vue';
 import FormFieldEmail from './../global/FormFieldEmail.vue';
-import FormFieldTextRequired from './../global/FormFieldTextRequired.vue';
 import FormFieldPassword from '../global/FormFieldPassword.vue';
 import FormFieldPasswordConfirm from '../global/FormFieldPasswordConfirm.vue';
 import FormFieldPhone from './../global/FormFieldPhone.vue';
+import FormFieldTextRequired from './../global/FormFieldTextRequired.vue';
 
 // types
 import type { FormOption } from 'src/components/types/Form';
@@ -36,6 +43,7 @@ import type { FormOption } from 'src/components/types/Form';
 export default defineComponent({
   name: 'FormRegisterCoordinator',
   components: {
+    FormFieldCheckboxRequired,
     FormFieldCompany,
     FormFieldEmail,
     FormFieldTextRequired,
@@ -186,65 +194,31 @@ export default defineComponent({
             class="col-12"
             data-cy="form-register-coordinator-responsibility"
           >
-            <q-field
-              dense
-              borderless
-              hide-bottom-space
-              :model-value="formRegisterCoordinator.responsibility"
-              :rules="[
-                (val) =>
-                  !!val ||
-                  $t('register.coordinator.form.messageResponsibilityRequired'),
-              ]"
+            <form-field-checkbox-required
+              v-model="formRegisterCoordinator.responsibility"
+              :validation-message="
+                $t('register.coordinator.form.messageResponsibilityRequired')
+              "
             >
-              <q-checkbox
-                dense
-                v-model="formRegisterCoordinator.responsibility"
-                color="primary"
-                :true-value="true"
-                :false-value="false"
-                class="text-grey-10"
-              >
-                <span>{{
-                  $t('register.coordinator.form.labelResponsibility')
-                }}</span>
-              </q-checkbox>
-            </q-field>
+              {{ $t('register.coordinator.form.labelResponsibility') }}
+            </form-field-checkbox-required>
           </div>
           <!-- Input: confirm consent -->
           <div class="col-12" data-cy="form-register-coordinator-terms">
-            <q-field
-              dense
-              borderless
-              hide-bottom-space
-              :model-value="formRegisterCoordinator.terms"
-              :rules="[
-                (val) =>
-                  !!val || $t('register.coordinator.form.messageTermsRequired'),
-              ]"
+            <!-- Checkbox: terms -->
+            <form-field-checkbox-required
+              v-model="formRegisterCoordinator.terms"
+              :validation-message="
+                $t('register.coordinator.form.messageTermsRequired')
+              "
             >
-              <q-checkbox
-                dense
-                id="form-register-coordinator-terms"
-                v-model="formRegisterCoordinator.terms"
-                color="primary"
-                :true-value="true"
-                :false-value="false"
-                rules="required"
-                class="text-grey-10"
-              >
-                <!-- Default slot: label -->
-                <span>
-                  {{ $t('register.coordinator.form.labelPrivacyConsent') }}
-                  <!-- Link: terms -->
-                  <!-- TODO: Link to terms page -->
-                  <a href="#" target="_blank" class="text-primary">{{
-                    $t('register.coordinator.form.linkPrivacyConsent')
-                  }}</a
-                  >.
-                </span>
-              </q-checkbox>
-            </q-field>
+              {{ $t('register.coordinator.form.labelPrivacyConsent') }}
+              <!-- Link: terms -->
+              <!-- TODO: Link to terms page -->
+              <a href="#" target="_blank" class="text-primary">
+                {{ $t('register.coordinator.form.linkPrivacyConsent') }} </a
+              >.
+            </form-field-checkbox-required>
           </div>
         </div>
         <!-- Button: submit -->

--- a/src/css/form.scss
+++ b/src/css/form.scss
@@ -1,3 +1,10 @@
 .q-field__control {
   border-radius: 8px !important;
 }
+.q-checkbox .q-checkbox__bg {
+  border: 1px solid $grey-6;
+  border-radius: 4px;
+}
+.q-checkbox .q-checkbox__svg {
+  padding: 3px;
+}


### PR DESCRIPTION
Add component `FormFieldCheckboxRequired` to simplify the use of required checkboxes (consents etc.) across codebase.
This is used in `FormRegisterCoordinator` and will be used in `RegisterChallengePayment` - payment step of challenge registration.

* Add a new component.
* Add tests (display + validation).
* Update FormFieldTestWrapper component to handle passing boolean value, validation messages and slots.
* Move styles for checkbox to global CSS.