### PR TITLE
src/components: fix eslint error in TaskListCoordinator component

### DIFF
--- a/src/components/coordinator/TaskListCoordinator.vue
+++ b/src/components/coordinator/TaskListCoordinator.vue
@@ -73,9 +73,11 @@ export default defineComponent({
         props.tasks.forEach((task: TaskCoordinator) => {
           const taskMonth = date.formatDate(task.date, 'MMMM YYYY');
           // if a new month, push month into the task
-          taskMonth !== month
-            ? tasks.push({ ...task, month: taskMonth })
-            : tasks.push(task);
+          if (taskMonth !== month) {
+            tasks.push({ ...task, month: taskMonth });
+          } else {
+            tasks.push(task);
+          }
           month = taskMonth;
         });
 


### PR DESCRIPTION
Fix eslint error in `TaskListCoordinator` component.
Error appears in eslint v8 and prevents tests in PR #496 from passing.

Replaces ternary operator short-hand with `if-else` code.