### PR TITLE
src/components/routes: update route selection behaviour in RoutesCalendar component

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -37,3 +37,4 @@ urlVideoOnboarding = "https://www.youtube.com/embed/ItfTtrEutgo?rel=0"
 challengeMonth = "may"
 challengeStartDate = "2024-10-01T12:00:00"
 containerWidth = "752px"
+challengeLoggingWindowDays = 8

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -6,7 +6,7 @@ const classSelectorCurrentDay = '.q-current-day';
 const classSelectorFutureDay = '.q-future-day';
 const classSelectorHeadWeekday = '.q-calendar-month__head--weekday';
 const classSelectorOutsideDay = '.q-outside';
-const classSelectorPastDay = '.q-past-day';
+const classSelectorPastDay = '.q-past-day:not(.q-disabled-day)';
 const dataSelectorButtonSave = '[data-cy="dialog-save-button"]';
 const dataSelectorDialogClose = '[data-cy="dialog-close"]';
 const dataSelectorDialogHeader = '[data-cy="dialog-header"]';

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -17,11 +17,15 @@ const dataSelectorItemFromWorkActive =
   '[data-cy="calendar-item-icon-fromwork-active"]';
 const dataSelectorItemFromWorkEmpty =
   '[data-cy="calendar-item-icon-fromwork-empty"]';
+const dataSelectorItemFromWorkLogged =
+  '[data-cy="calendar-item-icon-fromwork-logged"]';
 const dataSelectorItemToWork = '[data-cy="calendar-item-display-to-work"]';
 const dataSelectorItemToWorkActive =
   '[data-cy="calendar-item-icon-towork-active"]';
 const dataSelectorItemToWorkEmpty =
   '[data-cy="calendar-item-icon-towork-empty"]';
+const dataSelectorItemToWorkLogged =
+  '[data-cy="calendar-item-icon-towork-logged"]';
 const dataSelectorRouteInputDistance = '[data-cy="route-input-distance"]';
 const selectorCalendarTitle = 'calendar-title';
 const selectorRouteCalendarPanel = 'route-calendar-panel';
@@ -282,6 +286,50 @@ function coreTests() {
       .first()
       .find(dataSelectorItemToWorkActive)
       .should('not.exist');
+  });
+
+  it('only allows to select a single logged route', () => {
+    // enable today's "to work" route
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    // enable today's "from work" route
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
+    // only one route should be active
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemFromWorkActive)
+      .should('have.length', 1);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemToWorkActive)
+      .should('have.length', 1);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemToWorkLogged)
+      .first()
+      .click({ force: true });
+    // only one route should be active
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemFromWorkActive)
+      .should('have.length', 0);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemToWorkActive)
+      .should('have.length', 1);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemFromWorkLogged)
+      .first()
+      .click({ force: true });
+    // only one route should be active
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemFromWorkActive)
+      .should('have.length', 1);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemToWorkActive)
+      .should('have.length', 0);
+    // enable today's "to work" route
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemFromWorkActive)
+      .should('have.length', 0);
+    cy.dataCy(selectorRoutesCalendar)
+      .find(dataSelectorItemToWorkActive)
+      .should('have.length', 1);
   });
 }
 

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -29,4 +29,5 @@ export interface ConfigGlobal {
   challengeMonth: 'may' | 'october' | 'september';
   containerWidth: string;
   challengeStartDate: string;
+  challengeLoggingWindowDays: number;
 }

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -1,0 +1,176 @@
+// libraries
+import { computed, ref } from 'vue';
+
+// enums
+import { TransportDirection, TransportType } from '../components/types/Route';
+
+// types
+import type { Ref } from 'vue';
+import type {
+  RouteCalendarActive,
+  RouteCalendarDay,
+  RouteItem,
+} from '../components/types/Route';
+
+export const useCalendarRoutes = (days: Ref<RouteCalendarDay[]>) => {
+  /**
+   * Map of days with logged routes by key for an easy lookup.
+   * - key: date
+   * - value: RouteCalendarDay
+   */
+  const routesMap = computed((): Record<string, RouteCalendarDay> => {
+    const routesObject = {} as Record<string, RouteCalendarDay>;
+    if (days.value.length > 0) {
+      days.value.forEach((route: RouteCalendarDay) => {
+        routesObject[route.date] = route;
+      });
+    }
+    return routesObject;
+  });
+
+  /**
+   * Simplified version of active routes.
+   * Each item contains timestamp and direction.
+   * Mutable.
+   */
+  const activeRoutes = ref<RouteCalendarActive[]>([]);
+
+  /**
+   * Computed property of active routes.
+   * Each item contains full information about the route.
+   * Immutable.
+   */
+  const activeRouteItems = computed((): RouteItem[] => {
+    const routes = [] as RouteItem[];
+    activeRoutes.value.forEach((activeRoute: RouteCalendarActive): void => {
+      if (activeRoute.timestamp && activeRoute.direction) {
+        const day: RouteCalendarDay =
+          routesMap.value[activeRoute.timestamp.date];
+        if (
+          dayHasToWorkRoute(day) &&
+          activeRoute.direction === TransportDirection.toWork
+        ) {
+          // Route is already logged - load data.
+          routes.push({ ...day.toWork });
+        } else if (
+          dayHasFromWorkRoute(day) &&
+          activeRoute.direction === TransportDirection.fromWork
+        ) {
+          // Route is already logged - load data.
+          routes.push({ ...day.fromWork });
+        } else {
+          // Route is not logged - create empty route.
+          routes.push({
+            id: '',
+            date: activeRoute.timestamp.date,
+            direction: activeRoute.direction,
+            transport: TransportType.bike,
+            distance: 0,
+            inputType: 'input-number',
+          });
+        }
+      }
+    });
+    return routes;
+  });
+
+  const isActiveRouteLogged = computed((): boolean => {
+    return activeRoutes.value.reduce(
+      (accumulator: boolean, activeRoute: RouteCalendarActive): boolean => {
+        return isCalendarRouteLogged(activeRoute) || accumulator;
+      },
+      false,
+    );
+  });
+
+  /**
+   * Checks if a given calendar route is already logged.
+   * @param {RouteCalendarActive} activeRoute - The route to check.
+   * @return {boolean} True if the route is logged, false otherwise.
+   */
+  function isCalendarRouteLogged(activeRoute: RouteCalendarActive): boolean {
+    if (activeRoute.timestamp && activeRoute.direction) {
+      const day: RouteCalendarDay = routesMap.value[activeRoute.timestamp.date];
+      const isLoggedToWork =
+        activeRoute.direction === TransportDirection.toWork &&
+        dayHasToWorkRoute(day);
+      const isLoggedFromWork =
+        activeRoute.direction === TransportDirection.fromWork &&
+        dayHasFromWorkRoute(day);
+      return isLoggedToWork || isLoggedFromWork;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if a given day has a logged to work route.
+   * @param {RouteCalendarDay | null} day - Day to check or null.
+   * @return {boolean}
+   */
+  function dayHasToWorkRoute(day: RouteCalendarDay | null): boolean {
+    return !!day?.toWork;
+  }
+
+  /**
+   * Checks if a given day has a logged from work route.
+   * @param {RouteCalendarDay | null} day - Day to check or null.
+   * @return {boolean}
+   */
+  function dayHasFromWorkRoute(day: RouteCalendarDay | null): boolean {
+    return !!day?.fromWork;
+  }
+
+  /**
+   * Determines if route item is active.
+   * It checks timestamp and direction against stored routes.
+   * @param {RouteCalendarActive} route
+   * @return {boolean}
+   */
+  function isActive({ timestamp, direction }: RouteCalendarActive): boolean {
+    if (
+      !timestamp ||
+      !direction ||
+      !activeRoutes.value ||
+      !activeRoutes.value.length
+    ) {
+      return false;
+    }
+    return getActiveIndex({ timestamp, direction }) > -1;
+  }
+
+  /**
+   * Finds the index of given route based in the active array.
+   * @param {RouteCalendarActive} route
+   * @return {number} The index of the active route or -1 if route not found.
+   */
+  function getActiveIndex({
+    timestamp,
+    direction,
+  }: RouteCalendarActive): number {
+    if (
+      !timestamp ||
+      !direction ||
+      !activeRoutes.value ||
+      !activeRoutes.value.length
+    ) {
+      return -1;
+    }
+    return activeRoutes.value.findIndex((activeRoute) => {
+      return (
+        activeRoute.timestamp?.date === timestamp?.date &&
+        activeRoute.direction === direction
+      );
+    });
+  }
+
+  return {
+    activeRoutes,
+    activeRouteItems,
+    isActiveRouteLogged,
+    routesMap,
+    getActiveIndex,
+    isActive,
+    isCalendarRouteLogged,
+  };
+};

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -1,5 +1,6 @@
-import { parse } from 'toml';
-import { readFileSync } from 'fs';
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { parse } = require('toml');
+const { readFileSync } = require('fs');
 
 const getAppConfig = (process) => {
   let config = parse(

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -1,5 +1,5 @@
-const { parse } = require('toml');
-const { readFileSync } = require('fs');
+import { parse } from 'toml';
+import { readFileSync } from 'fs';
 
 const getAppConfig = (process) => {
   let config = parse(
@@ -64,6 +64,9 @@ const getAppConfig = (process) => {
     config['challengeStartDate'] = process.env.CHALLENGE_START_DATE;
   } else if (process.env.CONTAINER_WIDTH) {
     config['containerWidth'] = process.env.CONTAINER_WIDTH;
+  } else if (process.env.CHALLENGE_LOGGING_WINDOW_DAYS) {
+    config['challengeLoggingWindowDays'] =
+      process.env.CHALLENGE_LOGGING_WINDOW_DAYS;
   }
 
   return config;


### PR DESCRIPTION
Updates behaviour of selecting routes in Calendar:

* User can only select routes within X days in the past (defined in global config)
* If a route is logged (user data saved) it can only be selected individually
* If empty routes are selected and user click on logged route, all other routes are deselected
* If logged route is selected and user clicks on empty route, logged route is deselected

Refactored the route-selection behaviour into a new composable `useCalendarRoutes.ts`.

Disabled eslint rule which prevented from using require in `get_app_conf.js` (this is necessary as we are not using `"type": "module"` in package.json)