### PR TITLE
src/components/routes: update RouteList components' behaviour

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -35,6 +35,6 @@ urlVideoLoggingRoutes = "https://www.youtube.com/embed/ItfTtrEutgo?rel=0"
 urlVideoOnboarding = "https://www.youtube.com/embed/ItfTtrEutgo?rel=0"
 
 challengeMonth = "may"
-challengeStartDate = "2024-10-01T12:00:00"
+challengeStartDate = "2024-08-01T12:00:00"
 containerWidth = "752px"
 challengeLoggingWindowDays = 8

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -44,8 +44,8 @@ describe('<RouteCalendarPanel>', () => {
 
   context('desktop - empty route', () => {
     beforeEach(() => {
-      cy.fixture('routeList').then((listRoutes) => {
-        const routes = [listRoutes[2]];
+      cy.fixture('routeEmpty').then((routeEmpty) => {
+        const routes = [routeEmpty];
         cy.wrap(routes).as('routes');
         cy.mount(RouteCalendarPanel, {
           props: {

--- a/src/components/__tests__/RouteListDisplay.cy.js
+++ b/src/components/__tests__/RouteListDisplay.cy.js
@@ -1,13 +1,19 @@
-import { colors } from 'quasar';
+import { colors, date } from 'quasar';
+import { computed } from 'vue';
 import RouteListDisplay from 'components/routes/RouteListDisplay.vue';
 import { i18n } from '../../boot/i18n';
 import { testRouteListDayDate } from '../../../test/cypress/support/commonTests';
 import { useRoutes } from '../../../src/composables/useRoutes';
-import { TransportDirection } from '../../../src/components/types/Route';
+import { useLogRoutes } from '../../../src/composables/useLogRoutes';
+import { rideToWorkByBikeConfig } from '../../../src/boot/global_vars';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
 const { getTransportLabel } = useRoutes();
+
+// variables
+const { challengeLoggingWindowDays, challengeStartDate } =
+  rideToWorkByBikeConfig;
 
 describe('<RouteListDisplay>', () => {
   it('has translation for all strings', () => {
@@ -72,21 +78,35 @@ function coreTests() {
 
   it('renders route list transport methods', () => {
     cy.fixture('routeList').then((routeList) => {
-      // for each route check if icon is correct
-      cy.dataCy('route-list-item').each(($element, index) => {
-        if (routeList[index].direction === TransportDirection.toWork) {
-          cy.wrap($element)
-            .find('[data-cy="label-direction"]')
-            .should('contain', i18n.global.t('routes.labelDirectionToWork'));
+      // initialize composable function
+      const { hasTransportDistance } = useLogRoutes(computed(() => routeList));
+      // check logged routes by id
+      routeList.forEach((loggedRoute) => {
+        const startDate = date.addToDate(new Date(challengeStartDate), {
+          days: -1,
+        });
+        const endDate = date.addToDate(new Date(), {
+          days: -1 * challengeLoggingWindowDays,
+        });
+        if (loggedRoute.date > startDate && loggedRoute.date <= endDate) {
+          // has transport label
+          cy.dataCy(selectorRouteListItemWrapper)
+            .find(`[data-id="${loggedRoute.id}"]`)
+            .should('contain', getTransportLabel(loggedRoute.transport));
+          // has transport distance (value)
+          if (hasTransportDistance(loggedRoute) && loggedRoute.distance > 0) {
+            cy.dataCy(selectorRouteListItemWrapper)
+              .find(`[data-id="${loggedRoute.id}"]`)
+              .find('[data-cy="label-distance"]')
+              .should('be.visible')
+              .and('have.value', loggedRoute.distance);
+          } else {
+            cy.dataCy(selectorRouteListItemWrapper)
+              .find(`[data-id="${loggedRoute.id}"]`)
+              .find('[data-cy="label-distance"]')
+              .should('not.exist');
+          }
         }
-        if (routeList[index].direction === TransportDirection.fromWork) {
-          cy.wrap($element)
-            .find('[data-cy="label-direction"]')
-            .should('contain', i18n.global.t('routes.labelDirectionFromWork'));
-        }
-        cy.wrap($element)
-          .find('[data-cy="description-transport"]')
-          .should('contain', getTransportLabel(routeList[index].transport));
       });
     });
   });

--- a/src/components/__tests__/RouteListDisplay.cy.js
+++ b/src/components/__tests__/RouteListDisplay.cy.js
@@ -22,6 +22,7 @@ describe('<RouteListDisplay>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-08-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListDisplay, {
           props: {
@@ -41,6 +42,7 @@ describe('<RouteListDisplay>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-08-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListDisplay, {
           props: {

--- a/src/components/__tests__/RouteListDisplay.cy.js
+++ b/src/components/__tests__/RouteListDisplay.cy.js
@@ -14,6 +14,7 @@ const { getTransportLabel } = useRoutes();
 // variables
 const { challengeLoggingWindowDays, challengeStartDate } =
   rideToWorkByBikeConfig;
+const fixedDate = '2024-08-15';
 
 describe('<RouteListDisplay>', () => {
   it('has translation for all strings', () => {
@@ -22,7 +23,7 @@ describe('<RouteListDisplay>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.clock(new Date('2024-08-15').getTime());
+      cy.clock(new Date(fixedDate).getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListDisplay, {
           props: {
@@ -42,7 +43,7 @@ describe('<RouteListDisplay>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.clock(new Date('2024-08-15').getTime());
+      cy.clock(new Date(fixedDate).getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListDisplay, {
           props: {

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -10,6 +10,10 @@ import { rideToWorkByBikeConfig } from '../../../src/boot/global_vars';
 const { getTransportLabel } = useRoutes();
 
 // selectors
+const dataSelectorButtonToggleTransport = '[data-cy="button-toggle-transport"]';
+const dataSelectorInputDistance = '[data-cy="input-distance"]';
+const dataSelectorRouteDistance = '[data-cy="route-distance"]';
+const dataSelectorSelectAction = '[data-cy="select-action"]';
 const selectorButtonSave = 'button-save';
 const selectorRouteListEdit = 'route-list-edit';
 const selectorRouteListItem = 'route-list-item';
@@ -66,7 +70,12 @@ describe('<RouteListEdit>', () => {
       // test changing input type
       cy.dataCy(selectorRouteListItem)
         .first()
-        .find('[data-cy="select-action"]')
+        .find(dataSelectorButtonToggleTransport)
+        .first()
+        .click();
+      cy.dataCy(selectorRouteListItem)
+        .first()
+        .find(dataSelectorSelectAction)
         .select(i18n.global.t('routes.actionTraceMap'));
       cy.dataCy(selectorButtonSave).should(
         'contain',
@@ -75,8 +84,13 @@ describe('<RouteListEdit>', () => {
       // reset
       cy.dataCy(selectorRouteListItem)
         .first()
-        .find('[data-cy="select-action"]')
+        .find(dataSelectorSelectAction)
         .select(i18n.global.t('routes.actionInputDistance'));
+      cy.dataCy(selectorRouteListItem)
+        .first()
+        .find(dataSelectorButtonToggleTransport)
+        .last()
+        .click();
       cy.dataCy(selectorButtonSave).should(
         'contain',
         i18n.global.tc('routes.buttonSaveChangesCount', 0, { count: 0 }),
@@ -142,13 +156,13 @@ function coreTests() {
           if (hasTransportDistance(loggedRoute)) {
             cy.dataCy(selectorRouteListItemWrapper)
               .find(`[data-id="${loggedRoute.id}"]`)
-              .find('[data-cy="route-distance"]')
+              .find(dataSelectorRouteDistance)
               .should('be.visible')
               .and('have.value', loggedRoute.distance);
           } else {
             cy.dataCy(selectorRouteListItemWrapper)
               .find(`[data-id="${loggedRoute.id}"]`)
-              .find('[data-cy="route-distance"]')
+              .find(dataSelectorRouteDistance)
               .should('not.exist');
           }
         }
@@ -168,7 +182,7 @@ function coreTests() {
     // introduce a change
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="button-toggle-transport"]')
+      .find(dataSelectorButtonToggleTransport)
       .last()
       .click();
     cy.dataCy(selectorButtonSave).should(
@@ -178,7 +192,7 @@ function coreTests() {
     // revert change
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="button-toggle-transport"]')
+      .find(dataSelectorButtonToggleTransport)
       .first()
       .click();
     cy.dataCy(selectorButtonSave).should(
@@ -189,14 +203,14 @@ function coreTests() {
     // change first route
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="button-toggle-transport"]')
+      .find(dataSelectorButtonToggleTransport)
       .last()
       .click();
     // change last route
     cy.dataCy(selectorRouteListItem)
       .last()
-      .find('[data-cy="button-toggle-transport"]')
-      .last()
+      .find(dataSelectorButtonToggleTransport)
+      .first()
       .click();
     // count changes
     cy.dataCy(selectorButtonSave).should(
@@ -206,13 +220,13 @@ function coreTests() {
     // revert changes
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="button-toggle-transport"]')
+      .find(dataSelectorButtonToggleTransport)
       .first()
       .click();
     cy.dataCy(selectorRouteListItem)
       .last()
-      .find('[data-cy="button-toggle-transport"]')
-      .first()
+      .find(dataSelectorButtonToggleTransport)
+      .last()
       .click();
     cy.dataCy(selectorButtonSave).should(
       'contain',
@@ -222,15 +236,15 @@ function coreTests() {
     // test inputting distance value
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .clear();
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .type(1);
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .blur();
     cy.dataCy(selectorButtonSave).should(
       'contain',
@@ -239,15 +253,15 @@ function coreTests() {
     // reset
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .clear();
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .type(10);
     cy.dataCy(selectorRouteListItem)
       .first()
-      .find('[data-cy="input-distance"]')
+      .find(dataSelectorInputDistance)
       .blur();
     cy.dataCy(selectorButtonSave).should(
       'contain',

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -1,3 +1,4 @@
+import { date } from 'quasar';
 import { computed } from 'vue';
 import RouteListEdit from 'components/routes/RouteListEdit.vue';
 import { i18n } from '../../boot/i18n';
@@ -27,7 +28,7 @@ describe('<RouteListEdit>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.clock(new Date('2024-03-15').getTime());
+      cy.clock(new Date('2024-08-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListEdit, {
           props: {
@@ -85,7 +86,7 @@ describe('<RouteListEdit>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.clock(new Date('2024-03-15').getTime());
+      cy.clock(new Date('2024-08-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListEdit, {
           props: {
@@ -128,22 +129,28 @@ function coreTests() {
       const { hasTransportDistance } = useLogRoutes(computed(() => routeList));
       // check logged routes by id
       routeList.forEach((loggedRoute) => {
-        // has transport label
-        cy.dataCy(selectorRouteListItemWrapper)
-          .find(`[data-id="${loggedRoute.id}"]`)
-          .should('contain', getTransportLabel(loggedRoute.transport));
-        // has transport distance (value)
-        if (hasTransportDistance(loggedRoute)) {
+        const startDate = date.addToDate(new Date(), {
+          days: -1 * challengeLoggingWindowDays,
+        });
+        const endDate = new Date();
+        if (loggedRoute.date > startDate && loggedRoute.date <= endDate) {
+          // has transport label
           cy.dataCy(selectorRouteListItemWrapper)
             .find(`[data-id="${loggedRoute.id}"]`)
-            .find('[data-cy="route-distance"]')
-            .should('be.visible')
-            .and('have.value', loggedRoute.distance);
-        } else {
-          cy.dataCy(selectorRouteListItemWrapper)
-            .find(`[data-id="${loggedRoute.id}"]`)
-            .find('[data-cy="route-distance"]')
-            .should('not.exist');
+            .should('contain', getTransportLabel(loggedRoute.transport));
+          // has transport distance (value)
+          if (hasTransportDistance(loggedRoute)) {
+            cy.dataCy(selectorRouteListItemWrapper)
+              .find(`[data-id="${loggedRoute.id}"]`)
+              .find('[data-cy="route-distance"]')
+              .should('be.visible')
+              .and('have.value', loggedRoute.distance);
+          } else {
+            cy.dataCy(selectorRouteListItemWrapper)
+              .find(`[data-id="${loggedRoute.id}"]`)
+              .find('[data-cy="route-distance"]')
+              .should('not.exist');
+          }
         }
       });
     });

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -1,7 +1,10 @@
 import RouteListEdit from 'components/routes/RouteListEdit.vue';
 import { i18n } from '../../boot/i18n';
 import { testRouteListDayDate } from '../../../test/cypress/support/commonTests';
-import { TransportDirection } from '../../../src/components/types/Route';
+// import { TransportDirection } from '../../../src/components/types/Route';
+import { useRoutes } from '../../../src/composables/useRoutes';
+
+const { getTransportLabel } = useRoutes();
 
 // selectors
 const selectorButtonSave = 'button-save';
@@ -21,6 +24,7 @@ describe('<RouteListEdit>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-03-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListEdit, {
           props: {
@@ -43,6 +47,7 @@ describe('<RouteListEdit>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-03-15').getTime());
       cy.fixture('routeList').then((routes) => {
         cy.mount(RouteListEdit, {
           props: {
@@ -77,20 +82,12 @@ function coreTests() {
   // day date (title) styles
   testRouteListDayDate();
 
-  it('renders route list transport methods', () => {
+  it.only('renders route list transport methods', () => {
     cy.fixture('routeList').then((routeList) => {
-      // for each route check if icon is correct
-      cy.dataCy(selectorRouteListItem).each(($element, index) => {
-        if (routeList[index].direction === TransportDirection.toWork) {
-          cy.wrap($element)
-            .find('[data-cy="label-direction"]')
-            .should('contain', i18n.global.t('routes.labelDirectionToWork'));
-        }
-        if (routeList[index].direction === TransportDirection.fromWork) {
-          cy.wrap($element)
-            .find('[data-cy="label-direction"]')
-            .should('contain', i18n.global.t('routes.labelDirectionFromWork'));
-        }
+      routeList.forEach((loggedRoute) => {
+        cy.dataCy(selectorRouteListItemWrapper)
+          .find(`[data-id="${loggedRoute.id}"]`)
+          .should('contain', getTransportLabel(loggedRoute.transport));
       });
     });
   });

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -2,9 +2,9 @@ import { computed } from 'vue';
 import RouteListEdit from 'components/routes/RouteListEdit.vue';
 import { i18n } from '../../boot/i18n';
 import { testRouteListDayDate } from '../../../test/cypress/support/commonTests';
-// import { TransportDirection } from '../../../src/components/types/Route';
 import { useRoutes } from '../../../src/composables/useRoutes';
 import { useLogRoutes } from '../../../src/composables/useLogRoutes';
+import { rideToWorkByBikeConfig } from '../../../src/boot/global_vars';
 
 const { getTransportLabel } = useRoutes();
 
@@ -18,6 +18,7 @@ const selectorSectionDirection = 'section-direction';
 // variables
 const routeListItemWrapperWidthDesktop = 50;
 const routeListItemWrapperWidthMobile = 100;
+const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
 
 describe('<RouteListEdit>', () => {
   it('has translation for all strings', () => {
@@ -111,7 +112,9 @@ function coreTests() {
     // component visible
     cy.dataCy(selectorRouteListEdit).should('be.visible');
     // items visible
-    cy.dataCy(selectorRouteListItem).should('be.visible');
+    cy.dataCy(selectorRouteListItem)
+      .should('be.visible')
+      .and('have.length', challengeLoggingWindowDays * 2);
     // direction labels visible
     cy.dataCy(selectorSectionDirection).should('be.visible');
   });

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -61,7 +61,6 @@ export default defineComponent({
   setup(props, { emit }) {
     const { borderRadiusCard: borderRadius, colorGray: borderColor } =
       rideToWorkByBikeConfig;
-
     const routes = computed(() => [props.route]);
     const { action, distance, transportType, isShownDistance } =
       useLogRoutes(routes);
@@ -103,6 +102,7 @@ export default defineComponent({
 
 <template>
   <div
+    v-if="route"
     class="text-grey-10"
     :style="{
       'border-radius': borderRadius,

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -19,13 +19,17 @@
  */
 
 // libraries
-import { computed, defineComponent } from 'vue';
+import { date } from 'quasar';
+import { defineComponent, ref } from 'vue';
 
 // components
 import RouteItemDisplay from './RouteItemDisplay.vue';
 
 // composables
 import { useRoutes } from '../../composables/useRoutes';
+
+// config
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // types
 import type { RouteItem, RouteListDay } from '../types/Route';
@@ -35,18 +39,36 @@ export default defineComponent({
   props: {
     routes: {
       type: Array as () => RouteItem[],
+      required: true,
     },
   },
   components: {
     RouteItemDisplay,
   },
   setup(props) {
-    const { formatDate, formatDateName, getDays } = useRoutes();
-    const days = computed((): RouteListDay[] => {
-      return getDays(props.routes);
+    const { formatDate, formatDateName, createDaysArrayWithRoutes } =
+      useRoutes();
+
+    const { challengeLoggingWindowDays, challengeStartDate } =
+      rideToWorkByBikeConfig;
+    const todayDate = new Date();
+    // Start date is not included in createDaysArrayWithRoutes so we subtract 1 day.
+    const startDate = date.addToDate(new Date(challengeStartDate), {
+      days: -1,
+    });
+    const endDate = date.addToDate(todayDate, {
+      days: -1 * challengeLoggingWindowDays,
     });
 
+    const days = ref<RouteListDay[]>(
+      createDaysArrayWithRoutes(startDate, endDate, props.routes),
+    );
+
     return {
+      challengeLoggingWindowDays,
+      challengeStartDate,
+      startDate,
+      endDate,
       days,
       formatDate,
       formatDateName,

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -65,10 +65,6 @@ export default defineComponent({
     );
 
     return {
-      challengeLoggingWindowDays,
-      challengeStartDate,
-      startDate,
-      endDate,
       days,
       formatDate,
       formatDateName,

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -70,14 +70,29 @@ export default defineComponent({
       </h3>
       <div class="q-py-md">
         <div class="row q-col-gutter-lg">
-          <!-- Item: Route -->
+          <!-- Item: Route to work -->
           <div
-            v-for="route in day.routes"
-            :key="route.id"
+            v-if="day.toWork"
             class="col-12 col-sm-6"
             data-cy="route-list-item-wrapper"
           >
-            <route-item-display :route="route" data-cy="route-list-item" />
+            <route-item-display
+              :route="day.toWork"
+              data-cy="route-list-item"
+              :data-id="day.toWork.id"
+            />
+          </div>
+          <!-- Item: Route from work -->
+          <div
+            v-if="day.fromWork"
+            class="col-12 col-sm-6"
+            data-cy="route-list-item-wrapper"
+          >
+            <route-item-display
+              :route="day.fromWork"
+              data-cy="route-list-item"
+              :data-id="day.fromWork.id"
+            />
           </div>
         </div>
       </div>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -2,8 +2,8 @@
 /**
  * RouteListEdit Component
  *
- * @description * Use this component to render routes in a list view
- * for editing.
+ * @description * Use this component to render routes which can be edited
+ * by the user. The selection of routes is defined by global config.
  *
  * @props
  * - `routes` (RouteItem, required): The object representing a list of routes.
@@ -19,13 +19,20 @@
  */
 
 // libraries
-import { computed, defineComponent, onMounted, ref } from 'vue';
+import { date } from 'quasar';
+import { computed, defineComponent, ref } from 'vue';
 
 // component
 import RouteItemEdit from './RouteItemEdit.vue';
 
 // composables
 import { useRoutes } from 'src/composables/useRoutes';
+
+// config
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+
+// enums
+import { TransportDirection, TransportType } from '../types/Route';
 
 // types
 import type { RouteItem, RouteListDay } from '../types/Route';
@@ -41,18 +48,74 @@ export default defineComponent({
     RouteItemEdit,
   },
   setup(props) {
-    const { formatDate, formatDateName, getDays } = useRoutes();
-    const days = ref([] as RouteListDay[]);
-    // initiate local routes object
-    onMounted(() => {
-      days.value = getDays(props.routes);
-    });
+    const { formatDate, formatDateName, getRouteByDateAndDirection } =
+      useRoutes();
+
+    const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
+
+    const createDaysArray = (numberOfDays: number): RouteListDay[] => {
+      let days = [] as RouteListDay[];
+      const today = new Date();
+      if (props.routes) {
+        for (let i = 0; i < numberOfDays; i++) {
+          const currentDate = date.subtractFromDate(today, { days: i });
+
+          // For any given day, get data from routes or create an empty route.
+          const fromWork = getRouteByDateAndDirection(
+            props.routes,
+            currentDate,
+            TransportDirection.fromWork,
+          );
+          const toWork = getRouteByDateAndDirection(
+            props.routes,
+            currentDate,
+            TransportDirection.toWork,
+          );
+          days.push({
+            id: date.formatDate(currentDate, 'YYYY-MM-DD'),
+            date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+            fromWork: fromWork
+              ? fromWork
+              : ({
+                  id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.fromWork}`,
+                  date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+                  transport: TransportType.bike,
+                  distance: 0,
+                  direction: TransportDirection.fromWork,
+                  dirty: false,
+                  inputType: 'input-number',
+                } as RouteItem),
+            toWork: toWork
+              ? toWork
+              : ({
+                  id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.toWork}`,
+                  date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+                  transport: TransportType.bike,
+                  distance: 0,
+                  direction: TransportDirection.toWork,
+                  dirty: false,
+                  inputType: 'input-number',
+                } as RouteItem),
+          });
+        }
+      }
+      return days;
+    };
+
+    const days = ref<RouteListDay[]>(
+      createDaysArray(challengeLoggingWindowDays),
+    );
 
     // dirty state will be tracked within UI to show change count
     const dirtyCount = computed((): number => {
       let count = 0;
       days.value.forEach((day) => {
-        count += day.routes.filter((route) => route.dirty).length;
+        if (day.fromWork?.dirty) {
+          count += 1;
+        }
+        if (day.toWork?.dirty) {
+          count += 1;
+        }
       });
       return count;
     });
@@ -82,18 +145,24 @@ export default defineComponent({
       </h3>
       <div class="q-py-md">
         <div class="row q-col-gutter-lg">
-          <!-- Item: Route -->
-          <div
-            v-for="route in day.routes"
-            :key="route.id"
-            class="col-12 col-sm-6"
-            data-cy="route-list-item-wrapper"
-          >
+          <!-- Item: Route to work -->
+          <div class="col-12 col-sm-6" data-cy="route-list-item-wrapper">
             <route-item-edit
-              :route="route"
+              :route="day.toWork"
               class="full-height"
               data-cy="route-list-item"
-              @update:route="route.dirty = $event"
+              :data-id="day.toWork?.id"
+              @update:route="day.toWork.dirty = $event"
+            />
+          </div>
+          <!-- Item: Route from work -->
+          <div class="col-12 col-sm-6" data-cy="route-list-item-wrapper">
+            <route-item-edit
+              :route="day.fromWork"
+              class="full-height"
+              data-cy="route-list-item"
+              :data-id="day.fromWork?.id"
+              @update:route="day.fromWork.dirty = $event"
             />
           </div>
         </div>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -31,9 +31,6 @@ import { useRoutes } from 'src/composables/useRoutes';
 // config
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
-// enums
-import { TransportDirection, TransportType } from '../types/Route';
-
 // types
 import type { RouteItem, RouteListDay } from '../types/Route';
 
@@ -42,68 +39,25 @@ export default defineComponent({
   props: {
     routes: {
       type: Array as () => RouteItem[],
+      required: true,
     },
   },
   components: {
     RouteItemEdit,
   },
   setup(props) {
-    const { formatDate, formatDateName, getRouteByDateAndDirection } =
+    const { createDaysArrayWithRoutes, formatDate, formatDateName } =
       useRoutes();
 
     const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
-
-    const createDaysArray = (numberOfDays: number): RouteListDay[] => {
-      let days = [] as RouteListDay[];
-      const today = new Date();
-      if (props.routes) {
-        for (let i = 0; i < numberOfDays; i++) {
-          const currentDate = date.subtractFromDate(today, { days: i });
-
-          // For any given day, get data from routes or create an empty route.
-          const fromWork = getRouteByDateAndDirection(
-            props.routes,
-            currentDate,
-            TransportDirection.fromWork,
-          );
-          const toWork = getRouteByDateAndDirection(
-            props.routes,
-            currentDate,
-            TransportDirection.toWork,
-          );
-          days.push({
-            id: date.formatDate(currentDate, 'YYYY-MM-DD'),
-            date: date.formatDate(currentDate, 'YYYY-MM-DD'),
-            fromWork: fromWork
-              ? fromWork
-              : ({
-                  id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.fromWork}`,
-                  date: date.formatDate(currentDate, 'YYYY-MM-DD'),
-                  transport: TransportType.bike,
-                  distance: 0,
-                  direction: TransportDirection.fromWork,
-                  dirty: false,
-                  inputType: 'input-number',
-                } as RouteItem),
-            toWork: toWork
-              ? toWork
-              : ({
-                  id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.toWork}`,
-                  date: date.formatDate(currentDate, 'YYYY-MM-DD'),
-                  transport: TransportType.bike,
-                  distance: 0,
-                  direction: TransportDirection.toWork,
-                  dirty: false,
-                  inputType: 'input-number',
-                } as RouteItem),
-          });
-        }
-      }
-      return days;
-    };
+    const todayDate = new Date();
+    const startDate = date.addToDate(todayDate, {
+      days: -1 * challengeLoggingWindowDays,
+    });
+    const endDate = todayDate;
 
     const days = ref<RouteListDay[]>(
-      createDaysArray(challengeLoggingWindowDays),
+      createDaysArrayWithRoutes(startDate, endDate, props.routes),
     );
 
     // dirty state will be tracked within UI to show change count

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -3,7 +3,8 @@
  * RouteListEdit Component
  *
  * @description * Use this component to render routes which can be edited
- * by the user. The number of routes to log is defined by global config.
+ * by the user. The number of routes to log is defined by global config var
+ * `challengeLoggingWindowDays`.
  *
  * @props
  * - `routes` (RouteItem, required): The object representing a list of routes.
@@ -64,10 +65,7 @@ export default defineComponent({
     const dirtyCount = computed((): number => {
       let count = 0;
       days.value.forEach((day) => {
-        if (day.fromWork?.dirty) {
-          count += 1;
-        }
-        if (day.toWork?.dirty) {
+        if (day.fromWork?.dirty || day.toWork?.dirty) {
           count += 1;
         }
       });

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -3,7 +3,7 @@
  * RouteListEdit Component
  *
  * @description * Use this component to render routes which can be edited
- * by the user. The selection of routes is defined by global config.
+ * by the user. The number of routes to log is defined by global config.
  *
  * @props
  * - `routes` (RouteItem, required): The object representing a list of routes.

--- a/src/components/types/Route.ts
+++ b/src/components/types/Route.ts
@@ -28,7 +28,7 @@ export type RouteItem = {
   dirty?: boolean;
   distance: number;
   transport: TransportType;
-  inputType: RouteInputType;
+  inputType?: RouteInputType;
 };
 
 export type RouteInputType = 'input-number' | 'input-map';

--- a/src/components/types/Route.ts
+++ b/src/components/types/Route.ts
@@ -28,7 +28,7 @@ export type RouteItem = {
   dirty?: boolean;
   distance: number;
   transport: TransportType;
-  inputType?: RouteInputType;
+  inputType: RouteInputType;
 };
 
 export type RouteInputType = 'input-number' | 'input-map';
@@ -36,7 +36,8 @@ export type RouteInputType = 'input-number' | 'input-map';
 export type RouteListDay = {
   id: string;
   date: string;
-  routes: RouteItem[];
+  fromWork: RouteItem;
+  toWork: RouteItem;
 };
 
 export type RouteCalendarDay = {

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -39,12 +39,21 @@ export const useLogRoutes = (routes: ComputedRef<RouteItem[]>) => {
   });
 
   const isShownDistance = computed((): boolean => {
-    return (
-      transportType.value === TransportType.bike ||
-      transportType.value === TransportType.walk ||
-      transportType.value === TransportType.bus
-    );
+    return hasTransportDistance(transportType.value);
   });
+
+  /**
+   * Checks if the given transport type has distance.
+   * @param {TransportType} transport - The transport type to check.
+   * @return {boolean} Whether the transport has distance.
+   */
+  const hasTransportDistance = (transport: TransportType): boolean => {
+    return (
+      transport === TransportType.bike ||
+      transport === TransportType.walk ||
+      transport === TransportType.bus
+    );
+  };
 
   return {
     action,
@@ -52,5 +61,6 @@ export const useLogRoutes = (routes: ComputedRef<RouteItem[]>) => {
     routesCount,
     transportType,
     isShownDistance,
+    hasTransportDistance,
   };
 };

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -78,6 +78,8 @@ export const useRoutes = () => {
   ): RouteListDay[] => {
     const numberOfDays = date.getDateDiff(endDate, startDate, 'days');
     const days = [] as RouteListDay[];
+    const routeDateFormat = 'YYYY-MM-DD';
+
     if (routes) {
       for (let i = 0; i < numberOfDays; i++) {
         const currentDate = date.subtractFromDate(endDate, { days: i });
@@ -94,13 +96,13 @@ export const useRoutes = () => {
           TransportDirection.toWork,
         );
         days.push({
-          id: date.formatDate(currentDate, 'YYYY-MM-DD'),
-          date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+          id: date.formatDate(currentDate, routeDateFormat),
+          date: date.formatDate(currentDate, routeDateFormat),
           fromWork: fromWork
             ? fromWork
             : ({
-                id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.fromWork}`,
-                date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+                id: `${date.formatDate(currentDate, routeDateFormat)}-${TransportDirection.fromWork}`,
+                date: date.formatDate(currentDate, routeDateFormat),
                 transport: TransportType.none,
                 distance: 0,
                 direction: TransportDirection.fromWork,
@@ -110,8 +112,8 @@ export const useRoutes = () => {
           toWork: toWork
             ? toWork
             : ({
-                id: `${date.formatDate(currentDate, 'YYYY-MM-DD')}-${TransportDirection.toWork}`,
-                date: date.formatDate(currentDate, 'YYYY-MM-DD'),
+                id: `${date.formatDate(currentDate, routeDateFormat)}-${TransportDirection.toWork}`,
+                date: date.formatDate(currentDate, routeDateFormat),
                 transport: TransportType.none,
                 distance: 0,
                 direction: TransportDirection.toWork,

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -5,7 +5,7 @@ import { date } from 'quasar';
 import { i18n } from 'src/boot/i18n';
 
 // enums
-import { TransportType } from 'src/components/types/Route';
+import { TransportDirection, TransportType } from 'src/components/types/Route';
 
 // types
 import type { RouteItem, RouteListDay } from 'src/components/types/Route';
@@ -89,6 +89,30 @@ export const useRoutes = () => {
   };
 
   /**
+   * Retrieves a route from a given list of routes based on date and direction.
+   * @param {RouteItem[]} routes - The list of route items to search through.
+   * @param {Date} dateQuery - Route date.
+   * @param {TransportDirection} directionQuery - Route direction.
+   * @return {RouteItem | null} Matching route, or null if no match is found.
+   */
+  const getRouteByDateAndDirection = (
+    routes: RouteItem[],
+    dateQuery: Date,
+    directionQuery: TransportDirection,
+  ): RouteItem | null => {
+    const route = routes.find((route) => {
+      const matchesDate = date.isSameDate(
+        new Date(route.date),
+        dateQuery,
+        'day',
+      );
+      const matchesDirection = route.direction === directionQuery;
+      return matchesDate && matchesDirection;
+    });
+    return route || null;
+  };
+
+  /**
    * Formats a given date string into a specific format.
    *
    * @param dateString - The date string to be formatted.
@@ -129,6 +153,7 @@ export const useRoutes = () => {
     formatDate,
     formatDateName,
     getDays,
+    getRouteByDateAndDirection,
     getRouteDistance,
     getRouteIcon,
     getTransportLabel,

--- a/test/cypress/fixtures/routeEmpty.json
+++ b/test/cypress/fixtures/routeEmpty.json
@@ -1,0 +1,8 @@
+{
+  "id": "2024-08-14-toWork",
+  "date": "2024-08-14",
+  "transport": "bike",
+  "distance": 0,
+  "direction": "toWork",
+  "dirty": false
+}

--- a/test/cypress/fixtures/routeList.json
+++ b/test/cypress/fixtures/routeList.json
@@ -1,50 +1,50 @@
 [
   {
-    "id": "00001",
-    "date": "2024-03-15T20:00",
+    "id": "2024-03-15-toWork",
+    "date": "2024-03-15",
     "transport": "bike",
     "distance": 10,
     "direction": "toWork",
     "dirty": false
   },
   {
-    "id": "00002",
-    "date": "2024-03-14T20:00",
-    "transport": "bike",
-    "distance": 12,
-    "direction": "fromWork",
-    "dirty": false
-  },
-  {
-    "id": "00003",
-    "date": "2024-11-01T20:00",
-    "transport": null,
-    "distance": null,
-    "direction": "toWork",
-    "dirty": false
-  },
-  {
-    "id": "00004",
-    "date": "2024-11-01T20:00",
-    "transport": "bus",
-    "distance": 10,
-    "direction": "fromWork",
-    "dirty": false
-  },
-  {
-    "id": "00005",
-    "date": "2024-12-01T20:00",
+    "id": "2024-03-14-toWork",
+    "date": "2024-03-14",
     "transport": "car",
     "distance": 0,
     "direction": "toWork",
     "dirty": false
   },
   {
-    "id": "00006",
-    "date": "2024-12-01T20:00",
-    "transport": "none",
-    "distance": 0,
+    "id": "2024-03-14-fromWork",
+    "date": "2024-03-14",
+    "transport": "bike",
+    "distance": 12,
     "direction": "fromWork",
+    "dirty": false
+  },
+  {
+    "id": "2024-03-11-fromWork",
+    "date": "2024-03-11",
+    "transport": "bus",
+    "distance": 10,
+    "direction": "fromWork",
+    "dirty": false
+  },
+  {
+    "id": "2024-03-10-toWork",
+    "date": "2024-03-10",
+    "transport": "car",
+    "distance": 0,
+    "direction": "toWork",
+    "dirty": false
+  },
+  {
+    "id": "2024-03-10-toWork",
+    "date": "2024-03-10",
+    "transport": "car",
+    "distance": 0,
+    "direction": "toWork",
     "dirty": false
   }
 ]

--- a/test/cypress/fixtures/routeList.json
+++ b/test/cypress/fixtures/routeList.json
@@ -1,49 +1,57 @@
 [
   {
-    "id": "2024-03-15-toWork",
-    "date": "2024-03-15",
+    "id": "2024-08-15-toWork",
+    "date": "2024-08-15",
     "transport": "bike",
     "distance": 10,
     "direction": "toWork",
     "dirty": false
   },
   {
-    "id": "2024-03-14-toWork",
-    "date": "2024-03-14",
+    "id": "2024-08-14-toWork",
+    "date": "2024-08-14",
     "transport": "car",
     "distance": 0,
     "direction": "toWork",
     "dirty": false
   },
   {
-    "id": "2024-03-14-fromWork",
-    "date": "2024-03-14",
+    "id": "2024-08-14-fromWork",
+    "date": "2024-08-14",
     "transport": "bike",
     "distance": 12,
     "direction": "fromWork",
     "dirty": false
   },
   {
-    "id": "2024-03-11-fromWork",
-    "date": "2024-03-11",
+    "id": "2024-08-11-fromWork",
+    "date": "2024-08-11",
     "transport": "bus",
     "distance": 10,
     "direction": "fromWork",
     "dirty": false
   },
   {
-    "id": "2024-03-10-toWork",
-    "date": "2024-03-10",
+    "id": "2024-08-10-toWork",
+    "date": "2024-08-10",
     "transport": "car",
     "distance": 0,
     "direction": "toWork",
     "dirty": false
   },
   {
-    "id": "2024-03-10-toWork",
-    "date": "2024-03-10",
+    "id": "2024-08-10-toWork",
+    "date": "2024-08-10",
     "transport": "car",
     "distance": 0,
+    "direction": "toWork",
+    "dirty": false
+  },
+  {
+    "id": "2024-08-05-toWork",
+    "date": "2024-08-05",
+    "transport": "bike",
+    "distance": 15,
     "direction": "toWork",
     "dirty": false
   }


### PR DESCRIPTION
Update behaviour of RouteList components
Specification:

* Always render all routes for an active challenge
* Based on config, render X routes which are editable (`RouteListEdit` component)
* Render the rest of the routes as not editable (`RouteListDisplay` component)
* Logged routes data loaded from DB are integrated into the view

Refactored `getDays` method in `useRoutes.ts` composable to create an array of days with route data.
Updated old `RouteListDay` data structure to mirror the one used in Calendar (using `toWork` and `fromWork` parameters)
Added config settings and updated list components to use them.
Updated tests.