### PR TITLE
src/boot: register Pinia Vue store JS lib

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -34,7 +34,7 @@ module.exports = configure(function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ['logger', 'i18n', 'swiper', 'global_vars'],
+    boot: ['global_vars', 'i18n', 'logger', 'pinia', 'swiper'],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ['app.scss'],

--- a/src/boot/pinia.js
+++ b/src/boot/pinia.js
@@ -1,4 +1,5 @@
-import { store } from 'quasar/wrappers';
+import { boot } from 'quasar/wrappers';
+
 import { createPinia } from 'pinia';
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
 
@@ -16,11 +17,9 @@ import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
  * @see https://prazdevs.github.io/pinia-plugin-persistedstate/guide/limitations.html
  */
 
-export default store(() => {
+export default boot(({ app }) => {
   const pinia = createPinia();
-
   // plugins
   pinia.use(piniaPluginPersistedstate);
-
-  return pinia;
+  app.use(pinia);
 });


### PR DESCRIPTION
Register Pinia Vue store JS lib.

Fixes error message:

```
Uncaught (in promise) Error: [🍍]: "getActivePinia()" was called but there was no active Pinia. Are you trying to use a store before calling "app.use(pinia)"?
See https://pinia.vuejs.org/core-concepts/outside-component-usage.html for help.
This will fail in production.
```