### PR TITLE
src/components/__tests__: correct time setting in TaskListCoordinator tests

### DIFF
--- a/src/components/__tests__/TaskListCoordinator.cy.js
+++ b/src/components/__tests__/TaskListCoordinator.cy.js
@@ -15,11 +15,11 @@ describe('<TaskListCoordinator>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-01-01').getTime());
       cy.mount(TaskListCoordinator, {
         props: {},
       });
       cy.viewport('macbook-16');
-      cy.clock(new Date('2024-01-01').getTime());
     });
 
     coreTests();
@@ -27,11 +27,11 @@ describe('<TaskListCoordinator>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      cy.clock(new Date('2024-01-01').getTime());
       cy.mount(TaskListCoordinator, {
         props: {},
       });
       cy.viewport('iphone-6');
-      cy.clock(new Date('2024-01-01').getTime());
     });
 
     coreTests();


### PR DESCRIPTION
Tests for `TaskListCoordinator` currently fail because the date is not set before component initialization.

Update time setting so that `clock` sets date before component initialization.

Cy components tests error message:

```
  <TaskListCoordinator>
    ✓ has translation for all strings (35ms)
    desktop
      1) renders component
      2) allows to show past tasks
    mobile
      3) renders component
      4) allows to show past tasks


  1 passing (4m)
  4 failing

  1) <TaskListCoordinator>
       desktop
         renders component:

      AssertionError: Timed out retrying after 60000ms: Not enough elements found. Found '2', expected '3'.
      + expected - actual

      -2
      +3
      
      at coreTests/ (/home/runner/work/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/TaskListCoordinator.cy.js:59:10)
      at getRet (http://localhost:9001/__cypress/runner/cypress_runner.js:119259:20)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.try (http://localhost:9001/__cypress/runner/cypress_runner.js:4315:29)
      at thenFn (http://localhost:9001/__cypress/runner/cypress_runner.js:119270:60)
      at then (http://localhost:9001/__cypress/runner/cypress_runner.js:119521:21)
      at wrapped (http://localhost:9001/__cypress/runner/cypress_runner.js:138450:19)
      at __webpack_modules__</runCommand (http://localhost:9001/__cypress/runner/cypress_runner.js:144371:15)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseFromHandler (http://localhost:9001/__cypress/runner/cypress_runner.js:1519:31)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromise (http://localhost:9001/__cypress/runner/cypress_runner.js:1576:18)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseCtx (http://localhost:9001/__cypress/runner/cypress_runner.js:1613:10)
      at _drainQueueStep (http://localhost:9001/__cypress/runner/cypress_runner.js:2411:12)
      at _drainQueue (http://localhost:9001/__cypress/runner/cypress_runner.js:2400:24)
      at __webpack_modules__</Async.prototype._drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2416:16)
      at __webpack_modules__</Async/this.drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2286:14)

  2) <TaskListCoordinator>
       desktop
         allows to show past tasks:

      AssertionError: Timed out retrying after 60000ms: Too many elements found. Found '4', expected '3'.
      + expected - actual

      -4
      +3
      
      at coreTests/ (/home/runner/work/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/TaskListCoordinator.cy.js:93:10)
      at getRet (http://localhost:9001/__cypress/runner/cypress_runner.js:119259:20)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.try (http://localhost:9001/__cypress/runner/cypress_runner.js:4315:29)
      at thenFn (http://localhost:9001/__cypress/runner/cypress_runner.js:119270:60)
      at then (http://localhost:9001/__cypress/runner/cypress_runner.js:119521:21)
      at wrapped (http://localhost:9001/__cypress/runner/cypress_runner.js:138450:19)
      at __webpack_modules__</runCommand (http://localhost:9001/__cypress/runner/cypress_runner.js:144371:15)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseFromHandler (http://localhost:9001/__cypress/runner/cypress_runner.js:1519:31)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromise (http://localhost:9001/__cypress/runner/cypress_runner.js:1576:18)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseCtx (http://localhost:9001/__cypress/runner/cypress_runner.js:1613:10)
      at _drainQueueStep (http://localhost:9001/__cypress/runner/cypress_runner.js:2411:12)
      at _drainQueue (http://localhost:9001/__cypress/runner/cypress_runner.js:2400:24)
      at __webpack_modules__</Async.prototype._drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2416:16)
      at __webpack_modules__</Async/this.drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2286:14)

  3) <TaskListCoordinator>
       mobile
         renders component:

      AssertionError: Timed out retrying after 60000ms: Not enough elements found. Found '2', expected '3'.
      + expected - actual

      -2
      +3
      
      at coreTests/ (/home/runner/work/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/TaskListCoordinator.cy.js:59:10)
      at getRet (http://localhost:9001/__cypress/runner/cypress_runner.js:119259:20)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.try (http://localhost:9001/__cypress/runner/cypress_runner.js:4315:29)
      at thenFn (http://localhost:9001/__cypress/runner/cypress_runner.js:119270:60)
      at then (http://localhost:9001/__cypress/runner/cypress_runner.js:119521:21)
      at wrapped (http://localhost:9001/__cypress/runner/cypress_runner.js:138450:19)
      at __webpack_modules__</runCommand (http://localhost:9001/__cypress/runner/cypress_runner.js:144371:15)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseFromHandler (http://localhost:9001/__cypress/runner/cypress_runner.js:1519:31)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromise (http://localhost:9001/__cypress/runner/cypress_runner.js:1576:18)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseCtx (http://localhost:9001/__cypress/runner/cypress_runner.js:1613:10)
      at _drainQueueStep (http://localhost:9001/__cypress/runner/cypress_runner.js:2411:12)
      at _drainQueue (http://localhost:9001/__cypress/runner/cypress_runner.js:2400:24)
      at __webpack_modules__</Async.prototype._drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2416:16)
      at __webpack_modules__</Async/this.drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2286:14)

  4) <TaskListCoordinator>
       mobile
         allows to show past tasks:

      AssertionError: Timed out retrying after 60000ms: Too many elements found. Found '4', expected '3'.
      + expected - actual

      -4
      +3
      
      at coreTests/ (/home/runner/work/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/TaskListCoordinator.cy.js:93:10)
      at getRet (http://localhost:9001/__cypress/runner/cypress_runner.js:119259:20)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.try (http://localhost:9001/__cypress/runner/cypress_runner.js:4315:29)
      at thenFn (http://localhost:9001/__cypress/runner/cypress_runner.js:119270:60)
      at then (http://localhost:9001/__cypress/runner/cypress_runner.js:119521:21)
      at wrapped (http://localhost:9001/__cypress/runner/cypress_runner.js:138450:19)
      at __webpack_modules__</runCommand (http://localhost:9001/__cypress/runner/cypress_runner.js:144371:15)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseFromHandler (http://localhost:9001/__cypress/runner/cypress_runner.js:1519:31)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromise (http://localhost:9001/__cypress/runner/cypress_runner.js:1576:18)
      at __webpack_modules__</module.exports/Promise.prototype._settlePromiseCtx (http://localhost:9001/__cypress/runner/cypress_runner.js:1613:10)
      at _drainQueueStep (http://localhost:9001/__cypress/runner/cypress_runner.js:2411:12)
      at _drainQueue (http://localhost:9001/__cypress/runner/cypress_runner.js:2400:24)
      at __webpack_modules__</Async.prototype._drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2416:16)
      at __webpack_modules__</Async/this.drainQueues (http://localhost:9001/__cypress/runner/cypress_runner.js:2286:14)




  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        5                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      4                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  4                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     4 minutes, 1 second                                                              │
  │ Spec Ran:     TaskListCoordinator.cy.js                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘

```