### PR TITLE
src/utils: replace JS fs package with fs-extra package

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@originjs/vite-plugin-content": "^1.0.1",
     "@quasar/extras": "^1.0.0",
-    "fs": "^0.0.1-security",
+    "fs-extra": "^11.2.0",
     "pinia": "^2.2.2",
     "pinia-plugin-persistedstate": "^4.0.0",
     "quasar": "^2.6.0",

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { parse } = require('toml');
-const { readFileSync } = require('fs');
+const { readFileSync } = require('fs-extra');
 
 const getAppConfig = (process) => {
   let config = parse(

--- a/src/utils/get_deployed_app_version.js
+++ b/src/utils/get_deployed_app_version.js
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { parse } = require('toml');
-const { existsSync, readFileSync } = require('fs');
+const { existsSync, readFileSync } = require('fs-extra');
 
 const getDeployedAppVersion = () => {
   const deployed_app_version_file = './deployed_app_version.toml';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,7 +3157,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.0:
+fs-extra@^11.1.0, fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
@@ -3196,11 +3196,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz"
-  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
 
 fsevents@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
To fix Quasar framework Vite pre bundle error:

```
✘ [ERROR] [plugin vite:dep-pre-bundle] Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json.

    node_modules/vite/dist/node/chunks/dep-0a035c79.js:40970:10:
      40970 │     throw new Error(`Failed to resolve entry for package "${id}". ` +
            ╵           ^

    at packageEntryFailure (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:40970:11)
    at resolvePackageEntry (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:40966:9)
    at tryNodeResolve (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:40773:20)
    at Context.resolveId (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:40581:28)
    at Object.resolveId (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:39254:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:61588:27
    at async /home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:38771:34
    at async callback (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:933:28)
    at async handleRequest (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:713:30)

  This error came from the "onResolve" callback registered here:

    node_modules/vite/dist/node/chunks/dep-0a035c79.js:38750:18:
      38750 │             build.onResolve({ filter: /^[\w@][^:]/ }, async ({ path: id, importer, kind }) => {
            ╵                   ~~~~~~~~~

    at setup (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:38750:19)
    at handlePlugins (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:855:23)
    at Object.buildOrServe (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:1149:7)
    at /home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:2110:17
    at new Promise (<anonymous>)
    at Object.build (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:2109:14)
    at Object.build (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/node_modules/esbuild/lib/main.js:1956:51)
    at runOptimizeDeps (/home/tomas/auto_mat_software/msimon/ride-to-work-by-bike-frontend/node_modules/vite/dist/node/chunks/dep-0a035c79.js:39994:34)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

  The plugin "vite:dep-pre-bundle" was triggered by this import

    node_modules/geotiff/dist-module/source/file.js:1:15:
      1 │ import fs from 'fs';
```

Required for PR #470 (vue3js-openlayers lib).