### PR TITLE
test/cypress/e2e: fix profile e2e test by testing new menu selectors

### DIFF
--- a/test/cypress/e2e/profile.spec.cy.js
+++ b/test/cypress/e2e/profile.spec.cy.js
@@ -47,7 +47,8 @@ describe('Profile page', () => {
       cy.dataCy('drawer-header').should('be.visible');
       cy.dataCy('user-select').should('be.visible');
       cy.dataCy('drawer-toggle-buttons').should('be.visible');
-      cy.dataCy('drawer-menu').should('be.visible');
+      cy.dataCy('drawer-menu-top').should('be.visible');
+      cy.dataCy('drawer-menu-bottom').should('be.visible');
     });
   });
 });


### PR DESCRIPTION
Update selectors in the `profile` E2E test - `drawer-menu` got replaced with `drawer-menu-top` and `drawer-menu-bottom`