### PR TITLE
test/cypress/support: fix command for testing translation strings

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -51,6 +51,8 @@ Cypress.Commands.add(
     );
 
     translationKeyList.forEach((translationKey) => {
+      // set global locale to English
+      i18n.global.locale = 'en';
       const defaultEnglishString = i18n.global.t(
         translationKey,
         {},
@@ -61,7 +63,7 @@ Cypress.Commands.add(
       locales
         .filter((locale) => locale !== 'en')
         .forEach((locale) => {
-          // required for E2E tests to work
+          // set to the tested locale
           i18n.global.locale = locale;
 
           const translatedString = i18n.global.t(


### PR DESCRIPTION
Issue: In `FormLogin`, some tests did not pass, because the English strings that other translations are compared to were not correctly reset using `global.locale`. This change fixes the issue.