### PR TITLE
Fix REST API login URL missing / on the end of URL path

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -66,4 +66,4 @@ entryFeePaymentOptions = "500,700"
 apiBase = "https://test.dopracenakole.cz/rest/"
 apiVersion = "1.0"
 
-urlApiLogin = "auth/login"
+urlApiLogin = "auth/login/"


### PR DESCRIPTION
Prevent automatically add missing / on the end of URL by backend and redirect original POST request to modified URL with GET request type, which cause backend REST API login HTTP 405 Method Not Allowed error and endpoint return JSON data `{"detail":"Metoda \"GET\" není povolena."}`

Login REST API URL endpoint rest/auth/login/ accept POST, OPTIONS request method type.