### PR TITLE
test/cypress/support: add visibility check before click in UserSelect e2e test

### DIFF
--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -148,7 +148,7 @@ export const testUserSelect = (selector: string): void => {
     ];
 
     cy.dataCy(selector).within(() => {
-      cy.dataCy(selectorUserSelectInput).click();
+      cy.dataCy(selectorUserSelectInput).should('be.visible').click();
     });
     cy.get(classSelectorMenu)
       .should('be.visible')


### PR DESCRIPTION
Add visibility check before click in UserSelect e2e test.
This should help preventing the occasional failures of this test due to button not being clickable.