### PR TITLE
src/layouts: remove button to toggle city admin view from MainLayout

### DIFF
--- a/src/components/__tests__/DrawerToggleButtons.cy.js
+++ b/src/components/__tests__/DrawerToggleButtons.cy.js
@@ -1,6 +1,9 @@
 import DrawerToggleButtons from 'components/global/DrawerToggleButtons.vue';
 import { i18n } from '../../boot/i18n';
 
+// selectors
+const selectorDrawerToggleButtons = 'drawer-toggle-buttons';
+
 describe('<DrawerToggleButtons>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
@@ -24,7 +27,7 @@ describe('<DrawerToggleButtons>', () => {
 
 function coreTests() {
   it('renders component', () => {
-    cy.dataCy('drawer-toggle-buttons')
+    cy.dataCy(selectorDrawerToggleButtons)
       .should('be.visible')
       .and('contain', i18n.global.t('drawerMenu.buttonCityAdministration'))
       .and('contain', i18n.global.t('drawerMenu.buttonParticipation'));

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -6,7 +6,6 @@ import { i18n } from '../boot/i18n';
 // import components
 import DrawerHeader from 'components/global/DrawerHeader.vue';
 import DrawerMenu from 'components/global/DrawerMenu.vue';
-import DrawerToggleButtons from 'src/components/global/DrawerToggleButtons.vue';
 import FooterBar from 'components/global/FooterBar.vue';
 import MobileBottomPanel from 'components/global/MobileBottomPanel.vue';
 import UserSelect from 'components/global/UserSelect.vue';
@@ -33,7 +32,6 @@ export default defineComponent({
   components: {
     DrawerHeader,
     DrawerMenu,
-    DrawerToggleButtons,
     FooterBar,
     MobileBottomPanel,
     UserSelect,
@@ -78,10 +76,6 @@ export default defineComponent({
         <drawer-header data-cy="drawer-header" />
         <!-- User options dropdown -->
         <user-select class="q-pt-lg" data-cy="user-select-desktop" />
-        <drawer-toggle-buttons
-          class="q-pt-lg"
-          data-cy="drawer-toggle-buttons"
-        />
       </div>
       <!-- Navigation menu -->
       <drawer-menu :items="menuTop" class="q-pt-lg" data-cy="drawer-menu-top" />

--- a/test/cypress/e2e/community.spec.cy.js
+++ b/test/cypress/e2e/community.spec.cy.js
@@ -26,7 +26,6 @@ describe('Community page', () => {
       cy.dataCy('q-drawer').should('be.visible');
       cy.dataCy('drawer-header').should('be.visible');
       cy.dataCy('user-select-desktop').should('be.visible');
-      cy.dataCy('drawer-toggle-buttons').should('be.visible');
       cy.dataCy('drawer-menu-top').should('be.visible');
       cy.dataCy('drawer-menu-bottom').should('be.visible');
     });

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -100,7 +100,6 @@ export const testDesktopSidebar = (): void => {
   const selectorDrawer = 'q-drawer';
   const selectorDrawerHeader = 'drawer-header';
   const selectorUserSelectDesktop = 'user-select-desktop';
-  const selectorDrawerToggleButtons = 'drawer-toggle-buttons';
   const selectorDrawerMenuTop = 'drawer-menu-top';
   const selectorDrawerMenuBottom = 'drawer-menu-bottom';
 
@@ -108,7 +107,6 @@ export const testDesktopSidebar = (): void => {
     cy.dataCy(selectorDrawer).should('be.visible');
     cy.dataCy(selectorDrawerHeader).should('be.visible');
     cy.dataCy(selectorUserSelectDesktop).should('be.visible');
-    cy.dataCy(selectorDrawerToggleButtons).should('be.visible');
     cy.dataCy(selectorDrawerMenuTop).should('be.visible');
     cy.dataCy(selectorDrawerMenuBottom).should('be.visible');
   });


### PR DESCRIPTION
Remove button to toggle city admin view from MainLayout.
City admin view is not currently available.