### PR TITLE
src/components: add component PageHeading for all content pages

### DIFF
--- a/src/components/__tests__/BreadcrumbTitle.cy.js
+++ b/src/components/__tests__/BreadcrumbTitle.cy.js
@@ -1,5 +1,10 @@
+import { colors } from 'quasar';
 import BreadcrumbTitle from 'components/global/BreadcrumbTitle.vue';
 import { i18n } from '../../boot/i18n';
+
+// colors
+const { getPaletteColor } = colors;
+const primary = getPaletteColor('primary');
 
 describe('<BreadcrumbTitle>', () => {
   it('has translation for all strings', () => {
@@ -39,6 +44,7 @@ function coreTests() {
     cy.dataCy('breadcrumb-title').should('be.visible');
     cy.dataCy('breadcrumb-title-current')
       .should('be.visible')
-      .and('contain', i18n.global.t('results.titleResultsYou'));
+      .and('contain', i18n.global.t('results.titleResultsYou'))
+      .and('have.color', primary);
   });
 }

--- a/src/components/__tests__/BreadcrumbTitle.cy.js
+++ b/src/components/__tests__/BreadcrumbTitle.cy.js
@@ -4,7 +4,13 @@ import { i18n } from '../../boot/i18n';
 
 // colors
 const { getPaletteColor } = colors;
+const black = getPaletteColor('black');
 const primary = getPaletteColor('primary');
+
+// selectors
+const selectorBreadcrumbTitle = 'breadcrumb-title';
+const selectorBreadcrumbTitleEl = 'breadcrumb-title-el';
+const selectorBreadcrumbTitleCurrent = 'breadcrumb-title-current';
 
 describe('<BreadcrumbTitle>', () => {
   it('has translation for all strings', () => {
@@ -41,10 +47,11 @@ describe('<BreadcrumbTitle>', () => {
 function coreTests() {
   it('renders component', () => {
     // within the component test, the breadcrumb renders only current route
-    cy.dataCy('breadcrumb-title').should('be.visible');
-    cy.dataCy('breadcrumb-title-current')
+    cy.dataCy(selectorBreadcrumbTitle).should('be.visible');
+    cy.dataCy(selectorBreadcrumbTitleEl).should('have.color', primary);
+    cy.dataCy(selectorBreadcrumbTitleCurrent)
       .should('be.visible')
       .and('contain', i18n.global.t('results.titleResultsYou'))
-      .and('have.color', primary);
+      .and('have.color', black);
   });
 }

--- a/src/components/__tests__/PageHeading.cy.js
+++ b/src/components/__tests__/PageHeading.cy.js
@@ -1,0 +1,94 @@
+import { colors } from 'quasar';
+import PageHeading from 'components/global/PageHeading.vue';
+import { i18n } from '../../boot/i18n';
+
+// colors
+const { getPaletteColor } = colors;
+const black = getPaletteColor('black');
+const grey10 = getPaletteColor('grey-10');
+
+// selectors
+const selectorPageHeading = 'page-heading';
+const selectorPageHeadingTitle = 'page-heading-title';
+const selectorPageHeadingPerex = 'page-heading-perex';
+
+// variables
+const title = 'Page Title';
+const perex = 'Page perex';
+const titleFontSize = 34;
+const titleFontWeight = 700;
+const perexFontSize = 14;
+const perexFontWeight = 400;
+const perexMarginTop = 24;
+const componentMarginBottom = 48;
+const componentMarginTop = 24;
+describe('<PageHeading>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.mount(PageHeading, {
+        props: {},
+        slots: {
+          default: title,
+          perex: perex,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.mount(PageHeading, {
+        props: {},
+        slots: {
+          default: title,
+          perex: perex,
+        },
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy(selectorPageHeading).should('be.visible');
+    cy.dataCy(selectorPageHeadingTitle)
+      .should('be.visible')
+      .and('contain', title)
+      .and('have.css', 'font-size', `${titleFontSize}px`)
+      .and('have.css', 'font-weight', `${titleFontWeight}`)
+      .and('have.color', black)
+      .and('contain', title)
+      .and('have.css', 'margin-bottom', '0px')
+      .and('have.css', 'margin-top', '0px');
+    cy.dataCy(selectorPageHeadingPerex)
+      .should('be.visible')
+      .and('have.css', 'font-size', `${perexFontSize}px`)
+      .and('have.css', 'font-weight', `${perexFontWeight}`)
+      .and('have.color', grey10)
+      .and('contain', perex)
+      .and('have.css', 'margin-top', `${perexMarginTop}px`);
+  });
+
+  it('has correct margins', () => {
+    cy.dataCy(selectorPageHeading).should(
+      'have.css',
+      'margin-bottom',
+      `${componentMarginBottom}px`,
+    );
+    cy.dataCy(selectorPageHeading).should(
+      'have.css',
+      'margin-top',
+      `${componentMarginTop}px`,
+    );
+  });
+}

--- a/src/components/__tests__/PageHeading.cy.js
+++ b/src/components/__tests__/PageHeading.cy.js
@@ -10,18 +10,18 @@ const grey10 = getPaletteColor('grey-10');
 // selectors
 const selectorPageHeading = 'page-heading';
 const selectorPageHeadingTitle = 'page-heading-title';
-const selectorPageHeadingPerex = 'page-heading-perex';
+const selectorPageHeadingSecondary = 'page-heading-secondary';
 
 // variables
 const title = 'Page Title';
-const perex = 'Page perex';
+const secondaryContent = 'Secondary Content';
 const titleFontSize = 34;
 const titleFontWeight = 700;
-const perexFontSize = 14;
-const perexFontWeight = 400;
-const perexMarginTop = 24;
+const secondaryFontSize = 14;
+const secondaryFontWeight = 400;
+const secondaryMarginTop = 24;
 const componentMarginBottom = 48;
-const componentMarginTop = 24;
+
 describe('<PageHeading>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext([], 'index.component', i18n);
@@ -33,7 +33,7 @@ describe('<PageHeading>', () => {
         props: {},
         slots: {
           default: title,
-          perex: perex,
+          secondary: secondaryContent,
         },
       });
       cy.viewport('macbook-16');
@@ -48,13 +48,43 @@ describe('<PageHeading>', () => {
         props: {},
         slots: {
           default: title,
-          perex: perex,
+          secondary: secondaryContent,
         },
       });
       cy.viewport('iphone-6');
     });
 
     coreTests();
+  });
+
+  context('horizontal layout', () => {
+    beforeEach(() => {
+      cy.mount(PageHeading, {
+        props: {
+          horizontal: true,
+        },
+        slots: {
+          default: title,
+          secondary: secondaryContent,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('applies horizontal layout classes', () => {
+      cy.testElementsSideBySide(
+        selectorPageHeadingTitle,
+        selectorPageHeadingSecondary,
+      );
+    });
+
+    it('removes top margin from secondary content in horizontal mode', () => {
+      cy.dataCy(selectorPageHeadingSecondary).should(
+        'have.css',
+        'margin-top',
+        '0px',
+      );
+    });
   });
 });
 
@@ -70,13 +100,13 @@ function coreTests() {
       .and('contain', title)
       .and('have.css', 'margin-bottom', '0px')
       .and('have.css', 'margin-top', '0px');
-    cy.dataCy(selectorPageHeadingPerex)
+    cy.dataCy(selectorPageHeadingSecondary)
       .should('be.visible')
-      .and('have.css', 'font-size', `${perexFontSize}px`)
-      .and('have.css', 'font-weight', `${perexFontWeight}`)
+      .and('have.css', 'font-size', `${secondaryFontSize}px`)
+      .and('have.css', 'font-weight', `${secondaryFontWeight}`)
       .and('have.color', grey10)
-      .and('contain', perex)
-      .and('have.css', 'margin-top', `${perexMarginTop}px`);
+      .and('contain', secondaryContent)
+      .and('have.css', 'margin-top', `${secondaryMarginTop}px`);
   });
 
   it('has correct margins', () => {
@@ -84,11 +114,6 @@ function coreTests() {
       'have.css',
       'margin-bottom',
       `${componentMarginBottom}px`,
-    );
-    cy.dataCy(selectorPageHeading).should(
-      'have.css',
-      'margin-top',
-      `${componentMarginTop}px`,
     );
   });
 }

--- a/src/components/__tests__/PageHeading.cy.js
+++ b/src/components/__tests__/PageHeading.cy.js
@@ -40,6 +40,7 @@ describe('<PageHeading>', () => {
     });
 
     coreTests();
+    verticalLayoutTests();
   });
 
   context('mobile', () => {
@@ -55,6 +56,7 @@ describe('<PageHeading>', () => {
     });
 
     coreTests();
+    verticalLayoutTests();
   });
 
   context('horizontal layout', () => {
@@ -70,6 +72,8 @@ describe('<PageHeading>', () => {
       });
       cy.viewport('macbook-16');
     });
+
+    coreTests();
 
     it('applies horizontal layout classes', () => {
       cy.testElementsSideBySide(
@@ -105,8 +109,7 @@ function coreTests() {
       .and('have.css', 'font-size', `${secondaryFontSize}px`)
       .and('have.css', 'font-weight', `${secondaryFontWeight}`)
       .and('have.color', grey10)
-      .and('contain', secondaryContent)
-      .and('have.css', 'margin-top', `${secondaryMarginTop}px`);
+      .and('contain', secondaryContent);
   });
 
   it('has correct margins', () => {
@@ -114,6 +117,16 @@ function coreTests() {
       'have.css',
       'margin-bottom',
       `${componentMarginBottom}px`,
+    );
+  });
+}
+
+function verticalLayoutTests() {
+  it('has margin top on secondary content', () => {
+    cy.dataCy(selectorPageHeadingSecondary).should(
+      'have.css',
+      'margin-top',
+      `${secondaryMarginTop}px`,
     );
   });
 }

--- a/src/components/global/BreadcrumbTitle.vue
+++ b/src/components/global/BreadcrumbTitle.vue
@@ -68,7 +68,11 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-breadcrumbs active-color="black" data-cy="breadcrumb-title">
+  <q-breadcrumbs
+    class="text-h4 text-weight-bold"
+    active-color="black"
+    data-cy="breadcrumb-title"
+  >
     <template v-slot:separator>
       <q-icon size="32px" color="primary" name="chevron_right" />
     </template>

--- a/src/components/global/BreadcrumbTitle.vue
+++ b/src/components/global/BreadcrumbTitle.vue
@@ -68,13 +68,9 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-breadcrumbs
-    class="text-h5 text-gray-7 text-weight-regular"
-    active-color="gray-10"
-    data-cy="breadcrumb-title"
-  >
+  <q-breadcrumbs active-color="black" data-cy="breadcrumb-title">
     <template v-slot:separator>
-      <q-icon size="24px" name="chevron_right" />
+      <q-icon size="32px" color="primary" name="chevron_right" />
     </template>
 
     <q-breadcrumbs-el
@@ -83,12 +79,9 @@ export default defineComponent({
       :label="$t(`breadcrumb.${page.name}`)"
       :icon="page.icon"
       :to="page.path"
+      class="text-primary"
       data-cy="breadcrumb-title-el"
     />
-    <q-breadcrumbs-el
-      class="text-weight-bold"
-      :label="title"
-      data-cy="breadcrumb-title-current"
-    />
+    <q-breadcrumbs-el :label="title" data-cy="breadcrumb-title-current" />
   </q-breadcrumbs>
 </template>

--- a/src/components/global/PageHeading.vue
+++ b/src/components/global/PageHeading.vue
@@ -21,7 +21,7 @@
  *   </template>
  * </page-heading>
  *
- * @see [Figma Design](...)
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=7004-32012&t=IZOUj0U34mMeiIrt-1)
  */
 
 // libraries

--- a/src/components/global/PageHeading.vue
+++ b/src/components/global/PageHeading.vue
@@ -1,0 +1,53 @@
+<script lang="ts">
+/**
+ * PageHeading Component
+ *
+ * @description Use this component to render a heading for a page.
+ *
+ * @slots
+ * - `title`: For the page title (optional).
+ * - `perex`: For the page perex (optional).
+ *
+ * @example
+ * <page-heading>
+ *   <template #title>
+ *     Page Title
+ *   </template>
+ *   <template #perex>
+ *     Page perex
+ *   </template>
+ * </page-heading>
+ *
+ * @see [Figma Design](...)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'PageHeading',
+});
+</script>
+
+<template>
+  <div
+    v-if="$slots.default || $slots.perex"
+    data-cy="page-heading"
+    class="q-mt-lg q-mb-xl"
+  >
+    <h1
+      v-if="$slots.default"
+      class="text-h4 text-weight-bold text-black q-my-none"
+      data-cy="page-heading-title"
+    >
+      <slot />
+    </h1>
+    <div
+      v-if="$slots.perex"
+      class="q-mt-lg text-subtitle2 text-weight-regular text-grey-10"
+      data-cy="page-heading-perex"
+    >
+      <slot name="perex" />
+    </div>
+  </div>
+</template>

--- a/src/components/global/PageHeading.vue
+++ b/src/components/global/PageHeading.vue
@@ -2,19 +2,22 @@
 /**
  * PageHeading Component
  *
- * @description Use this component to render a heading for a page.
+ * @description Use this component to render a heading for a page with an optional secondary element.
+ *
+ * @props
+ * - `horizontal` (Boolean): If true, applies a horizontal layout with flex properties.
  *
  * @slots
- * - `title`: For the page title (optional).
- * - `perex`: For the page perex (optional).
+ * - `default`: For the page title (optional).
+ * - `secondary`: For secondary content or UI elements (optional).
  *
  * @example
- * <page-heading>
- *   <template #title>
+ * <page-heading horizontal>
+ *   <template #default>
  *     Page Title
  *   </template>
- *   <template #perex>
- *     Page perex
+ *   <template #secondary>
+ *     <q-btn>Action</q-btn>
  *   </template>
  * </page-heading>
  *
@@ -26,14 +29,23 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'PageHeading',
+  props: {
+    horizontal: {
+      type: Boolean,
+      default: false,
+    },
+  },
 });
 </script>
 
 <template>
   <div
-    v-if="$slots.default || $slots.perex"
+    v-if="$slots.default || $slots.secondary"
     data-cy="page-heading"
-    class="q-mt-lg q-mb-xl"
+    class="q-mb-xl"
+    :class="{
+      'col-12 flex flex-wrap items-center justify-between gap-16': horizontal,
+    }"
   >
     <h1
       v-if="$slots.default"
@@ -43,11 +55,12 @@ export default defineComponent({
       <slot />
     </h1>
     <div
-      v-if="$slots.perex"
-      class="q-mt-lg text-subtitle2 text-weight-regular text-grey-10"
-      data-cy="page-heading-perex"
+      v-if="$slots.secondary"
+      class="text-subtitle2 text-weight-regular text-grey-10"
+      :class="{ 'q-mt-lg': !horizontal }"
+      data-cy="page-heading-secondary"
     >
-      <slot name="perex" />
+      <slot name="secondary" />
     </div>
   </div>
 </template>

--- a/src/components/global/PageHeading.vue
+++ b/src/components/global/PageHeading.vue
@@ -17,7 +17,7 @@
  *     Page Title
  *   </template>
  *   <template #secondary>
- *     <q-btn>Action</q-btn>
+ *     Secondary content
  *   </template>
  * </page-heading>
  *

--- a/src/components/global/PageHeading.vue
+++ b/src/components/global/PageHeading.vue
@@ -47,6 +47,7 @@ export default defineComponent({
       'col-12 flex flex-wrap items-center justify-between gap-16': horizontal,
     }"
   >
+    <!-- Title -->
     <h1
       v-if="$slots.default"
       class="text-h4 text-weight-bold text-black q-my-none"
@@ -54,6 +55,8 @@ export default defineComponent({
     >
       <slot />
     </h1>
+
+    <!-- Secondary content -->
     <div
       v-if="$slots.secondary"
       class="text-subtitle2 text-weight-regular text-grey-10"

--- a/src/pages/CommunityPage.vue
+++ b/src/pages/CommunityPage.vue
@@ -24,6 +24,7 @@ import ForumPostList from 'src/components/community/ForumPostList.vue';
 import ListCardFollow from '../components/homepage/ListCardFollow.vue';
 import ListCardPost from 'src/components/homepage/ListCardPost.vue';
 import ListCardSlider from '../components/global/ListCardSlider.vue';
+import PageHeading from 'src/components/global/PageHeading.vue';
 import SectionHeading from 'src/components/global/SectionHeading.vue';
 
 // composables
@@ -54,6 +55,7 @@ export default defineComponent({
     ListCardFollow,
     ListCardPost,
     ListCardSlider,
+    PageHeading,
     SectionHeading,
   },
   setup() {
@@ -83,21 +85,21 @@ export default defineComponent({
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
     <div class="q-px-lg bg-white q-pb-xl q-pt-lg">
-      <!-- Section title -->
-      <div class="col-12 flex flex-wrap items-center justify-between gap-16">
-        <!-- Page title -->
-        <div>
-          <h1
-            class="text-h5 q-my-none text-weight-bold"
-            data-cy="community-page-title"
-          >
-            {{ $t('community.titleCommunity') }}
-          </h1>
-        </div>
-
-        <!-- Select: City -->
-        <FormFieldSelectCity v-model="city" data-cy="form-field-select-city" />
-      </div>
+      <!-- Page title -->
+      <page-heading
+        horizontal
+        class="q-mt-none q-mb-none"
+        data-cy="community-page-title"
+      >
+        {{ $t('community.titleCommunity') }}
+        <template #secondary>
+          <!-- Select: City -->
+          <form-field-select-city
+            v-model="city"
+            data-cy="form-field-select-city"
+          />
+        </template>
+      </page-heading>
 
       <!-- Section: Local events -->
       <div class="q-mt-lg">

--- a/src/pages/CompanyCoordinatorPage.vue
+++ b/src/pages/CompanyCoordinatorPage.vue
@@ -13,9 +13,14 @@
 // libraries
 import { defineComponent } from 'vue';
 
+// components
+import PageHeading from 'components/global/PageHeading.vue';
+
 export default defineComponent({
   name: 'CompanyCoordinatorPage',
-  components: {},
+  components: {
+    PageHeading,
+  },
   setup() {
     return {};
   },
@@ -29,14 +34,9 @@ export default defineComponent({
       <!-- Section title -->
       <div class="col-12 flex flex-wrap items-center justify-between gap-16">
         <!-- Page title -->
-        <div>
-          <h1
-            class="text-h5 q-my-none text-weight-bold"
-            data-cy="company-coordinator-title"
-          >
-            {{ $t('companyCoordinator.titleBecomeCoordinator') }}
-          </h1>
-        </div>
+        <page-heading data-cy="company-coordinator-title">
+          {{ $t('companyCoordinator.titleBecomeCoordinator') }}
+        </page-heading>
       </div>
 
       <div class="row q-col-gutter-lg">

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -1,12 +1,9 @@
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
     <div class="q-px-lg bg-white">
-      <h1
-        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
-        data-cy="index-title"
-      >
+      <page-heading data-cy="index-title">
         {{ $t('index.title') }}
-      </h1>
+      </page-heading>
       <countdown-event :release-date="releaseDate" data-cy="countdown-event" />
       <!-- Title -->
       <section-heading class="q-pt-xl q-mb-md" data-cy="card-list-title">
@@ -137,6 +134,7 @@ import ListCardOffer from 'components/homepage/ListCardOffer.vue';
 import ListCardPost from 'components/homepage/ListCardPost.vue';
 import ListCardProgress from 'components/homepage/ListCardProgress.vue';
 import NewsletterFeature from 'components/homepage/NewsletterFeature.vue';
+import PageHeading from 'src/components/global/PageHeading.vue';
 import SectionColumns from 'components/homepage/SectionColumns.vue';
 import SectionHeading from 'src/components/global/SectionHeading.vue';
 import SliderProgress from 'components/homepage/SliderProgress.vue';
@@ -171,6 +169,7 @@ export default defineComponent({
     ListCardPost,
     ListCardProgress,
     NewsletterFeature,
+    PageHeading,
     SectionColumns,
     SectionHeading,
     SliderProgress,

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
-    <div class="q-px-lg bg-white">
+    <div class="q-px-lg q-pt-lg bg-white">
       <page-heading data-cy="index-title">
         {{ $t('index.title') }}
       </page-heading>

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -21,6 +21,7 @@ import CardOffer from '../components/homepage/CardOffer.vue';
 import CardPrize from 'src/components/global/CardPrize.vue';
 import FormFieldSelectCity from 'src/components/form/FormFieldSelectCity.vue';
 import ListPartners from '../components/global/ListPartners.vue';
+import PageHeading from 'components/global/PageHeading.vue';
 import SectionColumns from '../components/homepage/SectionColumns.vue';
 import SectionHeading from '../components/global/SectionHeading.vue';
 
@@ -38,6 +39,7 @@ export default defineComponent({
     CardPrize,
     FormFieldSelectCity,
     ListPartners,
+    PageHeading,
     SectionColumns,
     SectionHeading,
   },
@@ -61,21 +63,17 @@ export default defineComponent({
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
     <div class="q-px-lg bg-white q-pb-xl q-pt-lg">
-      <!-- Section title -->
-      <div class="col-12 flex flex-wrap items-center justify-between gap-16">
-        <!-- Page title -->
-        <div>
-          <h1
-            class="text-h5 q-my-none text-weight-bold"
-            data-cy="prizes-page-title"
-          >
-            {{ $t('prizes.titlePrizes') }}
-          </h1>
-        </div>
-
-        <!-- Select: City -->
-        <FormFieldSelectCity v-model="city" data-cy="form-field-select-city" />
-      </div>
+      <!-- Page title -->
+      <page-heading horizontal data-cy="prizes-page-title">
+        {{ $t('prizes.titlePrizes') }}
+        <template #secondary>
+          <!-- Select: City -->
+          <form-field-select-city
+            v-model="city"
+            data-cy="form-field-select-city"
+          />
+        </template>
+      </page-heading>
 
       <!-- Section: Special offers -->
       <div class="q-mt-xl">

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -14,11 +14,13 @@
  */
 
 // components
+import PageHeading from 'components/global/PageHeading.vue';
 import ProfileTabs from '../components/profile/ProfileTabs.vue';
 
 export default {
   name: 'ProfilePage',
   components: {
+    PageHeading,
     ProfileTabs,
   },
 };
@@ -26,17 +28,12 @@ export default {
 
 <template>
   <q-page class="overflow-hidden" data-cy="profile-page">
-    <div class="q-px-lg bg-white q-pb-xl q-pt-lg">
+    <div class="q-px-lg bg-white q-pt-lg">
       <!-- Page title -->
-      <div>
-        <h1
-          class="text-h5 q-my-none text-weight-bold"
-          data-cy="profile-page-title"
-        >
-          {{ $t('profile.titleProfile') }}
-        </h1>
-      </div>
+      <page-heading data-cy="profile-page-title">
+        {{ $t('profile.titleProfile') }}
+      </page-heading>
     </div>
-    <profile-tabs class="bg-white" data-cy="profile-tabs" />
+    <profile-tabs class="bg-white q-pb-xl" data-cy="profile-tabs" />
   </q-page>
 </template>

--- a/src/pages/ResultsDetailPage.vue
+++ b/src/pages/ResultsDetailPage.vue
@@ -17,6 +17,7 @@ import { defineComponent } from 'vue';
 // components
 import BreadcrumbTitle from 'src/components/global/BreadcrumbTitle.vue';
 import ListCardSlider from '../components/global/ListCardSlider.vue';
+import PageHeading from 'src/components/global/PageHeading.vue';
 import ResultsList from '../components/results/ResultsList.vue';
 import ResultsTabs from '../components/results/ResultsTabs.vue';
 
@@ -31,6 +32,7 @@ export default defineComponent({
   components: {
     BreadcrumbTitle,
     ListCardSlider,
+    PageHeading,
     ResultsList,
     ResultsTabs,
   },
@@ -51,10 +53,10 @@ export default defineComponent({
 
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
-    <div class="q-px-lg bg-white q-pb-xl">
-      <div class="q-pt-lg">
+    <div class="q-px-lg bg-white q-pt-lg q-pb-xl">
+      <page-heading data-cy="results-detail-page-title">
         <breadcrumb-title :title="$t('results.titleResultsYou')" />
-      </div>
+      </page-heading>
 
       <results-list data-cy="results-list" />
 

--- a/src/pages/ResultsPage.vue
+++ b/src/pages/ResultsPage.vue
@@ -17,12 +17,14 @@
 import { defineComponent } from 'vue';
 
 // components
+import PageHeading from 'components/global/PageHeading.vue';
 import ResultsChallengeOngoing from 'components/results/ResultsChallengeOngoing.vue';
 import ResultsChallengeUpcoming from 'components/results/ResultsChallengeUpcoming.vue';
 
 export default defineComponent({
   name: 'ResultsPage',
   components: {
+    PageHeading,
     ResultsChallengeOngoing,
     ResultsChallengeUpcoming,
   },
@@ -36,14 +38,11 @@ export default defineComponent({
 
 <template>
   <q-page class="overflow-hidden" data-cy="q-main">
-    <div class="q-px-lg bg-white q-pb-xl">
+    <div class="q-px-lg q-pt-lg bg-white q-pb-xl">
       <!-- Heading -->
-      <h1
-        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
-        data-cy="results-page-title"
-      >
+      <page-heading data-cy="results-page-title">
         {{ $t('results.titleResults') }}
-      </h1>
+      </page-heading>
 
       <results-challenge-upcoming
         v-if="state === 'challenge-upcoming'"

--- a/src/pages/RoutesPage.vue
+++ b/src/pages/RoutesPage.vue
@@ -1,16 +1,17 @@
 <template>
   <q-page class="overflow-hidden bg-white" data-cy="q-main">
-    <div class="q-px-lg">
-      <h1
-        class="text-h5 q-mt-none q-pt-lg text-weight-bold"
-        data-cy="routes-page-title"
-      >
+    <div class="q-px-lg q-pt-lg">
+      <page-heading data-cy="routes-page-title">
         {{ $t('routes.titleRoutes') }}
-      </h1>
-      <div data-cy="routes-page-instructions">
-        <p>{{ $t('routes.instructionRouteLogTimeframe') }}</p>
-        <p>{{ $t('routes.instructionRouteCombination') }}</p>
-      </div>
+        <template #secondary>
+          <div data-cy="routes-page-instructions">
+            <p>{{ $t('routes.instructionRouteLogTimeframe') }}</p>
+            <p class="q-mb-none">
+              {{ $t('routes.instructionRouteCombination') }}
+            </p>
+          </div>
+        </template>
+      </page-heading>
     </div>
     <route-tabs data-cy="route-tabs" />
   </q-page>
@@ -21,12 +22,14 @@
 import { defineComponent } from 'vue';
 
 // components
+import PageHeading from 'src/components/global/PageHeading.vue';
 import RouteTabs from 'src/components/routes/RouteTabs.vue';
 
 export default defineComponent({
   name: 'RoutesPage',
   components: {
     RouteTabs,
+    PageHeading,
   },
 });
 </script>

--- a/test/cypress/e2e/community.spec.cy.js
+++ b/test/cypress/e2e/community.spec.cy.js
@@ -62,7 +62,7 @@ function coreTests() {
         .then(($el) => {
           cy.wrap(i18n.global.t('community.titleCommunity')).then(
             (translation) => {
-              expect($el.text()).to.equal(translation);
+              cy.wrap($el).should('contain', translation);
             },
           );
         });

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -360,8 +360,6 @@ function coreTests() {
       cy.dataCy('q-main').should('be.visible');
       cy.dataCy('index-title')
         .should('be.visible')
-        .and('have.css', 'font-size', '24px')
-        .and('have.css', 'font-weight', '700')
         .then(($el) => {
           cy.wrap(i18n.global.t('index.title')).then((translation) => {
             expect($el.text()).to.equal(translation);

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -51,7 +51,11 @@ function coreTests() {
       // title
       cy.dataCy('prizes-page-title')
         .should('be.visible')
-        .and('contain', i18n.global.t('prizes.titlePrizes'));
+        .then(($el) => {
+          cy.wrap(i18n.global.t('prizes.titlePrizes')).then((translation) => {
+            cy.wrap($el).should('contain', translation);
+          });
+        });
       cy.dataCy('form-field-select-city').should('be.visible');
     });
   });

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -51,11 +51,7 @@ function coreTests() {
       // title
       cy.dataCy('prizes-page-title')
         .should('be.visible')
-        .then(($el) => {
-          cy.wrap(i18n.global.t('prizes.titlePrizes')).then((translation) => {
-            expect($el.text()).to.equal(translation);
-          });
-        });
+        .and('contain', i18n.global.t('prizes.titlePrizes'));
       cy.dataCy('form-field-select-city').should('be.visible');
     });
   });


### PR DESCRIPTION
Add component `PageHeading` to unify styling across the content pages.

Accommodates for the following use cases:

* Additional content below the title.
* Additional content on the same row as title (flexed to the right) - uses the `horizontal` prop.
* Allows to be used with `BreadcrumbTitle` component, showing breadcrumb on nested pages.

Updates E2E tests where appropriate to only check for content and not styling.