### PR TITLE
config: update and unify the white background color from config

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -8,10 +8,10 @@ colorGray = "#D4D4D4"
 colorGrayLight = "#F3F7FF"
 colorGrayMiddle = "#DCE1ED"
 colorWhite = "#FFFFFF"
-colorWhiteOpacity = "rgba(255, 255, 255, 0.5)"
 colorBlack = "#000000"
 colorRed = "#F15857"
 colorSecondaryBackgroundOpacity = 0.4
+colorWhiteBackgroundOpacity = 0.2
 
 # STYLING ATTRIBUTES
 

--- a/src/components/__tests__/BannerAppButtons.cy.js
+++ b/src/components/__tests__/BannerAppButtons.cy.js
@@ -19,7 +19,7 @@ const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
 const whiteOpacity = changeAlpha(
   white,
-  rideToWorkByBikeConfig.opacityWhiteBackground,
+  rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
 
 describe('<BannerAppButtons>', () => {

--- a/src/components/__tests__/BannerAppButtons.cy.js
+++ b/src/components/__tests__/BannerAppButtons.cy.js
@@ -15,8 +15,12 @@ const rideToWorkByBikeConfig = JSON.parse(
 const urlAppStore = rideToWorkByBikeConfig.urlAppStore;
 const urlGooglePlay = rideToWorkByBikeConfig.urlGooglePlay;
 
-const { getPaletteColor } = colors;
-const grey10 = getPaletteColor('grey-10');
+const { getPaletteColor, changeAlpha } = colors;
+const white = getPaletteColor('white');
+const whiteOpacity = changeAlpha(
+  white,
+  rideToWorkByBikeConfig.opacityWhiteBackground,
+);
 
 describe('<BannerAppButtons>', () => {
   it('has translation for all strings', () => {
@@ -38,7 +42,7 @@ describe('<BannerAppButtons>', () => {
     it('renders container with semi-transparent white background and rounded corners', () => {
       cy.dataCy('banner-app-buttons')
         .should('have.css', 'padding', '16px')
-        .and('have.backgroundColor', 'rgba(255, 255, 255, 0.5)')
+        .and('have.backgroundColor', whiteOpacity)
         .and('have.css', 'border-radius', '8px');
     });
 
@@ -46,7 +50,7 @@ describe('<BannerAppButtons>', () => {
       cy.dataCy('banner-app-buttons-title')
         .should('have.css', 'font-size', '14px')
         .and('have.css', 'font-weight', '700')
-        .and('have.color', grey10)
+        .and('have.color', white)
         .and('contain', i18n.global.t('login.bannerAppButtons.title'))
         .then(($title) => {
           expect($title.text()).to.equal(
@@ -59,7 +63,7 @@ describe('<BannerAppButtons>', () => {
       cy.dataCy('banner-app-buttons-description')
         .should('have.css', 'font-size', '12px')
         .and('have.css', 'font-weight', '400')
-        .and('have.color', grey10)
+        .and('have.color', white)
         .and('contain', i18n.global.t('login.bannerAppButtons.description'))
         .then(($description) => {
           expect($description.text()).to.equal(

--- a/src/components/__tests__/EmailVerification.cy.js
+++ b/src/components/__tests__/EmailVerification.cy.js
@@ -13,7 +13,7 @@ const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
 const whiteOpacity = changeAlpha(
   white,
-  rideToWorkByBikeConfig.opacityWhiteBackground,
+  rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
 
 // selectors

--- a/src/components/__tests__/EmailVerification.cy.js
+++ b/src/components/__tests__/EmailVerification.cy.js
@@ -11,7 +11,10 @@ import { httpSuccessfullStatus } from '../../../test/cypress/support/commonTests
 // colors
 const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
-const whiteOpacity20 = changeAlpha(white, 0.2);
+const whiteOpacity = changeAlpha(
+  white,
+  rideToWorkByBikeConfig.opacityWhiteBackground,
+);
 
 // selectors
 const selectorEmailVerification = 'email-verification';
@@ -163,7 +166,7 @@ function coreTests() {
     // avatar
     cy.dataCy(selectorEmailVerificationAvatar)
       .should('be.visible')
-      .and('have.backgroundColor', whiteOpacity20)
+      .and('have.backgroundColor', whiteOpacity)
       .invoke('height')
       .should('eq', avatarSize);
     cy.dataCy(selectorEmailVerificationAvatar)

--- a/src/components/__tests__/FormLogin.cy.js
+++ b/src/components/__tests__/FormLogin.cy.js
@@ -19,12 +19,16 @@ const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
 const primary = getPaletteColor('primary');
 const secondary = getPaletteColor('secondary');
-const whiteOpacity20 = changeAlpha(white, 0.2);
+const whiteOpacity = changeAlpha(
+  white,
+  rideToWorkByBikeConfig.opacityWhiteBackground,
+);
 
 // selectors
 const classSelectorQNotificationMessage = '.q-notification__message';
 const selectorLoginPromptNoAccount = 'login-prompt-no-account';
 const selectorLoginLinkRegister = 'login-link-register';
+const selectorFormLoginSeparator = 'form-login-separator';
 
 // variables
 const {
@@ -157,6 +161,12 @@ describe('<FormLogin>', () => {
         .should('have.attr', 'type', 'password');
     });
 
+    it('renders separator', () => {
+      cy.dataCy(selectorFormLoginSeparator)
+        .should('be.visible')
+        .and('have.backgroundColor', whiteOpacity);
+    });
+
     it('renders forgotten password link', () => {
       cy.dataCy('form-login-forgotten-password')
         .should('be.visible')
@@ -276,7 +286,7 @@ describe('<FormLogin>', () => {
       // icon wrapper
       cy.dataCy('form-reset-finished-icon-wrapper')
         .should('be.visible')
-        .and('have.backgroundColor', whiteOpacity20)
+        .and('have.backgroundColor', whiteOpacity)
         .and('have.css', 'border-radius', '50%');
       // icon
       cy.dataCy('form-reset-finished-icon')

--- a/src/components/__tests__/FormLogin.cy.js
+++ b/src/components/__tests__/FormLogin.cy.js
@@ -21,7 +21,7 @@ const primary = getPaletteColor('primary');
 const secondary = getPaletteColor('secondary');
 const whiteOpacity = changeAlpha(
   white,
-  rideToWorkByBikeConfig.opacityWhiteBackground,
+  rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
 
 // selectors

--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -19,7 +19,7 @@ const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
 const whiteOpacity = changeAlpha(
   white,
-  rideToWorkByBikeConfig.opacityWhiteBackground,
+  rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
 
 // selectors

--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -15,8 +15,12 @@ import {
 import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_lang';
 
 // colors
-const { getPaletteColor } = colors;
+const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
+const whiteOpacity = changeAlpha(
+  white,
+  rideToWorkByBikeConfig.opacityWhiteBackground,
+);
 
 // selectors
 const selectorFormRegisterTitle = 'form-register-title';
@@ -51,13 +55,8 @@ const fontWeightText = 400;
 const router = route();
 const testEmail = 'test@test.com';
 const testPassword = '12345a';
-const {
-  apiBase,
-  apiDefaultLang,
-  colorWhiteOpacity,
-  borderRadiusCardSmall,
-  urlApiRegister,
-} = rideToWorkByBikeConfig;
+const { apiBase, apiDefaultLang, borderRadiusCardSmall, urlApiRegister } =
+  rideToWorkByBikeConfig;
 
 const compareRegisterResponseWithStore = (registerResponse) => {
   cy.contains(i18n.global.t('register.apiMessageSuccess')).should('be.visible');
@@ -258,7 +257,7 @@ describe('<FormRegister>', () => {
       // wrapper
       cy.dataCy(selectorFormRegisterCoordinator)
         .should('have.css', 'padding', '16px')
-        .and('have.backgroundColor', colorWhiteOpacity)
+        .and('have.backgroundColor', whiteOpacity)
         .and('have.css', 'border-radius', borderRadiusCardSmall);
       // description
       cy.dataCy(selectorFormRegisterCoordinatorDescription)

--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -47,6 +47,7 @@ const selectorFormRegisterTextNoActiveChallenge =
 const selectorFormRegisterPrivacyConsent = 'form-register-privacy-consent';
 const selectorFormRegisterNewsletterSubscription =
   'form-register-newsletter-subscription';
+const selectorFormRegisterSeparator = 'form-register-separator';
 
 // variables
 const iconSize = 18;
@@ -161,6 +162,12 @@ describe('<FormRegister>', () => {
       cy.dataCy(selectorFormRegisterPasswordConfirmIcon)
         .invoke('width')
         .should('be.equal', iconSize);
+    });
+
+    it('renders separator', () => {
+      cy.dataCy(selectorFormRegisterSeparator)
+        .should('be.visible')
+        .and('have.backgroundColor', whiteOpacity);
     });
 
     testPasswordInputReveal(selectorFormRegisterPassword);

--- a/src/components/login/BannerAppButtons.vue
+++ b/src/components/login/BannerAppButtons.vue
@@ -28,7 +28,7 @@ export default defineComponent({
     const { getPaletteColor, changeAlpha } = colors;
     const whiteOpacity = changeAlpha(
       getPaletteColor('white'),
-      rideToWorkByBikeConfig.opacityWhiteBackground,
+      rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
     const urlGooglePlay = rideToWorkByBikeConfig.urlGooglePlay;

--- a/src/components/login/BannerAppButtons.vue
+++ b/src/components/login/BannerAppButtons.vue
@@ -26,9 +26,8 @@ export default defineComponent({
   name: 'BannerAppButtons',
   setup() {
     const { getPaletteColor, changeAlpha } = colors;
-    const white = getPaletteColor('white');
     const whiteOpacity = changeAlpha(
-      white,
+      getPaletteColor('white'),
       rideToWorkByBikeConfig.opacityWhiteBackground,
     );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;

--- a/src/components/login/BannerAppButtons.vue
+++ b/src/components/login/BannerAppButtons.vue
@@ -16,6 +16,7 @@
  */
 
 // libraries
+import { colors } from 'quasar';
 import { defineComponent } from 'vue';
 
 // config
@@ -24,16 +25,21 @@ import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 export default defineComponent({
   name: 'BannerAppButtons',
   setup() {
-    const backgroundColor = rideToWorkByBikeConfig.colorWhiteOpacity;
+    const { getPaletteColor, changeAlpha } = colors;
+    const white = getPaletteColor('white');
+    const whiteOpacity = changeAlpha(
+      white,
+      rideToWorkByBikeConfig.opacityWhiteBackground,
+    );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
     const urlGooglePlay = rideToWorkByBikeConfig.urlGooglePlay;
     const urlAppStore = rideToWorkByBikeConfig.urlAppStore;
 
     return {
-      backgroundColor,
       borderRadius,
       urlGooglePlay,
       urlAppStore,
+      whiteOpacity,
     };
   },
 });
@@ -41,9 +47,9 @@ export default defineComponent({
 
 <template>
   <div
-    class="q-pa-md text-grey-10"
+    class="q-pa-md text-white"
     :style="{
-      'background-color': backgroundColor,
+      'background-color': whiteOpacity,
       'border-radius': borderRadius,
     }"
     data-cy="banner-app-buttons"

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -194,7 +194,11 @@ export default defineComponent({
       />
     </q-form>
     <!-- Separator -->
-    <q-separator :style="{ backgroundColor: whiteOpacity }" class="q-my-lg" />
+    <q-separator
+      :style="{ backgroundColor: whiteOpacity }"
+      class="q-my-lg"
+      data-cy="form-login-separator"
+    />
     <!-- Buttons: Login with 3rd party -->
     <login-register-buttons variant="login" />
     <!-- Link: Register -->

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -88,7 +88,7 @@ export default defineComponent({
     const { getPaletteColor, changeAlpha } = colors;
     const whiteOpacity = changeAlpha(
       getPaletteColor('white'),
-      rideToWorkByBikeConfig.opacityWhiteBackground,
+      rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
 
     return {

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -68,7 +68,6 @@ export default defineComponent({
       loginStore.setLoginFormState(state);
     };
 
-    const backgroundColor = rideToWorkByBikeConfig.colorWhiteOpacity;
     const contactEmail = computed(() => loginStore.getPasswordResetEmail);
 
     const { isEmail, isFilled } = useValidation();
@@ -88,10 +87,12 @@ export default defineComponent({
     // colors
     const { getPaletteColor, changeAlpha } = colors;
     const white = getPaletteColor('white');
-    const whiteOpacity20 = changeAlpha(white, 0.2);
+    const whiteOpacity = changeAlpha(
+      white,
+      rideToWorkByBikeConfig.opacityWhiteBackground,
+    );
 
     return {
-      backgroundColor,
       contactEmail,
       formPasswordReset,
       formState,
@@ -99,7 +100,7 @@ export default defineComponent({
       LoginFormState,
       loginLoading,
       formLogin,
-      whiteOpacity20,
+      whiteOpacity,
       isEmail,
       isFilled,
       onSubmitLogin,
@@ -193,7 +194,7 @@ export default defineComponent({
       />
     </q-form>
     <!-- Separator -->
-    <q-separator :style="{ backgroundColor: whiteOpacity20 }" class="q-my-lg" />
+    <q-separator :style="{ backgroundColor: whiteOpacity }" class="q-my-lg" />
     <!-- Buttons: Login with 3rd party -->
     <login-register-buttons variant="login" />
     <!-- Link: Register -->
@@ -280,7 +281,7 @@ export default defineComponent({
       <div class="flex">
         <q-avatar
           size="64px"
-          :style="{ backgroundColor: whiteOpacity20 }"
+          :style="{ backgroundColor: whiteOpacity }"
           data-cy="form-reset-finished-icon-wrapper"
         >
           <q-icon

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -86,9 +86,8 @@ export default defineComponent({
 
     // colors
     const { getPaletteColor, changeAlpha } = colors;
-    const white = getPaletteColor('white');
     const whiteOpacity = changeAlpha(
-      white,
+      getPaletteColor('white'),
       rideToWorkByBikeConfig.opacityWhiteBackground,
     );
 

--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -73,15 +73,13 @@ export default defineComponent({
 
     // colors
     const { getPaletteColor, changeAlpha } = colors;
-    const white = getPaletteColor('white');
     const whiteOpacity = changeAlpha(
-      white,
+      getPaletteColor('white'),
       rideToWorkByBikeConfig.opacityWhiteBackground,
     );
 
     return {
       email,
-      white,
       whiteOpacity,
     };
   },
@@ -95,7 +93,7 @@ export default defineComponent({
       <q-avatar
         size="64px"
         :style="{ backgroundColor: whiteOpacity }"
-        :color="white"
+        color="white"
         data-cy="email-verification-avatar"
       >
         <!-- Icon -->

--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -74,12 +74,15 @@ export default defineComponent({
     // colors
     const { getPaletteColor, changeAlpha } = colors;
     const white = getPaletteColor('white');
-    const whiteOpacity20 = changeAlpha(white, 0.2);
+    const whiteOpacity = changeAlpha(
+      white,
+      rideToWorkByBikeConfig.opacityWhiteBackground,
+    );
 
     return {
       email,
       white,
-      whiteOpacity20,
+      whiteOpacity,
     };
   },
 });
@@ -91,7 +94,7 @@ export default defineComponent({
     <div class="q-mb-lg" data-cy="email-verification-graphics">
       <q-avatar
         size="64px"
-        :style="{ backgroundColor: whiteOpacity20 }"
+        :style="{ backgroundColor: whiteOpacity }"
         :color="white"
         data-cy="email-verification-avatar"
       >

--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     const { getPaletteColor, changeAlpha } = colors;
     const whiteOpacity = changeAlpha(
       getPaletteColor('white'),
-      rideToWorkByBikeConfig.opacityWhiteBackground,
+      rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
 
     return {

--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -92,8 +92,7 @@ export default defineComponent({
     <div class="q-mb-lg" data-cy="email-verification-graphics">
       <q-avatar
         size="64px"
-        :style="{ backgroundColor: whiteOpacity }"
-        color="white"
+        :style="{ backgroundColor: whiteOpacity, color: 'white' }"
         data-cy="email-verification-avatar"
       >
         <!-- Icon -->

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -82,7 +82,7 @@ export default defineComponent({
     const { getPaletteColor, changeAlpha } = colors;
     const whiteOpacity = changeAlpha(
       getPaletteColor('white'),
-      rideToWorkByBikeConfig.opacityWhiteBackground,
+      rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
 

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -26,6 +26,7 @@
  */
 
 // libraries
+import { colors } from 'quasar';
 import { defineComponent, ref, reactive, computed } from 'vue';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
@@ -78,11 +79,16 @@ export default defineComponent({
       formRegister.password2 = '';
     };
 
-    const backgroundColor = rideToWorkByBikeConfig.colorWhiteOpacity;
+    const { getPaletteColor, changeAlpha } = colors;
+    const white = getPaletteColor('white');
+    const whiteOpacity = changeAlpha(
+      white,
+      rideToWorkByBikeConfig.opacityWhiteBackground,
+    );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
 
     return {
-      backgroundColor,
+      whiteOpacity,
       borderRadius,
       formRegister,
       isActiveChallenge,
@@ -291,7 +297,7 @@ export default defineComponent({
         <div
           class="q-pa-md text-body2 text-white"
           :style="{
-            'background-color': backgroundColor,
+            'background-color': whiteOpacity,
             'border-radius': borderRadius,
           }"
           data-cy="form-register-coordinator"

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -80,9 +80,8 @@ export default defineComponent({
     };
 
     const { getPaletteColor, changeAlpha } = colors;
-    const white = getPaletteColor('white');
     const whiteOpacity = changeAlpha(
-      white,
+      getPaletteColor('white'),
       rideToWorkByBikeConfig.opacityWhiteBackground,
     );
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -289,7 +289,11 @@ export default defineComponent({
         data-cy="form-register-submit"
       />
       <!-- Separator -->
-      <q-separator color="grey-2" class="q-my-lg" />
+      <q-separator
+        :style="{ backgroundColor: whiteOpacity }"
+        class="q-my-lg"
+        data-cy="form-register-separator"
+      />
       <!-- Buttons: Register with 3rd party -->
       <login-register-buttons variant="register" />
       <!-- Link: Register Coordinator -->

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -7,10 +7,10 @@ export interface ConfigGlobal {
   colorGrayLight: string;
   colorGrayMiddle: string;
   colorWhite: string;
-  colorWhiteOpacity: string;
   colorBlack: string;
   colorRed: string;
   colorSecondaryBackgroundOpacity: number;
+  colorWhiteBackgroundOpacity: number;
   image: string;
   width: string;
   title: string;

--- a/src/utils/get_app_conf.js
+++ b/src/utils/get_app_conf.js
@@ -23,15 +23,15 @@ const getAppConfig = (process) => {
     config['colorGrayMiddle'] = process.env.COLOR_GRAY_MIDDLE;
   } else if (process.env.COLOR_WHITE) {
     config['colorWhite'] = process.env.COLOR_WHITE;
-  } else if (process.env.COLOR_WHITE_OPACITY) {
-    config['colorWhiteOpacity'] = process.env.COLOR_WHITE_OPACITY;
   } else if (process.env.COLOR_BLACK) {
     config['colorBlack'] = process.env.COLOR_BLACK;
   } else if (process.env.COLOR_RED) {
     config['colorRed'] = process.env.COLOR_RED;
   } else if (process.env.COLOR_SECONDARY_BACKGROUND_OPACITY) {
     config['colorSecondaryBackgroundOpacity'] =
-      process.env.OPACITY_SECONDARY_BACKGROUND;
+      process.env.COLOR_SECONDARY_BACKGROUND_OPACITY;
+  } else if (process.env.COLOR_WHITE_BACKGROUND_OPACITY) {
+    config['colorWhiteBackgroundOpacity'] = process.env.COLOR_WHITE_BACKGROUND_OPACITY;
   } else if (process.env.IMAGE) {
     config['image'] = process.env.IMAGE;
   } else if (process.env.WIDTH) {


### PR DESCRIPTION
Update the approach to getting a white background color with opacity.
* Define shared variable opacity in config.
* Use opacity to derive whiteOpacity color in components.
* Change color of text in white box on login screen.
* Unify color of separators on login and register screens and add tests.

Unifies inconsistency in design file:

1. [white email icon on white background 20%](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=6269-24822&t=Kg5tEX1Skno3i6DW-1)
2. [blue email icon on white background 50%](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=6385-26491&t=Kg5tEX1Skno3i6DW-1)

Renders all instances of given icon as variant 1.