### PR TITLE
src/components/__tests__: fix request header when requesting Facebook URL in FooterBar tests

### DIFF
--- a/src/components/__tests__/FooterBar.cy.js
+++ b/src/components/__tests__/FooterBar.cy.js
@@ -8,6 +8,7 @@ import {
   httpSuccessfullStatus,
   httpTooManyRequestsStatus,
   httpTooManyRequestsStatusMessage,
+  userAgentHeader,
 } from '../../../test/cypress/support/commonTests';
 
 // colors
@@ -238,6 +239,7 @@ function coreTests() {
     cy.request({
       url: rideToWorkByBikeConfig.urlFacebook,
       failOnStatusCode: failOnStatusCode,
+      headers: { ...userAgentHeader },
     }).then((resp) => {
       if (resp.status === httpTooManyRequestsStatus) {
         cy.log(httpTooManyRequestsStatusMessage);

--- a/src/components/__tests__/FooterBar.cy.js
+++ b/src/components/__tests__/FooterBar.cy.js
@@ -50,12 +50,6 @@ const flexWrap = 'wrap';
 const fontSize = '14px';
 const fontWeight = '400';
 
-// Fix make request user-agent header on the macOS with Google Chrome web browser
-const urlTwitterUserAgentHeader =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
-AppleWebKit/537.36 (KHTML, like Gecko) \
-Chrome/119.0.0.0 Safari/537.36';
-
 describe('<FooterBar>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext([], 'index.component', i18n);
@@ -259,7 +253,7 @@ function coreTests() {
     });
     cy.request({
       url: rideToWorkByBikeConfig.urlTwitter,
-      headers: { 'user-agent': urlTwitterUserAgentHeader },
+      headers: { ...userAgentHeader },
       failOnStatusCode: failOnStatusCode,
     }).then((resp) => {
       if (resp.status === httpTooManyRequestsStatus) {

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -267,6 +267,10 @@ export const httpInternalServerErrorStatus = 500;
 export const httpTooManyRequestsStatus = 429;
 export const httpTooManyRequestsStatusMessage = `HTTP status code ${httpTooManyRequestsStatus} Too Many Requests ("rate limiting").`;
 export const failOnStatusCode = false;
+export const userAgentHeader = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+};
 
 // access token expiration time: Tuesday 24. September 2024 22:36:03
 const fixtureTokenExpiration = new Date('2024-09-24T20:36:03Z');


### PR DESCRIPTION
In `FooterBar` tests, add `User-Agent` header to fix response code value of the `cy.request`.