### PR TITLE
src/components: add component LoginRegisterMobileMenu for responsive header

### DIFF
--- a/src/components/__tests__/LoginRegisterHeader.cy.js
+++ b/src/components/__tests__/LoginRegisterHeader.cy.js
@@ -12,12 +12,14 @@ const selectorButtonHelp = 'button-help';
 const selectorIconHelp = 'icon-help';
 const selectorLanguageSwitcher = 'language-switcher';
 const selectorLogo = 'header-logo';
+const selectorLoginRegisterMobileMenu = 'login-register-mobile-menu';
 
 // variables
 const helpButtonFontSize = '15px';
 const helpButtonSize = 45;
 const iconHelpSize = 38;
-const logoHeight = 80;
+const logoHeightDesktop = 80;
+const logoHeightMobile = 48;
 
 describe('<LoginRegisterHeader>', () => {
   it('has translation for all strings', () => {
@@ -33,7 +35,40 @@ describe('<LoginRegisterHeader>', () => {
       cy.viewport('macbook-16');
     });
 
-    coreTests();
+    it('renders logo in desktop size', () => {
+      cy.dataCy(selectorLogo)
+        .should('be.visible')
+        .invoke('height')
+        .should('be.equal', logoHeightDesktop);
+    });
+
+    it('renders help button', () => {
+      // button
+      cy.dataCy(selectorButtonHelp)
+        .should('be.visible')
+        .and('have.css', 'font-size', helpButtonFontSize)
+        .and('have.css', 'font-weight', '500')
+        .and('have.backgroundColor', white)
+        .and('have.css', 'border-radius', '50%');
+      cy.dataCy(selectorButtonHelp)
+        .invoke('height')
+        .should('be.equal', helpButtonSize);
+      cy.dataCy(selectorButtonHelp)
+        .invoke('width')
+        .should('be.equal', helpButtonSize);
+      // icon
+      cy.dataCy(selectorIconHelp).should('have.color', primary);
+      cy.dataCy(selectorIconHelp)
+        .invoke('height')
+        .should('be.equal', iconHelpSize);
+      cy.dataCy(selectorIconHelp)
+        .invoke('width')
+        .should('be.equal', iconHelpSize);
+    });
+
+    it('renders language switcher', () => {
+      cy.dataCy(selectorLanguageSwitcher).should('be.visible');
+    });
   });
 
   context('mobile', () => {
@@ -44,43 +79,15 @@ describe('<LoginRegisterHeader>', () => {
       cy.viewport('iphone-6');
     });
 
-    coreTests();
+    it('renders logo in mobile size', () => {
+      cy.dataCy(selectorLogo)
+        .should('be.visible')
+        .invoke('height')
+        .should('be.equal', logoHeightMobile);
+    });
+
+    it('renders login register mobile menu', () => {
+      cy.dataCy(selectorLoginRegisterMobileMenu).should('be.visible');
+    });
   });
 });
-
-function coreTests() {
-  it('renders logo', () => {
-    cy.dataCy(selectorLogo)
-      .should('be.visible')
-      .invoke('height')
-      .should('be.equal', logoHeight);
-  });
-
-  it('renders help button', () => {
-    // button
-    cy.dataCy(selectorButtonHelp)
-      .should('be.visible')
-      .and('have.css', 'font-size', helpButtonFontSize)
-      .and('have.css', 'font-weight', '500')
-      .and('have.backgroundColor', white)
-      .and('have.css', 'border-radius', '50%');
-    cy.dataCy(selectorButtonHelp)
-      .invoke('height')
-      .should('be.equal', helpButtonSize);
-    cy.dataCy(selectorButtonHelp)
-      .invoke('width')
-      .should('be.equal', helpButtonSize);
-    // icon
-    cy.dataCy(selectorIconHelp).should('have.color', primary);
-    cy.dataCy(selectorIconHelp)
-      .invoke('height')
-      .should('be.equal', iconHelpSize);
-    cy.dataCy(selectorIconHelp)
-      .invoke('width')
-      .should('be.equal', iconHelpSize);
-  });
-
-  it('renders language switcher', () => {
-    cy.dataCy(selectorLanguageSwitcher).should('be.visible');
-  });
-}

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -5,9 +5,10 @@ import LoginRegisterMobileMenu from 'components/global/LoginRegisterMobileMenu.v
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { emptyUser, useLoginStore } from '../../stores/login';
+import { rgbaColorObjectToString } from '../../utils';
 
 // colors
-const { getPaletteColor } = colors;
+const { getPaletteColor, changeAlpha, hexToRgb } = colors;
 const primary = getPaletteColor('primary');
 const white = getPaletteColor('white');
 
@@ -31,7 +32,7 @@ const selectorMobileMenu = 'login-register-mobile-menu';
 
 // variables
 const fontWeightBold = 700;
-const border = `1px solid rgba(255, 255, 255, ${colorWhiteBackgroundOpacity})`;
+const border = `1px solid ${rgbaColorObjectToString(hexToRgb(changeAlpha(white, colorWhiteBackgroundOpacity)))}`;
 
 describe('<LoginRegisterMobileMenu>', () => {
   beforeEach(() => {

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -5,32 +5,32 @@ import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { useLoginStore } from '../../stores/login';
 
-// config
-const { borderRadiusCard, colorWhiteBackgroundOpacity } =
-  rideToWorkByBikeConfig;
-
 // colors
 const { getPaletteColor } = colors;
 const primary = getPaletteColor('primary');
 const white = getPaletteColor('white');
-const border = `1px solid rgba(255, 255, 255, ${colorWhiteBackgroundOpacity})`;
+
+// config
+const { borderRadiusCard, colorWhiteBackgroundOpacity } =
+  rideToWorkByBikeConfig;
 
 // selectors
-const selectorMobileMenu = 'login-register-mobile-menu';
+const selectorDialogHelp = 'dialog-help';
 const selectorMenuButton = 'mobile-menu-button';
 const selectorMenuDropdown = 'mobile-menu-dropdown';
 const selectorMenuHelp = 'mobile-menu-help';
-const selectorDialogHelp = 'dialog-help';
 const selectorMenuLanguageHeader = 'mobile-menu-language-header';
 const selectorMenuLanguageSwitcher = 'mobile-menu-language-switcher';
 const selectorMenuLogout = 'mobile-menu-logout';
-const selectorMenuUserInfo = 'mobile-menu-user-info';
-const selectorMenuUserInfoLabel = 'mobile-menu-user-info-label';
-const selectorMenuUserInfoEmail = 'mobile-menu-user-info-email';
 const selectorMenuSeparator = 'mobile-menu-separator';
+const selectorMenuUserInfo = 'mobile-menu-user-info';
+const selectorMenuUserInfoEmail = 'mobile-menu-user-info-email';
+const selectorMenuUserInfoLabel = 'mobile-menu-user-info-label';
+const selectorMobileMenu = 'login-register-mobile-menu';
 
 // variables
 const fontWeightBold = 700;
+const border = `1px solid rgba(255, 255, 255, ${colorWhiteBackgroundOpacity})`;
 
 describe('<LoginRegisterMobileMenu>', () => {
   beforeEach(() => {

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -1,9 +1,10 @@
+import { nextTick } from 'vue';
 import { colors } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 import LoginRegisterMobileMenu from 'components/global/LoginRegisterMobileMenu.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
-import { useLoginStore } from '../../stores/login';
+import { emptyUser, useLoginStore } from '../../stores/login';
 
 // colors
 const { getPaletteColor } = colors;
@@ -171,6 +172,25 @@ describe('<LoginRegisterMobileMenu>', () => {
         cy.dataCy(selectorMenuSeparator).last().should('exist');
         cy.dataCy(selectorMenuLanguageHeader).should('be.visible');
         cy.dataCy(selectorMenuLanguageSwitcher).should('be.visible');
+      });
+    });
+
+    it('logs out user when logout button is clicked', () => {
+      const store = useLoginStore();
+      // user is logged in
+      cy.wrap(store.getUserEmail).should('not.be.empty');
+      // open menu and click logout
+      cy.dataCy(selectorMenuButton).click();
+      cy.dataCy(selectorMenuLogout).click();
+      // menu is closed
+      cy.dataCy(selectorMenuDropdown).should('not.exist');
+      // store is cleared
+      nextTick(() => {
+        cy.wrap(store.getUserEmail).should('be.empty');
+        cy.wrap(store.getUser).should('deep.equal', emptyUser);
+        cy.wrap(store.getAccessToken).should('be.empty');
+        cy.wrap(store.getRefreshToken).should('be.empty');
+        cy.wrap(store.getJwtExpiration).should('be.null');
       });
     });
   });

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -1,0 +1,25 @@
+import LoginRegisterMobileMenu from 'components/global/LoginRegisterMobileMenu.vue';
+import { i18n } from '../../boot/i18n';
+
+describe('<LoginRegisterMobileMenu>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('default', () => {
+    beforeEach(() => {
+      cy.mount(LoginRegisterMobileMenu, {
+        props: {},
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    cy.dataCy('component').should('be.visible');
+  });
+}

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -41,10 +41,11 @@ describe('<LoginRegisterMobileMenu>', () => {
 
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
-      ['labelHelp', 'labelLanguage', 'labelLoggedInAs', 'labelLogOut'],
+      ['labelHelp', 'labelLanguage', 'labelLoggedInAs'],
       'loginRegisterMobileMenu',
       i18n,
     );
+    cy.testLanguageStringsInContext(['logout'], 'userSelect', i18n);
   });
 
   context('logged out', () => {
@@ -158,7 +159,7 @@ describe('<LoginRegisterMobileMenu>', () => {
       // logout button
       cy.dataCy(selectorMenuLogout)
         .should('be.visible')
-        .and('contain', i18n.global.t('loginRegisterMobileMenu.labelLogOut'));
+        .and('contain', i18n.global.t('userSelect.logout'));
     });
 
     it('shows all menu items and separators', () => {

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -2,11 +2,17 @@ import { colors } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 import LoginRegisterMobileMenu from 'components/global/LoginRegisterMobileMenu.vue';
 import { i18n } from '../../boot/i18n';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
+
+// config
+const { borderRadiusCard, colorWhiteBackgroundOpacity } =
+  rideToWorkByBikeConfig;
 
 // colors
 const { getPaletteColor } = colors;
 const primary = getPaletteColor('primary');
 const white = getPaletteColor('white');
+const border = `1px solid rgba(255, 255, 255, ${colorWhiteBackgroundOpacity})`;
 
 // selectors
 const selectorMobileMenu = 'login-register-mobile-menu';
@@ -57,7 +63,11 @@ describe('<LoginRegisterMobileMenu>', () => {
       // click menu button
       cy.dataCy(selectorMenuButton).click();
       // menu dropdown
-      cy.dataCy(selectorMenuDropdown).should('be.visible');
+      cy.dataCy(selectorMenuDropdown)
+        .should('be.visible')
+        .and('have.backgroundColor', primary)
+        .and('have.css', 'border', border)
+        .and('have.css', 'border-radius', borderRadiusCard);
       // help button
       cy.dataCy(selectorMenuHelp).should('be.visible');
       // language header

--- a/src/components/__tests__/LoginRegisterMobileMenu.cy.js
+++ b/src/components/__tests__/LoginRegisterMobileMenu.cy.js
@@ -1,12 +1,37 @@
+import { colors } from 'quasar';
+import { createPinia, setActivePinia } from 'pinia';
 import LoginRegisterMobileMenu from 'components/global/LoginRegisterMobileMenu.vue';
 import { i18n } from '../../boot/i18n';
 
+// colors
+const { getPaletteColor } = colors;
+const primary = getPaletteColor('primary');
+const white = getPaletteColor('white');
+
+// selectors
+const selectorMobileMenu = 'login-register-mobile-menu';
+const selectorMenuButton = 'mobile-menu-button';
+const selectorMenuDropdown = 'mobile-menu-dropdown';
+const selectorMenuHelp = 'mobile-menu-help';
+const selectorDialogHelp = 'dialog-help';
+const selectorMenuLanguageHeader = 'mobile-menu-language-header';
+const selectorMenuLanguageSwitcher = 'mobile-menu-language-switcher';
+const selectorMenuUserInfo = 'mobile-menu-user-info';
+
 describe('<LoginRegisterMobileMenu>', () => {
-  it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  beforeEach(() => {
+    setActivePinia(createPinia());
   });
 
-  context('default', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['labelHelp', 'labelLanguage', 'labelLoggedInAs', 'labelLogOut'],
+      'loginRegisterMobileMenu',
+      i18n,
+    );
+  });
+
+  context('logged out', () => {
     beforeEach(() => {
       cy.mount(LoginRegisterMobileMenu, {
         props: {},
@@ -14,12 +39,56 @@ describe('<LoginRegisterMobileMenu>', () => {
       cy.viewport('iphone-6');
     });
 
-    coreTests();
+    it('renders component', () => {
+      cy.dataCy(selectorMobileMenu).should('be.visible');
+    });
+
+    it('renders menu button with correct styling', () => {
+      cy.dataCy(selectorMenuButton)
+        .should('be.visible')
+        .and('have.backgroundColor', white)
+        .and('have.color', primary);
+    });
+
+    it('shows menu with correct items when clicked', () => {
+      // menu initially hidden
+      cy.dataCy(selectorMenuDropdown).should('not.exist');
+      cy.dataCy(selectorMenuUserInfo).should('not.exist');
+      // click menu button
+      cy.dataCy(selectorMenuButton).click();
+      // menu dropdown
+      cy.dataCy(selectorMenuDropdown).should('be.visible');
+      // help button
+      cy.dataCy(selectorMenuHelp).should('be.visible');
+      // language header
+      cy.dataCy(selectorMenuLanguageHeader)
+        .should('be.visible')
+        .and('contain', i18n.global.t('loginRegisterMobileMenu.labelLanguage'));
+      // language switcher
+      cy.dataCy(selectorMenuLanguageSwitcher).should('be.visible');
+    });
+
+    it('renders help button', () => {
+      // open menu
+      cy.dataCy(selectorMenuButton).click();
+      // help button
+      cy.dataCy(selectorMenuHelp)
+        .should('be.visible')
+        .and('contain', i18n.global.t('loginRegisterMobileMenu.labelHelp'));
+      // click help button
+      cy.dataCy(selectorMenuHelp).click();
+      // help dialog
+      cy.dataCy(selectorDialogHelp).should('be.visible');
+    });
+
+    it('renders language switcher', () => {
+      // open menu
+      cy.dataCy(selectorMenuButton).click();
+      // language switcher
+      cy.dataCy(selectorMenuLanguageSwitcher)
+        .should('be.visible')
+        .find('[data-cy="language-switcher"]')
+        .should('exist');
+    });
   });
 });
-
-function coreTests() {
-  it('renders component', () => {
-    cy.dataCy('component').should('be.visible');
-  });
-}

--- a/src/components/global/LoginRegisterHeader.vue
+++ b/src/components/global/LoginRegisterHeader.vue
@@ -74,7 +74,7 @@ export default defineComponent({
     </div>
     <div v-else class="flex items-center gap-16">
       <!-- Mobile menu -->
-      <login-register-mobile-menu />
+      <login-register-mobile-menu data-cy="login-register-mobile-menu" />
     </div>
   </div>
 </template>

--- a/src/components/global/LoginRegisterHeader.vue
+++ b/src/components/global/LoginRegisterHeader.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       :height="logoHeight"
       data-cy="header-logo"
     />
-    <div v-if="!isDesktop" class="flex items-center gap-32">
+    <div v-if="isDesktop" class="flex items-center gap-32">
       <!-- Help icon link for displaying modal dialog -->
       <help-button data-cy="help-button" />
       <!-- Language switcher -->

--- a/src/components/global/LoginRegisterHeader.vue
+++ b/src/components/global/LoginRegisterHeader.vue
@@ -21,12 +21,14 @@
  */
 
 // libraries
-import { defineComponent } from 'vue';
+import { Screen } from 'quasar';
+import { computed, defineComponent } from 'vue';
 
 // components
 import HeaderLogo from './HeaderLogo.vue';
 import HelpButton from './HelpButton.vue';
 import LanguageSwitcher from './LanguageSwitcher.vue';
+import LoginRegisterMobileMenu from './LoginRegisterMobileMenu.vue';
 
 export default defineComponent({
   name: 'LoginRegisterHeader',
@@ -34,9 +36,24 @@ export default defineComponent({
     HeaderLogo,
     HelpButton,
     LanguageSwitcher,
+    LoginRegisterMobileMenu,
   },
   setup() {
-    return {};
+    const isDesktop = computed((): boolean => {
+      return Screen.gt.sm;
+    });
+    const logoHeight = computed((): string => {
+      return isDesktop.value ? '80px' : '48px';
+    });
+    const logoWidth = computed((): string => {
+      return isDesktop.value ? '280px' : '170px';
+    });
+
+    return {
+      isDesktop,
+      logoHeight,
+      logoWidth,
+    };
   },
 });
 </script>
@@ -44,18 +61,20 @@ export default defineComponent({
 <template>
   <div class="flex items-center justify-between q-py-lg">
     <!-- RTWBB logo -->
-    <header-logo width="280px" height="80px" data-cy="header-logo" />
-    <div class="flex items-center gap-32">
+    <header-logo
+      :width="logoWidth"
+      :height="logoHeight"
+      data-cy="header-logo"
+    />
+    <div v-if="isDesktop" class="flex items-center gap-32">
       <!-- Help icon link for displaying modal dialog -->
       <help-button data-cy="help-button" />
       <!-- Language switcher -->
       <language-switcher variant="light" data-cy="language-switcher" />
     </div>
+    <div v-else class="flex items-center gap-16">
+      <!-- Mobile menu -->
+      <login-register-mobile-menu />
+    </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-.logo {
-  height: 80px;
-}
-</style>

--- a/src/components/global/LoginRegisterHeader.vue
+++ b/src/components/global/LoginRegisterHeader.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       :height="logoHeight"
       data-cy="header-logo"
     />
-    <div v-if="isDesktop" class="flex items-center gap-32">
+    <div v-if="!isDesktop" class="flex items-center gap-32">
       <!-- Help icon link for displaying modal dialog -->
       <help-button data-cy="help-button" />
       <!-- Language switcher -->

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -20,11 +20,15 @@
  */
 
 // libraries
+import { colors } from 'quasar';
 import { computed, defineComponent } from 'vue';
 
 // components
 import HelpButton from './HelpButton.vue';
 import LanguageSwitcher from './LanguageSwitcher.vue';
+
+// config
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // stores
 import { useLoginStore } from '../../stores/login';
@@ -41,8 +45,16 @@ export default defineComponent({
 
     const loginStore = useLoginStore();
     const userEmail = computed((): string => loginStore.getUserEmail);
+    const { borderRadiusCard: borderRadius, colorWhiteBackgroundOpacity } =
+      rideToWorkByBikeConfig;
+    const { getPaletteColor, changeAlpha } = colors;
+    const white = getPaletteColor('white');
+    const whiteOpacity = changeAlpha(white, colorWhiteBackgroundOpacity);
+    const border = `1px solid ${whiteOpacity}`;
 
     return {
+      border,
+      borderRadius,
       mobileMenuOffsetTop,
       mobileMenuOffsetRight,
       userEmail,
@@ -62,15 +74,18 @@ export default defineComponent({
       data-cy="mobile-menu-button"
     >
       <q-menu
-        class="block"
+        dark
+        class="block bg-primary"
         anchor="bottom right"
         self="top right"
         :offset="[mobileMenuOffsetRight, mobileMenuOffsetTop]"
+        :style="{ border, borderRadius }"
         data-cy="mobile-menu-dropdown"
       >
-        <q-list style="min-width: 80vw" class="q-py-sm">
+        <q-list dark style="min-width: 80vw" class="q-py-sm">
           <!-- Logged in info -->
           <q-item
+            dark
             v-if="userEmail"
             class="text-center"
             data-cy="mobile-menu-user-info"
@@ -87,11 +102,11 @@ export default defineComponent({
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-separator v-if="userEmail" class="q-my-sm" />
+          <q-separator v-if="userEmail" dark class="q-my-sm" />
           <!-- Item: Help -->
           <help-button data-cy="mobile-menu-help">
             <template #button="{ openDialog }">
-              <q-item clickable @click.prevent="openDialog">
+              <q-item dark clickable @click.prevent="openDialog">
                 <q-item-section>{{
                   $t('loginRegisterMobileMenu.labelHelp')
                 }}</q-item-section>
@@ -99,21 +114,20 @@ export default defineComponent({
             </template>
           </help-button>
           <!-- Item: Log out -->
-          <q-item clickable v-close-popup data-cy="mobile-menu-logout">
+          <q-item dark clickable v-close-popup data-cy="mobile-menu-logout">
             <q-item-section>{{
               $t('loginRegisterMobileMenu.labelLogOut')
             }}</q-item-section>
           </q-item>
-          <q-separator class="q-my-sm" />
+          <q-separator dark class="q-my-sm" />
           <q-item-label header data-cy="mobile-menu-language-header">
             {{ $t('loginRegisterMobileMenu.labelLanguage') }}
           </q-item-label>
-          <q-item v-close-popup data-cy="mobile-menu-language-switcher">
+          <q-item dark v-close-popup data-cy="mobile-menu-language-switcher">
             <!-- Item: Language switcher -->
             <language-switcher
               variant="light"
               class="q-py-none q-my-none"
-              style="padding: 0"
               data-cy="language-switcher"
             />
           </q-item>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -1,0 +1,73 @@
+<script lang="ts">
+/**
+ * LoginRegisterMobileMenu Component
+ *
+ * @description * Use this component to ... .
+ * You can adjust its appearance by ... .
+ *
+ * @props
+ * - `NAME` (TYPE, required): The object representing ... .
+ *   It should be of type `TYPE`.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @slots
+ * - `content`: For ... .
+ *   exposed props and methods:
+ *     - `state`
+ *
+ * @components
+ * - `CHILD`: Component to ... .
+ *
+ * @example
+ * <LoginRegisterMobileMenu></LoginRegisterMobileMenu>
+ *
+ * @see [Figma Design](...)
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'LoginRegisterMobileMenu',
+});
+</script>
+
+<template>
+  <q-btn unelevated round color="white" text-color="primary" icon="menu">
+    <q-menu
+      class="block"
+      anchor="bottom right"
+      self="top right"
+      :offset="[0, 20]"
+    >
+      <q-list style="min-width: 80vw">
+        <q-item clickable v-close-popup>
+          <q-item-section>New tab</q-item-section>
+        </q-item>
+        <q-item clickable v-close-popup>
+          <q-item-section>New incognito tab</q-item-section>
+        </q-item>
+        <q-separator />
+        <q-item clickable v-close-popup>
+          <q-item-section>Recent tabs</q-item-section>
+        </q-item>
+        <q-item clickable v-close-popup>
+          <q-item-section>History</q-item-section>
+        </q-item>
+        <q-item clickable v-close-popup>
+          <q-item-section>Downloads</q-item-section>
+        </q-item>
+        <q-separator />
+        <q-item clickable v-close-popup>
+          <q-item-section>Settings</q-item-section>
+        </q-item>
+        <q-separator />
+        <q-item clickable v-close-popup>
+          <q-item-section>Help &amp; Feedback</q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
+  </q-btn>
+</template>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -70,7 +70,11 @@ export default defineComponent({
       >
         <q-list style="min-width: 80vw" class="q-py-sm">
           <!-- Logged in info -->
-          <q-item class="text-center" data-cy="mobile-menu-user-info">
+          <q-item
+            v-if="userEmail"
+            class="text-center"
+            data-cy="mobile-menu-user-info"
+          >
             <q-item-section>
               <q-item-label caption data-cy="mobile-menu-user-info-label">
                 {{ $t('loginRegisterMobileMenu.labelLoggedInAs') }}
@@ -83,9 +87,9 @@ export default defineComponent({
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-separator class="q-my-sm" />
+          <q-separator v-if="userEmail" class="q-my-sm" />
           <!-- Item: Help -->
-          <help-button>
+          <help-button data-cy="mobile-menu-help">
             <template #button="{ openDialog }">
               <q-item clickable @click.prevent="openDialog">
                 <q-item-section>{{
@@ -110,6 +114,7 @@ export default defineComponent({
               variant="light"
               class="q-py-none q-my-none"
               style="padding: 0"
+              data-cy="language-switcher"
             />
           </q-item>
         </q-list>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -20,11 +20,14 @@
  */
 
 // libraries
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 
 // components
 import HelpButton from './HelpButton.vue';
 import LanguageSwitcher from './LanguageSwitcher.vue';
+
+// stores
+import { useLoginStore } from '../../stores/login';
 
 export default defineComponent({
   name: 'LoginRegisterMobileMenu',
@@ -36,64 +39,81 @@ export default defineComponent({
     const mobileMenuOffsetTop = 20;
     const mobileMenuOffsetRight = 0;
 
+    const loginStore = useLoginStore();
+    const userEmail = computed((): string => loginStore.getUserEmail);
+
     return {
       mobileMenuOffsetTop,
       mobileMenuOffsetRight,
+      userEmail,
     };
   },
 });
 </script>
 
 <template>
-  <q-btn unelevated round color="white" text-color="primary" icon="menu">
-    <q-menu
-      class="block"
-      anchor="bottom right"
-      self="top right"
-      :offset="[mobileMenuOffsetRight, mobileMenuOffsetTop]"
+  <div data-cy="login-register-mobile-menu">
+    <q-btn
+      unelevated
+      round
+      color="white"
+      text-color="primary"
+      icon="menu"
+      data-cy="mobile-menu-button"
     >
-      <q-list style="min-width: 80vw" class="q-py-sm">
-        <!-- Logged in info -->
-        <q-item class="text-center">
-          <q-item-section>
-            <q-item-label caption>{{
-              $t('loginRegisterMobileMenu.labelLoggedInAs')
-            }}</q-item-label>
-            <q-item-label class="text-weight-bold text-primary"
-              >anonym@dopracenakole.cz</q-item-label
-            >
-          </q-item-section>
-        </q-item>
-        <q-separator class="q-my-sm" />
-        <!-- Item: Help -->
-        <help-button>
-          <template #button="{ openDialog }">
-            <q-item clickable @click.prevent="openDialog">
-              <q-item-section>{{
-                $t('loginRegisterMobileMenu.labelHelp')
-              }}</q-item-section>
-            </q-item>
-          </template>
-        </help-button>
-        <!-- Item: Log out -->
-        <q-item clickable v-close-popup>
-          <q-item-section>{{
-            $t('loginRegisterMobileMenu.labelLogOut')
-          }}</q-item-section>
-        </q-item>
-        <q-separator class="q-my-sm" />
-        <q-item-label header>{{
-          $t('loginRegisterMobileMenu.labelLanguage')
-        }}</q-item-label>
-        <q-item v-close-popup>
-          <!-- Item: Language switcher -->
-          <language-switcher
-            variant="light"
-            class="q-py-none q-my-none"
-            style="padding: 0"
-          />
-        </q-item>
-      </q-list>
-    </q-menu>
-  </q-btn>
+      <q-menu
+        class="block"
+        anchor="bottom right"
+        self="top right"
+        :offset="[mobileMenuOffsetRight, mobileMenuOffsetTop]"
+        data-cy="mobile-menu-dropdown"
+      >
+        <q-list style="min-width: 80vw" class="q-py-sm">
+          <!-- Logged in info -->
+          <q-item class="text-center" data-cy="mobile-menu-user-info">
+            <q-item-section>
+              <q-item-label caption data-cy="mobile-menu-user-info-label">
+                {{ $t('loginRegisterMobileMenu.labelLoggedInAs') }}
+              </q-item-label>
+              <q-item-label
+                class="text-weight-bold text-primary"
+                data-cy="mobile-menu-user-info-email"
+              >
+                {{ userEmail }}
+              </q-item-label>
+            </q-item-section>
+          </q-item>
+          <q-separator class="q-my-sm" />
+          <!-- Item: Help -->
+          <help-button>
+            <template #button="{ openDialog }">
+              <q-item clickable @click.prevent="openDialog">
+                <q-item-section>{{
+                  $t('loginRegisterMobileMenu.labelHelp')
+                }}</q-item-section>
+              </q-item>
+            </template>
+          </help-button>
+          <!-- Item: Log out -->
+          <q-item clickable v-close-popup data-cy="mobile-menu-logout">
+            <q-item-section>{{
+              $t('loginRegisterMobileMenu.labelLogOut')
+            }}</q-item-section>
+          </q-item>
+          <q-separator class="q-my-sm" />
+          <q-item-label header data-cy="mobile-menu-language-header">
+            {{ $t('loginRegisterMobileMenu.labelLanguage') }}
+          </q-item-label>
+          <q-item v-close-popup data-cy="mobile-menu-language-switcher">
+            <!-- Item: Language switcher -->
+            <language-switcher
+              variant="light"
+              class="q-py-none q-my-none"
+              style="padding: 0"
+            />
+          </q-item>
+        </q-list>
+      </q-menu>
+    </q-btn>
+  </div>
 </template>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -2,28 +2,20 @@
 /**
  * LoginRegisterMobileMenu Component
  *
- * @description * Use this component to ... .
- * You can adjust its appearance by ... .
- *
- * @props
- * - `NAME` (TYPE, required): The object representing ... .
- *   It should be of type `TYPE`.
- *
- * @events
- * - `update:modelValue`: Emitted as a part of v-model structure.
- *
- * @slots
- * - `content`: For ... .
- *   exposed props and methods:
- *     - `state`
+ * @description * Use this component to render a mobile dropdown menu in
+ * `LoginRegisterHeader` component.
+ * Note: It should be rendered only on mobile devices and only on pages
+ * using the `LoginRegisterLayout`.
  *
  * @components
- * - `CHILD`: Component to ... .
+ * - `HelpButton`: Component to render help icon with dialog.
  *
  * @example
- * <LoginRegisterMobileMenu></LoginRegisterMobileMenu>
+ * <login-register-mobile-menu />
  *
- * @see [Figma Design](...)
+ * @see
+ * [Figma Design: Variant Logged out](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=1074-15529&t=4UqwJpgG48utdVoI-1)
+ * [Figma Design: Variant Logged in](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=1174-15287&t=4UqwJpgG48utdVoI-1)
  */
 
 // libraries

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -143,9 +143,7 @@ export default defineComponent({
             data-cy="mobile-menu-logout"
             @click="onLogout"
           >
-            <q-item-section>{{
-              $t('loginRegisterMobileMenu.labelLogOut')
-            }}</q-item-section>
+            <q-item-section>{{ $t('userSelect.logout') }}</q-item-section>
           </q-item>
           <!-- Separator -->
           <q-separator dark class="q-my-sm" data-cy="mobile-menu-separator" />

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -21,7 +21,7 @@
 
 // libraries
 import { colors } from 'quasar';
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 
 // components
 import HelpButton from './HelpButton.vue';
@@ -43,6 +43,9 @@ export default defineComponent({
     const mobileMenuOffsetTop = 20;
     const mobileMenuOffsetRight = 0;
 
+    const isOpen = ref(false);
+    const icon = computed(() => (isOpen.value ? 'close' : 'menu'));
+
     const loginStore = useLoginStore();
     const userEmail = computed((): string => loginStore.getUserEmail);
     const { borderRadiusCard: borderRadius, colorWhiteBackgroundOpacity } =
@@ -55,6 +58,8 @@ export default defineComponent({
     return {
       border,
       borderRadius,
+      icon,
+      isOpen,
       mobileMenuOffsetTop,
       mobileMenuOffsetRight,
       userEmail,
@@ -70,10 +75,11 @@ export default defineComponent({
       round
       color="white"
       text-color="primary"
-      icon="menu"
+      :icon="icon"
       data-cy="mobile-menu-button"
     >
       <q-menu
+        v-model="isOpen"
         dark
         class="block bg-primary"
         anchor="bottom right"
@@ -95,14 +101,19 @@ export default defineComponent({
                 {{ $t('loginRegisterMobileMenu.labelLoggedInAs') }}
               </q-item-label>
               <q-item-label
-                class="text-weight-bold text-primary"
+                class="text-weight-bold text-white"
                 data-cy="mobile-menu-user-info-email"
               >
                 {{ userEmail }}
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-separator v-if="userEmail" dark class="q-my-sm" />
+          <q-separator
+            v-if="userEmail"
+            dark
+            class="q-my-sm"
+            data-cy="mobile-menu-separator"
+          />
           <!-- Item: Help -->
           <help-button data-cy="mobile-menu-help">
             <template #button="{ openDialog }">
@@ -119,7 +130,7 @@ export default defineComponent({
               $t('loginRegisterMobileMenu.labelLogOut')
             }}</q-item-section>
           </q-item>
-          <q-separator dark class="q-my-sm" />
+          <q-separator dark class="q-my-sm" data-cy="mobile-menu-separator" />
           <q-item-label header data-cy="mobile-menu-language-header">
             {{ $t('loginRegisterMobileMenu.labelLanguage') }}
           </q-item-label>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -40,20 +40,20 @@ export default defineComponent({
     LanguageSwitcher,
   },
   setup() {
-    const mobileMenuOffsetTop = 20;
-    const mobileMenuOffsetRight = 0;
-
     const isOpen = ref(false);
     const icon = computed(() => (isOpen.value ? 'close' : 'menu'));
 
     const loginStore = useLoginStore();
     const userEmail = computed((): string => loginStore.getUserEmail);
+
     const { borderRadiusCard: borderRadius, colorWhiteBackgroundOpacity } =
       rideToWorkByBikeConfig;
     const { getPaletteColor, changeAlpha } = colors;
     const white = getPaletteColor('white');
     const whiteOpacity = changeAlpha(white, colorWhiteBackgroundOpacity);
     const border = `1px solid ${whiteOpacity}`;
+    const mobileMenuOffsetTop = 20;
+    const mobileMenuOffsetRight = 0;
 
     return {
       border,
@@ -70,6 +70,7 @@ export default defineComponent({
 
 <template>
   <div data-cy="login-register-mobile-menu">
+    <!-- Menu button -->
     <q-btn
       unelevated
       round
@@ -78,6 +79,7 @@ export default defineComponent({
       :icon="icon"
       data-cy="mobile-menu-button"
     >
+      <!-- Menu dropdown -->
       <q-menu
         v-model="isOpen"
         dark
@@ -97,9 +99,11 @@ export default defineComponent({
             data-cy="mobile-menu-user-info"
           >
             <q-item-section>
+              <!-- Label -->
               <q-item-label caption data-cy="mobile-menu-user-info-label">
                 {{ $t('loginRegisterMobileMenu.labelLoggedInAs') }}
               </q-item-label>
+              <!-- Email -->
               <q-item-label
                 class="text-weight-bold text-white"
                 data-cy="mobile-menu-user-info-email"
@@ -108,6 +112,7 @@ export default defineComponent({
               </q-item-label>
             </q-item-section>
           </q-item>
+          <!-- Separator -->
           <q-separator
             v-if="userEmail"
             dark
@@ -117,10 +122,11 @@ export default defineComponent({
           <!-- Item: Help -->
           <help-button data-cy="mobile-menu-help">
             <template #button="{ openDialog }">
+              <!-- Item -->
               <q-item dark clickable @click.prevent="openDialog">
-                <q-item-section>{{
-                  $t('loginRegisterMobileMenu.labelHelp')
-                }}</q-item-section>
+                <q-item-section>
+                  {{ $t('loginRegisterMobileMenu.labelHelp') }}
+                </q-item-section>
               </q-item>
             </template>
           </help-button>
@@ -130,7 +136,9 @@ export default defineComponent({
               $t('loginRegisterMobileMenu.labelLogOut')
             }}</q-item-section>
           </q-item>
+          <!-- Separator -->
           <q-separator dark class="q-my-sm" data-cy="mobile-menu-separator" />
+          <!-- Language header -->
           <q-item-label header data-cy="mobile-menu-language-header">
             {{ $t('loginRegisterMobileMenu.labelLanguage') }}
           </q-item-label>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -55,6 +55,10 @@ export default defineComponent({
     const mobileMenuOffsetTop = 20;
     const mobileMenuOffsetRight = 0;
 
+    const onLogout = () => {
+      loginStore.logout();
+    };
+
     return {
       border,
       borderRadius,
@@ -62,6 +66,7 @@ export default defineComponent({
       isOpen,
       mobileMenuOffsetTop,
       mobileMenuOffsetRight,
+      onLogout,
       userEmail,
     };
   },
@@ -131,7 +136,13 @@ export default defineComponent({
             </template>
           </help-button>
           <!-- Item: Log out -->
-          <q-item dark clickable v-close-popup data-cy="mobile-menu-logout">
+          <q-item
+            dark
+            clickable
+            v-close-popup
+            data-cy="mobile-menu-logout"
+            @click="onLogout"
+          >
             <q-item-section>{{
               $t('loginRegisterMobileMenu.labelLogOut')
             }}</q-item-section>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -56,7 +56,9 @@ export default defineComponent({
         <!-- Logged in info -->
         <q-item class="text-center">
           <q-item-section>
-            <q-item-label caption>Jste přihlášeni jako</q-item-label>
+            <q-item-label caption>{{
+              $t('loginRegisterMobileMenu.labelLoggedInAs')
+            }}</q-item-label>
             <q-item-label class="text-weight-bold text-primary"
               >anonym@dopracenakole.cz</q-item-label
             >
@@ -67,15 +69,22 @@ export default defineComponent({
         <help-button>
           <template #button="{ openDialog }">
             <q-item clickable @click.prevent="openDialog">
-              <q-item-section>{{ 'Nápověda' }}</q-item-section>
+              <q-item-section>{{
+                $t('loginRegisterMobileMenu.labelHelp')
+              }}</q-item-section>
             </q-item>
           </template>
         </help-button>
         <!-- Item: Log out -->
         <q-item clickable v-close-popup>
-          <q-item-section>Odhlásit se</q-item-section>
+          <q-item-section>{{
+            $t('loginRegisterMobileMenu.labelLogOut')
+          }}</q-item-section>
         </q-item>
         <q-separator class="q-my-sm" />
+        <q-item-label header>{{
+          $t('loginRegisterMobileMenu.labelLanguage')
+        }}</q-item-label>
         <q-item v-close-popup>
           <!-- Item: Language switcher -->
           <language-switcher

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -9,6 +9,7 @@
  *
  * @components
  * - `HelpButton`: Component to render help icon with dialog.
+ * - `LanguageSwitcher`: Component to render language switcher.
  *
  * @example
  * <login-register-mobile-menu />
@@ -23,11 +24,13 @@ import { defineComponent } from 'vue';
 
 // components
 import HelpButton from './HelpButton.vue';
+import LanguageSwitcher from './LanguageSwitcher.vue';
 
 export default defineComponent({
   name: 'LoginRegisterMobileMenu',
   components: {
     HelpButton,
+    LanguageSwitcher,
   },
   setup() {
     const mobileMenuOffsetTop = 20;
@@ -49,34 +52,37 @@ export default defineComponent({
       self="top right"
       :offset="[mobileMenuOffsetRight, mobileMenuOffsetTop]"
     >
-      <q-list style="min-width: 80vw">
+      <q-list style="min-width: 80vw" class="q-py-sm">
+        <!-- Logged in info -->
+        <q-item class="text-center">
+          <q-item-section>
+            <q-item-label caption>Jste přihlášeni jako</q-item-label>
+            <q-item-label class="text-weight-bold text-primary"
+              >anonym@dopracenakole.cz</q-item-label
+            >
+          </q-item-section>
+        </q-item>
+        <q-separator class="q-my-sm" />
+        <!-- Item: Help -->
         <help-button>
           <template #button="{ openDialog }">
             <q-item clickable @click.prevent="openDialog">
-              <q-item-section>New tab</q-item-section>
+              <q-item-section>{{ 'Nápověda' }}</q-item-section>
             </q-item>
           </template>
         </help-button>
+        <!-- Item: Log out -->
         <q-item clickable v-close-popup>
-          <q-item-section>New incognito tab</q-item-section>
+          <q-item-section>Odhlásit se</q-item-section>
         </q-item>
-        <q-separator />
-        <q-item clickable v-close-popup>
-          <q-item-section>Recent tabs</q-item-section>
-        </q-item>
-        <q-item clickable v-close-popup>
-          <q-item-section>History</q-item-section>
-        </q-item>
-        <q-item clickable v-close-popup>
-          <q-item-section>Downloads</q-item-section>
-        </q-item>
-        <q-separator />
-        <q-item clickable v-close-popup>
-          <q-item-section>Settings</q-item-section>
-        </q-item>
-        <q-separator />
-        <q-item clickable v-close-popup>
-          <q-item-section>Help &amp; Feedback</q-item-section>
+        <q-separator class="q-my-sm" />
+        <q-item v-close-popup>
+          <!-- Item: Language switcher -->
+          <language-switcher
+            variant="light"
+            class="q-py-none q-my-none"
+            style="padding: 0"
+          />
         </q-item>
       </q-list>
     </q-menu>

--- a/src/components/global/LoginRegisterMobileMenu.vue
+++ b/src/components/global/LoginRegisterMobileMenu.vue
@@ -21,8 +21,23 @@
 // libraries
 import { defineComponent } from 'vue';
 
+// components
+import HelpButton from './HelpButton.vue';
+
 export default defineComponent({
   name: 'LoginRegisterMobileMenu',
+  components: {
+    HelpButton,
+  },
+  setup() {
+    const mobileMenuOffsetTop = 20;
+    const mobileMenuOffsetRight = 0;
+
+    return {
+      mobileMenuOffsetTop,
+      mobileMenuOffsetRight,
+    };
+  },
 });
 </script>
 
@@ -32,12 +47,16 @@ export default defineComponent({
       class="block"
       anchor="bottom right"
       self="top right"
-      :offset="[0, 20]"
+      :offset="[mobileMenuOffsetRight, mobileMenuOffsetTop]"
     >
       <q-list style="min-width: 80vw">
-        <q-item clickable v-close-popup>
-          <q-item-section>New tab</q-item-section>
-        </q-item>
+        <help-button>
+          <template #button="{ openDialog }">
+            <q-item clickable @click.prevent="openDialog">
+              <q-item-section>New tab</q-item-section>
+            </q-item>
+          </template>
+        </help-button>
         <q-item clickable v-close-popup>
           <q-item-section>New incognito tab</q-item-section>
         </q-item>

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -415,10 +415,10 @@ apiMessageError = "Přihlášení se nezdařilo. Prosím, zkuste to znovu pozdě
 apiMessageErrorWithMessage = "Přihlášení se nezdařilo. Prosím, zkuste to znovu později. Chyba: {error}"
 
 [loginRegisterMobileMenu]
-labelLoggedInAs = "Jste přihlášeni jako"
 labelHelp = "Nápověda"
-labelLogOut = "Odhlásit se"
 labelLanguage = "Jazyk"
+labelLoggedInAs = "Jste přihlášeni jako"
+labelLogOut = "Odhlásit se"
 
 [login.form]
 titleLogin = "Přihlášení"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -414,6 +414,12 @@ apiMessageSuccess = "Přihlášení bylo úspěšné"
 apiMessageError = "Přihlášení se nezdařilo. Prosím, zkuste to znovu později. {error}"
 apiMessageErrorWithMessage = "Přihlášení se nezdařilo. Prosím, zkuste to znovu později. Chyba: {error}"
 
+[loginRegisterMobileMenu]
+labelLoggedInAs = "Jste přihlášeni jako"
+labelHelp = "Nápověda"
+labelLogOut = "Odhlásit se"
+labelLanguage = "Jazyk"
+
 [login.form]
 titleLogin = "Přihlášení"
 titlePasswordReset = "Zapomenuté heslo"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -418,7 +418,6 @@ apiMessageErrorWithMessage = "Přihlášení se nezdařilo. Prosím, zkuste to z
 labelHelp = "Nápověda"
 labelLanguage = "Jazyk"
 labelLoggedInAs = "Jste přihlášeni jako"
-labelLogOut = "Odhlásit se"
 
 [login.form]
 titleLogin = "Přihlášení"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -415,7 +415,6 @@ apiMessageErrorWithMessage = "Login failed. Please try again later. Error: {erro
 labelHelp = "Help"
 labelLanguage = "Language"
 labelLoggedInAs = "You are logged in as"
-labelLogOut = "Log out"
 
 [login.form]
 titleLogin = "Login"
@@ -705,7 +704,7 @@ unknown = "Not logged"
 [userSelect]
 companyCoordinator = "Become a company coordinator"
 connectApps = "Connect apps"
-logout = "Logout"
+logout = "Log out"
 newsletter = "Subscribe to newsletter"
 notifications = "Notification history"
 profileDetails = "Your profile"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -411,6 +411,12 @@ apiMessageSuccess = "Login was successful"
 apiMessageError = "Login failed. Please try again later. {error}"
 apiMessageErrorWithMessage = "Login failed. Please try again later. Error: {error}"
 
+[loginRegisterMobileMenu]
+labelLoggedInAs = "You are logged in as"
+labelHelp = "Help"
+labelLogOut = "Log out"
+labelLanguage = "Language"
+
 [login.form]
 titleLogin = "Login"
 titlePasswordReset = "Forgotten password"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -412,10 +412,10 @@ apiMessageError = "Login failed. Please try again later. {error}"
 apiMessageErrorWithMessage = "Login failed. Please try again later. Error: {error}"
 
 [loginRegisterMobileMenu]
-labelLoggedInAs = "You are logged in as"
 labelHelp = "Help"
-labelLogOut = "Log out"
 labelLanguage = "Language"
+labelLoggedInAs = "You are logged in as"
+labelLogOut = "Log out"
 
 [login.form]
 titleLogin = "Login"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -415,7 +415,6 @@ apiMessageErrorWithMessage = "Prihlásenie sa nepodarilo. Prosím, skúste to zn
 labelHelp = "Pomoc"
 labelLanguage = "Jazyk"
 labelLoggedInAs = "Ste prihlásení ako"
-labelLogOut = "Odhlásiť sa"
 
 [login.form]
 titleLogin = "Prihlásenie"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -412,10 +412,10 @@ apiMessageError = "Prihlásenie sa nepodarilo. Prosím, skúste to znovu pozděj
 apiMessageErrorWithMessage = "Prihlásenie sa nepodarilo. Prosím, skúste to znovu později. Chyba: {error}"
 
 [loginRegisterMobileMenu]
-labelLoggedInAs = "Ste prihlásení ako"
-labelHelp = "Pomocník"
-labelLogOut = "Odhlásiť sa"
+labelHelp = "Pomoc"
 labelLanguage = "Jazyk"
+labelLoggedInAs = "Ste prihlásení ako"
+labelLogOut = "Odhlásiť sa"
 
 [login.form]
 titleLogin = "Prihlásenie"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -411,6 +411,12 @@ apiMessageSuccess = "Prihlásenie bolo úspešné"
 apiMessageError = "Prihlásenie sa nepodarilo. Prosím, skúste to znovu později. {error}"
 apiMessageErrorWithMessage = "Prihlásenie sa nepodarilo. Prosím, skúste to znovu později. Chyba: {error}"
 
+[loginRegisterMobileMenu]
+labelLoggedInAs = "Ste prihlásení ako"
+labelHelp = "Pomocník"
+labelLogOut = "Odhlásiť sa"
+labelLanguage = "Jazyk"
+
 [login.form]
 titleLogin = "Prihlásenie"
 titlePasswordReset = "Zabudnuté heslo"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,13 @@ const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
   process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
 );
 
+interface RgbaI {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
 /*
  * Convert date time timestamp number to formated
  * date time string.
@@ -52,4 +59,22 @@ const requestTokenHeader = {
   Authorization: 'Bearer ',
 } as AxiosRequestHeaders;
 
-export { requestDefaultHeader, requestTokenHeader, timestampToDatetimeString };
+/*
+ * Convert RGBA color object definition returned from
+ * hexToRgb() function to string representation
+ * e.g. rgba(255, 255, 255, 0.2)
+ *
+ * @param {rgbai} rgba: RGBA object returned from hexToRgb() function
+ *
+ * @return {string}: RGBA string e.g. rgba(255, 255, 255, 0.2)
+ */
+const rgbaColorObjectToString = (rgba: RgbaI): string => {
+  return `rgba(${rgba['r']}, ${rgba['g']}, ${rgba['b']}, ${rgba['a'] / 100.0})`;
+};
+
+export {
+  requestDefaultHeader,
+  requestTokenHeader,
+  rgbaColorObjectToString,
+  timestampToDatetimeString,
+};


### PR DESCRIPTION
Add component `LoginRegisterMobileMenu` to display responsive header in the login-register layout.

* Adds the new component (integrating `HelpButton` and `LanguageSwitcher` components).
* Used component in `LoginRegisterHeader` based on screen size.
* Add translation strings.
* Add tests.