### PR TITLE
src/components/__tests__: ProfileCoordinatorContact wait for image load before snapshot

### DIFF
--- a/src/components/__tests__/ProfileCoordinatorContact.cy.js
+++ b/src/components/__tests__/ProfileCoordinatorContact.cy.js
@@ -101,12 +101,10 @@ describe('<ProfileCoordinatorContact>', () => {
         .should('not.exist')
         .then(() => {
           // take a snapshot
-          cy.dataCy(selectorAvatar).then(() => {
-            cy.matchImageSnapshotNamed(
-              selectorAvatar,
-              `${Cypress.currentTest.titlePath[0]}-avatar`,
-            );
-          });
+          cy.matchImageSnapshotNamed(
+            selectorAvatar,
+            `${Cypress.currentTest.titlePath[0]}-avatar`,
+          );
         });
     });
 

--- a/src/components/__tests__/ProfileCoordinatorContact.cy.js
+++ b/src/components/__tests__/ProfileCoordinatorContact.cy.js
@@ -95,20 +95,18 @@ describe('<ProfileCoordinatorContact>', () => {
         .should('be.visible')
         .and('have.css', 'width', avatarSize)
         .and('have.css', 'height', avatarSize);
+      // wait until image has no loading indicator
       cy.dataCy(selectorAvatar)
+        .find('.q-img__loading')
+        .should('not.exist')
         .then(() => {
-          // wait for image loading (otherwise, we might snapshot the placeholder)
-          return new Cypress.Promise((resolve) => {
-            setTimeout(() => {
-              resolve();
-            }, 500);
+          // take a snapshot
+          cy.dataCy(selectorAvatar).then(() => {
+            cy.matchImageSnapshotNamed(
+              selectorAvatar,
+              `${Cypress.currentTest.titlePath[0]}-avatar`,
+            );
           });
-        })
-        .then(() => {
-          cy.matchImageSnapshotNamed(
-            selectorAvatar,
-            `${Cypress.currentTest.titlePath[0]}-avatar`,
-          );
         });
     });
 


### PR DESCRIPTION
Solves issue where avatar snapshot would be taken while still showing the placeholder image.
If image has `src`, placeholder is being shown until the image is loading (together with a loader element)
We wait until the loader element does not exist to take the snapshot.
This should prevent the `ProfileCoordinatorContact` component test from failing occasionally.

Error message (OS MS Windows, Google Chrome web browser):

```
 1 failing

  1) <ProfileCoordinatorContact>
       desktop
         renders avatar of a company coordinator:
     Error: Image was 23.756377551020407% different from saved snapshot with 745 different pixels.
See diff for details: D:\a\ride-to-work-by-bike-frontend\ride-to-work-by-bike-frontend\test\cypress\snapshots\ProfileCoordinatorContact.cy.js\__diff_output__\ProfileCoordinatorContact -- desktop -- renders avatar of a company coordinator.diff.png
      at Context.<anonymous> (http://localhost:9000/__cypress/src/node_modules/.q-cache/vite/spa/deps/cypress-image-snapshot_command.js?v=0e49d342:67:21)
      at getRet (http://localhost:9000/__cypress/runner/cypress_runner.js:119161:20)
      at tryCatcher (http://localhost:9000/__cypress/runner/cypress_runner.js:1807:23)
      at Promise.attempt.Promise.try (http://localhost:9000/__cypress/runner/cypress_runner.js:4315:29)
      at Context.thenFn (http://localhost:9000/__cypress/runner/cypress_runner.js:119172:66)
      at Context.then (http://localhost:9000/__cypress/runner/cypress_runner.js:119423:21)
      at wrapped (http://localhost:9000/__cypress/runner/cypress_runner.js:137935:19)
      at <unknown> (http://localhost:9000/__cypress/runner/cypress_runner.js:143856:15)
      at tryCatcher (http://localhost:9000/__cypress/runner/cypress_runner.js:1807:23)
```