### PR TITLE
test/cypress/fixtures: add missing login response fixture JSON file

### DIFF
--- a/test/cypress/fixtures/loginResponse.json
+++ b/test/cypress/fixtures/loginResponse.json
@@ -1,0 +1,11 @@
+{
+  "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzI3MjEwMTYzLCJqdGkiOiJiMzY5M2I1ZTU3OWE0MDZhOWUyNWE0ZTQ3YzFmMjQ4NiIsInVzZXJfaWQiOjE4OTc2MX0.jAfrS_1R2FnoNcZmYUEoOqPq7evNLP7KzPAOFmuHu88",
+  "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcyNzI5NjI2MywianRpIjoiNzYzNGIxYzBiYTdiNDQ0Zjk0ZTZmNTA5M2E1MDM3MDYiLCJ1c2VyX2lkIjoxODk3NjF9.6J_L4wVjPN3bKAOU-UcvxhrIBirqLVrgi5AZefsqrt0",
+  "user": {
+    "pk": 1,
+    "username": "foobar",
+    "email": "foo@bar.org",
+    "first_name": "Foo",
+    "last_name": "Bar"
+  }
+}


### PR DESCRIPTION
Add missing login response fixture JSON file.

Fixes error message:

```
1 failing

  1) <LoginRegisterMobileMenu>
       logged in
         "before each" hook for "renders component":
     Error: A fixture file could not be found at any of the following paths:

    > test/cypress/fixtures/loginResponse.json
    > test/cypress/fixtures/loginResponse.json.[ext]

Cypress looked for these file extensions at the provided path:

    > .json, .js, .coffee, .html, .txt, .csv, .png, .jpg, .jpeg, .gif, .tif, .tiff, .zip

Provide a path to an existing fixture file.
```