### PR TITLE
src/components: add logout and redirect action to the 'register again' link in EmailVerification

### DIFF
--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -80,8 +80,19 @@ export default defineComponent({
       rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
 
+    const onRegisterAgain = (): void => {
+      logger?.debug(
+        `User clicked register again button, logout user and redirect to <${routesConf['register']['path']}> URL.`,
+      );
+      // logout current user
+      loginStore.logout();
+      // redirect to register page
+      router.push(routesConf['register']['path']);
+    };
+
     return {
       email,
+      onRegisterAgain,
       whiteOpacity,
     };
   },
@@ -128,6 +139,7 @@ export default defineComponent({
         class="text-white"
         to="register"
         data-cy="email-verification-register-link"
+        @click.prevent="onRegisterAgain"
         >{{ $t('register.form.linkRegister') }}</router-link
       >.
     </div>

--- a/src/components/register/EmailVerification.vue
+++ b/src/components/register/EmailVerification.vue
@@ -37,14 +37,20 @@ export default defineComponent({
     const isEmailVerified = computed(() => registerStore.getIsEmailVerified);
 
     const checkIsEmailVerified = async (): Promise<void> => {
-      if (!isEmailVerified.value) {
+      logger?.debug(
+        `Check if email is verified is user logged in <${loginStore.isUserLoggedIn}>.`,
+      );
+      if (!isEmailVerified.value && loginStore.isUserLoggedIn) {
         logger?.info(
           'Check if email is verified by <checkIsEmailVerified()> function.',
         );
         await registerStore.checkEmailVerification();
       } else {
+        const message = loginStore.isUserLoggedIn
+          ? 'Email is verified'
+          : 'User is not logged in';
         logger?.debug(
-          'Email is verified, disable <checkIsEmailVerified()>' +
+          `${message}, disable <checkIsEmailVerified()>` +
             ` function runned in every <${rideToWorkByBikeConfig.checkIsEmailVerifiedInterval}> seconds.`,
         );
         clearTimeout(checkIsEmailVerifiedId);

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -82,6 +82,7 @@ export const useLoginStore = defineStore('login', {
     getRefreshTokenTimeout: (state): NodeJS.Timeout | null =>
       state.refreshTokenTimeout,
     getUserEmail: (state): string => state.user.email,
+    isUserLoggedIn: (state): boolean => (state.user.email ? true : false),
   },
 
   actions: {
@@ -112,7 +113,6 @@ export const useLoginStore = defineStore('login', {
         this.refreshTokenTimeout = null;
       }
     },
-
     /**
      * Login user
      * Checks if email and password are set.


### PR DESCRIPTION
Add logout and redirect action to the 'register again' link in EmailVerification.
This ensures that user can access register page and register again with a different email.