### PR TITLE
src/components: select stats shown by ListCardProgress and test count

### DIFF
--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -50,13 +50,16 @@ describe('<ListCardProgress>', () => {
     it('renders list of stats', () => {
       cy.window().then(() => {
         cy.dataCy('progress-slider-stats').should('be.visible');
-        cy.dataCy('stats-bar-item').should('have.length', 3);
+        cy.dataCy('stats-bar-item').should('have.length', stats.length);
       });
     });
 
     it('renders correct number of items', () => {
       cy.window().then(() => {
-        cy.dataCy('card-list-progress-item').should('have.length', 3);
+        cy.dataCy('card-list-progress-item').should(
+          'have.length',
+          stats.length,
+        );
       });
     });
 

--- a/src/components/__tests__/ListCardProgress.cy.js
+++ b/src/components/__tests__/ListCardProgress.cy.js
@@ -50,6 +50,7 @@ describe('<ListCardProgress>', () => {
     it('renders list of stats', () => {
       cy.window().then(() => {
         cy.dataCy('progress-slider-stats').should('be.visible');
+        cy.dataCy('stats-bar-item').should('have.length', 3);
       });
     });
 

--- a/src/components/homepage/ListCardProgress.vue
+++ b/src/components/homepage/ListCardProgress.vue
@@ -47,6 +47,9 @@ import StatsBar from '../global/StatsBar.vue';
 // composables
 import { useStats } from 'src/composables/useStats';
 
+// enums
+import { StatisticsId } from '../types/Statistics';
+
 // types
 import type { ItemStatistics } from '../types/Statistics';
 import type { MemberResponse } from '../types/Results';
@@ -75,9 +78,16 @@ export default defineComponent({
   },
   setup() {
     const memberResults = memberResultsFixture as MemberResponse;
+
     const { getResultStatistics } = useStats();
+    // define which stats are shown
+    const shownStatsIds = [
+      StatisticsId.routes,
+      StatisticsId.distance,
+      StatisticsId.co2,
+    ];
     const stats = computed<ItemStatistics[]>(() =>
-      getResultStatistics(memberResults.results),
+      getResultStatistics(memberResults.results, shownStatsIds),
     );
 
     return {


### PR DESCRIPTION
Issue: `StatsBar` in the `ListCardProgress` component shows 4 items instead of 3.

Solution: Using an array of ids, select stats displayed by the `StatsBar` in the `ListCardProgress` component.
Add test for the item count.