### PR TITLE
src/components: pull MenuLinks social data from useSocialLinks composable

### DIFF
--- a/src/components/global/MenuLinks.vue
+++ b/src/components/global/MenuLinks.vue
@@ -77,6 +77,7 @@ export default defineComponent({
         unelevated
         :key="item.title"
         :href="item.url"
+        target="_blank"
         color="blue-grey-1"
         class="q-btn-underline text-body2 q-mt-md"
         data-cy="button-menu-links"

--- a/src/components/global/MenuLinks.vue
+++ b/src/components/global/MenuLinks.vue
@@ -84,9 +84,9 @@ export default defineComponent({
         <!-- Icon -->
         <q-icon :name="item.icon" size="xs" color="blue-grey-3"></q-icon>
         <!-- Label -->
-        <span v-if="item.title" class="inline-block text-black q-pl-sm">{{
-          $t(item.title)
-        }}</span>
+        <span v-if="item.title" class="inline-block text-black q-pl-sm">
+          {{ $t(item.title) }}
+        </span>
       </q-btn>
     </div>
   </div>

--- a/src/components/global/MenuLinks.vue
+++ b/src/components/global/MenuLinks.vue
@@ -24,8 +24,11 @@
 // libraries
 import { defineComponent, computed } from 'vue';
 
+// composables
+import { useSocialLinks } from '../../composables/useSocialLinks';
+
 // mocks
-import { socialLinks, usefulLinks } from '../../mocks/layout';
+import { usefulLinks } from '../../mocks/layout';
 
 export default defineComponent({
   name: 'MenuLinks',
@@ -41,6 +44,8 @@ export default defineComponent({
   },
   setup(props) {
     const items = computed(() => {
+      const { socialLinks } = useSocialLinks();
+
       if (props.variant === 'social') {
         return socialLinks;
       }
@@ -79,7 +84,9 @@ export default defineComponent({
         <!-- Icon -->
         <q-icon :name="item.icon" size="xs" color="blue-grey-3"></q-icon>
         <!-- Label -->
-        <span class="inline-block text-black q-pl-sm">{{ item.title }}</span>
+        <span v-if="item.title" class="inline-block text-black q-pl-sm">{{
+          $t(item.title)
+        }}</span>
       </q-btn>
     </div>
   </div>


### PR DESCRIPTION
Issue: `MenuLinks` social link URLs are not drawn from global config.

Use `useSocialLinks` composable which builds a list of links using the global config.
Tweak template for the use case.