### PR TITLE
src/components/types: add RegisterChallenge types for personal details section 

### DIFF
--- a/src/components/form/FormPersonalDetails.vue
+++ b/src/components/form/FormPersonalDetails.vue
@@ -34,10 +34,8 @@ import { i18n } from '../../boot/i18n';
 import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 
 // types
-import {
-  FormOption,
-  FormPersonalDetailsFields,
-} from 'src/components/types/Form';
+import { FormOption } from 'src/components/types/Form';
+import { RegisterChallengePersonalDetailsForm } from 'src/components/types/RegisterChallenge';
 
 export default defineComponent({
   name: 'FormPersonalDetails',
@@ -48,7 +46,7 @@ export default defineComponent({
   },
   setup() {
     const store = useRegisterChallengeStore();
-    const personalDetails = reactive<FormPersonalDetailsFields>(
+    const personalDetails = reactive<RegisterChallengePersonalDetailsForm>(
       store.getPersonalDetails,
     );
 

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -1,23 +1,10 @@
-// enums
-import { NewsletterType } from '../types/Newsletter';
-
 // types
 import type { Image } from './Image';
-import { Gender } from './Profile';
+
 export enum TestPaymentVoucher {
   full = 'FULL',
   half = 'HALF',
 }
-
-export type FormPersonalDetailsFields = {
-  firstName: string;
-  lastName: string;
-  email: string;
-  nickname: string;
-  gender: Gender | null;
-  newsletter: NewsletterType[];
-  terms: boolean;
-};
 
 export type FormOption = {
   label: string;

--- a/src/components/types/RegisterChallenge.ts
+++ b/src/components/types/RegisterChallenge.ts
@@ -2,7 +2,7 @@
 import type { NewsletterType } from './Newsletter';
 import type { Gender } from './Profile';
 
-interface CorePersonalDetails {
+interface BasePersonalDetails {
   ageGroup?: number;
   jobTitle?: string;
   language?: string;
@@ -16,7 +16,7 @@ interface CorePersonalDetails {
  * API endpoint declares the following properties as optional.
  */
 export interface RegisterChallengePersonalDetailsApi
-  extends CorePersonalDetails {
+  extends BasePersonalDetails {
   firstName?: string;
   gender?: Gender | null;
   lastName?: string;
@@ -27,7 +27,7 @@ export interface RegisterChallengePersonalDetailsApi
  * We also add the newsletter property.
  */
 export interface RegisterChallengePersonalDetailsForm
-  extends CorePersonalDetails {
+  extends BasePersonalDetails {
   firstName: string;
   gender: Gender | null;
   lastName: string;

--- a/src/components/types/RegisterChallenge.ts
+++ b/src/components/types/RegisterChallenge.ts
@@ -20,11 +20,11 @@ export interface RegisterChallengePersonalDetailsApi
   firstName?: string;
   gender?: Gender | null;
   lastName?: string;
-  newsletter?: NewsletterType[];
 }
 
 /**
  * For the use in form, we declare the following properties as required.
+ * We also add the newsletter property.
  */
 export interface RegisterChallengePersonalDetailsForm
   extends CorePersonalDetails {
@@ -32,4 +32,10 @@ export interface RegisterChallengePersonalDetailsForm
   gender: Gender | null;
   lastName: string;
   newsletter: NewsletterType[];
+}
+
+export interface RegisterChallengePostRequest {
+  personalDetails: RegisterChallengePersonalDetailsApi;
+  newsletter: NewsletterType[];
+  teamId?: number;
 }

--- a/src/components/types/RegisterChallenge.ts
+++ b/src/components/types/RegisterChallenge.ts
@@ -1,0 +1,35 @@
+// types
+import type { NewsletterType } from './Newsletter';
+import type { Gender } from './Profile';
+
+interface CorePersonalDetails {
+  ageGroup?: number;
+  jobTitle?: string;
+  language?: string;
+  nickname?: string;
+  phone?: string;
+  phonePermit?: boolean;
+  terms?: boolean;
+}
+
+/**
+ * API endpoint declares the following properties as optional.
+ */
+export interface RegisterChallengePersonalDetailsApi
+  extends CorePersonalDetails {
+  firstName?: string;
+  gender?: Gender | null;
+  lastName?: string;
+  newsletter?: NewsletterType[];
+}
+
+/**
+ * For the use in form, we declare the following properties as required.
+ */
+export interface RegisterChallengePersonalDetailsForm
+  extends CorePersonalDetails {
+  firstName: string;
+  gender: Gender | null;
+  lastName: string;
+  newsletter: NewsletterType[];
+}

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -13,9 +13,9 @@ import type { RegisterChallengePersonalDetailsForm } from '../components/types/R
 const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
   lastName: '',
+  newsletter: [] as NewsletterType[],
   nickname: '',
   gender: null as Gender | null,
-  newsletter: [] as NewsletterType[],
   terms: true,
 };
 

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -2,18 +2,17 @@
 import { defineStore } from 'pinia';
 
 // enums
+import { Gender } from '../components/types/Profile';
 import { NewsletterType } from '../components/types/Newsletter';
 import { OrganizationType } from '../components/types/Organization';
-import { Gender } from '../components/types/Profile';
 
 // types
-import type { FormPersonalDetailsFields } from '../components/types/Form';
 import type { Logger } from '../components/types/Logger';
+import type { RegisterChallengePersonalDetailsForm } from '../components/types/RegisterChallenge';
 
-const emptyFormPersonalDetails: FormPersonalDetailsFields = {
+const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
   lastName: '',
-  email: '',
   nickname: '',
   gender: null as Gender | null,
   newsletter: [] as NewsletterType[],
@@ -37,7 +36,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
   }),
 
   getters: {
-    getPersonalDetails: (state): FormPersonalDetailsFields =>
+    getPersonalDetails: (state): RegisterChallengePersonalDetailsForm =>
       state.personalDetails,
     getOrganizationType: (state): OrganizationType | null =>
       state.organizationType,
@@ -48,7 +47,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
   },
 
   actions: {
-    setPersonalDetails(personalDetails: FormPersonalDetailsFields) {
+    setPersonalDetails(personalDetails: RegisterChallengePersonalDetailsForm) {
       Object.assign(this.personalDetails, personalDetails);
     },
     setOrganizationType(organizationType: OrganizationType) {


### PR DESCRIPTION
Add new types in `RegisterChallenge.ts` for handling the personal details section.
In the type used on FE, several type properties are marked as "not optional" so that they correctly work with input elements.
In the type used for API, these are marked as optional, based on the BE model.
Removes `email` field from the store data, as this is not part of the type.
Distinguishes the placement of the `newsletter` variable in local data structure and in API data structure.