### PR TITLE
src/components/__tests__: remove unnecessary translation function in MenuLinks test

### DIFF
--- a/src/components/__tests__/MenuLinks.cy.js
+++ b/src/components/__tests__/MenuLinks.cy.js
@@ -79,7 +79,7 @@ describe('<MenuLinks>', () => {
         .each(($el, index) => {
           cy.wrap($el)
             .should('have.attr', 'href', usefulLinks[index].url)
-            .and('contain', i18n.global.t(usefulLinks[index].title));
+            .and('contain', usefulLinks[index].title);
         });
       cy.dataCy('button-menu-links')
         .and('have.backgroundColor', blueGrey1)


### PR DESCRIPTION
Remove unnecessary translation function in `MenuLinks` component test, causing the tests to fail.