### PR TITLE
test/cypress/e2e: remove "only" function from home E2E tests

### DIFF
--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -356,7 +356,7 @@ describe('Home page', () => {
       });
     });
 
-    it.only('renders all components', () => {
+    it('renders all components', () => {
       cy.get('@i18n').then((i18n) => {
         cy.dataCy('q-main').should('be.visible');
         // title


### PR DESCRIPTION
Remove incorrectly used `only` function.