### PR TITLE
src/components/__tests__: fix FormFieldNewsletter component tests

### DIFF
--- a/src/components/__tests__/FormFieldNewsletter.cy.js
+++ b/src/components/__tests__/FormFieldNewsletter.cy.js
@@ -85,7 +85,9 @@ function coreTests() {
     model.value = [];
     nextTick();
     cy.dataCy(selectorNewsletterAll).click();
-    cy.wrap(model).its('value').should('have.length', 3);
+    cy.wrap(model)
+      .its('value')
+      .should('have.length', Object.keys(NewsletterType).length);
   });
 
   it('deselects all options when "all" is unclicked', () => {
@@ -97,7 +99,9 @@ function coreTests() {
         cy.wrap($el).click();
       });
     nextTick();
-    cy.wrap(model).its('value').should('have.length', 3);
+    cy.wrap(model)
+      .its('value')
+      .should('have.length', Object.keys(NewsletterType).length);
     cy.dataCy(selectorNewsletterAll).click();
     nextTick();
     cy.wrap(model).its('value').should('have.length', 0);
@@ -107,7 +111,7 @@ function coreTests() {
     model.value = [];
     nextTick();
     cy.dataCy(selectorNewsletterOption)
-      .should('have.length', 3)
+      .should('have.length', Object.keys(NewsletterType).length)
       .each(($el) => {
         cy.wrap($el).click();
       });

--- a/src/components/__tests__/FormFieldNewsletter.cy.js
+++ b/src/components/__tests__/FormFieldNewsletter.cy.js
@@ -66,6 +66,8 @@ function coreTests() {
   });
 
   it('renders all newsletter options', () => {
+    model.value = [];
+    nextTick();
     cy.dataCy(selectorNewsletterOption).should('have.length', 3);
   });
 
@@ -73,6 +75,7 @@ function coreTests() {
     model.value = [];
     nextTick();
     cy.dataCy(selectorNewsletterOption).eq(0).click();
+    nextTick();
     cy.wrap(model)
       .its('value')
       .should('deep.equal', [NewsletterType.challenge]);
@@ -86,11 +89,13 @@ function coreTests() {
   });
 
   it('deselects all options when "all" is unclicked', () => {
-    nextTick();
     model.value = [];
-    cy.dataCy(selectorNewsletterOption).each(($el) => {
-      cy.wrap($el).click();
-    });
+    nextTick();
+    cy.dataCy(selectorNewsletterOption)
+      .should('have.length', 3)
+      .each(($el) => {
+        cy.wrap($el).click();
+      });
     nextTick();
     cy.wrap(model).its('value').should('have.length', 3);
     cy.dataCy(selectorNewsletterAll).click();
@@ -101,9 +106,11 @@ function coreTests() {
   it('selects "all" when all options are manually selected', () => {
     model.value = [];
     nextTick();
-    cy.dataCy(selectorNewsletterOption).each(($el) => {
-      cy.wrap($el).click();
-    });
+    cy.dataCy(selectorNewsletterOption)
+      .should('have.length', 3)
+      .each(($el) => {
+        cy.wrap($el).click();
+      });
     cy.dataCy(selectorNewsletterAll).should('be.checked');
   });
 }

--- a/src/components/__tests__/FormFieldNewsletter.cy.js
+++ b/src/components/__tests__/FormFieldNewsletter.cy.js
@@ -57,6 +57,8 @@ describe('<FormFieldNewsletter>', () => {
 
 function coreTests() {
   it('renders component', () => {
+    model.value = [];
+    nextTick();
     cy.dataCy(selectorNewsletterContainer).should('be.visible');
     cy.dataCy(selectorNewsletterLabel).should('be.visible');
     cy.dataCy(selectorNewsletterAll).should('be.visible');
@@ -69,41 +71,39 @@ function coreTests() {
 
   it('updates v-model when options are selected', () => {
     model.value = [];
-    nextTick().then(() => {
-      cy.dataCy(selectorNewsletterOption).eq(0).click();
-      cy.wrap(model)
-        .its('value')
-        .should('deep.equal', [NewsletterType.challenge]);
-    });
+    nextTick();
+    cy.dataCy(selectorNewsletterOption).eq(0).click();
+    cy.wrap(model)
+      .its('value')
+      .should('deep.equal', [NewsletterType.challenge]);
   });
 
   it('selects all options when "all" is clicked', () => {
     model.value = [];
-    nextTick().then(() => {
-      cy.dataCy(selectorNewsletterAll).click();
-      cy.wrap(model).its('value').should('have.length', 3);
-    });
+    nextTick();
+    cy.dataCy(selectorNewsletterAll).click();
+    cy.wrap(model).its('value').should('have.length', 3);
   });
 
   it('deselects all options when "all" is unclicked', () => {
-    model.value = [
-      NewsletterType.challenge,
-      NewsletterType.event,
-      NewsletterType.mobility,
-    ];
-    nextTick().then(() => {
-      cy.dataCy(selectorNewsletterAll).click();
-      cy.wrap(model).its('value').should('have.length', 0);
+    nextTick();
+    model.value = [];
+    cy.dataCy(selectorNewsletterOption).each(($el) => {
+      cy.wrap($el).click();
     });
+    nextTick();
+    cy.wrap(model).its('value').should('have.length', 3);
+    cy.dataCy(selectorNewsletterAll).click();
+    nextTick();
+    cy.wrap(model).its('value').should('have.length', 0);
   });
 
   it('selects "all" when all options are manually selected', () => {
     model.value = [];
-    nextTick().then(() => {
-      cy.dataCy(selectorNewsletterOption).each(($el) => {
-        cy.wrap($el).click();
-      });
-      cy.dataCy(selectorNewsletterAll).should('be.checked');
+    nextTick();
+    cy.dataCy(selectorNewsletterOption).each(($el) => {
+      cy.wrap($el).click();
     });
+    cy.dataCy(selectorNewsletterAll).should('be.checked');
   });
 }


### PR DESCRIPTION
Issue: `nextTick().then()` results in tests not being evaluated in correct sequence.

* Fix improper use of `nextTick` function in `FormFieldNewsletter` component tests.
* In test `deselects all options when "all" is unclicked`, use UI interactions to get to the desired starting state to avoid failure.
* Note: initial state `model.value = [];` must be set within each test (not in the `beforeEach` hook) otherwise, it is not correctly loaded).

