### PR TITLE
src/components/__tests__: fix MenuLinks component 'renders link buttons with correct styling (useful links variant)' test

### DIFF
--- a/src/components/__tests__/MenuLinks.cy.js
+++ b/src/components/__tests__/MenuLinks.cy.js
@@ -79,7 +79,7 @@ describe('<MenuLinks>', () => {
         .each(($el, index) => {
           cy.wrap($el)
             .should('have.attr', 'href', usefulLinks[index].url)
-            .and('contain', i18n.global.t(usefulLinks[index].title));
+            .and('contain', usefulLinks[index].title);
         });
       cy.dataCy('button-menu-links')
         .and('have.backgroundColor', blueGrey1)


### PR DESCRIPTION
Fix `MenuLinks` component 'renders link buttons with correct styling (useful links variant)' test.

Fix error message:

```
 useful
      1) renders link buttons with correct styling (useful links variant)


  3 passing (662ms)
  1 failing

  1) <MenuLinks>
       useful
         renders link buttons with correct styling (useful links variant):
     ReferenceError: i18n is not defined
      at Context.<anonymous> (/home/runner/work/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/MenuLinks.cy.js:82:29)
      at Context.callback (http://localhost:9001/__cypress/runner/cypress_runner.js:119396:26)
      at getRet (http://localhost:9001/__cypress/runner/cypress_runner.js:119161:20)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at Promise.attempt.Promise.try (http://localhost:9001/__cypress/runner/cypress_runner.js:4315:29)
      at thenFn (http://localhost:9001/__cypress/runner/cypress_runner.js:119172:66)
      at yieldItem (http://localhost:9001/__cypress/runner/cypress_runner.js:119404:16)
      at tryCatcher (http://localhost:9001/__cypress/runner/cypress_runner.js:1807:23)
      at Object.gotValue (http://localhost:9001/__cypress/runner/cypress_runner.js:6476:18)
      at Object.gotAccum (http://localhost:9001/__cypress/runner/cypress_runner.js:6465:25)
```