### PR TITLE
src/components/__tests__: update initiation timing for store variables in FormRegister component tests

### DIFF
--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { colors } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 import FormRegister from '../register/FormRegister.vue';
@@ -56,9 +57,12 @@ const testPassword = '12345a';
 const { apiBase, apiDefaultLang, urlApiRegister } = rideToWorkByBikeConfig;
 const defaultLoginUserEmailStoreValue = '';
 
-const compareRegisterResponseWithStore = (registerResponse) => {
-  const registerStore = useRegisterStore();
-  const loginStore = useLoginStore();
+const compareRegisterResponseWithStore = (
+  loginStore,
+  registerStore,
+  registerResponse,
+) => {
+  nextTick();
   expect(registerStore.getIsEmailVerified).to.equal(false);
   expect(loginStore.getUserEmail).to.equal(registerResponse.user.email);
   expect(loginStore.getUser).to.eql(registerResponse.user);
@@ -406,6 +410,8 @@ describe('<FormRegister>', () => {
     });
 
     it('allows to submit form after filling fields', () => {
+      const registerStore = useRegisterStore();
+      const loginStore = useLoginStore();
       // variables
       const apiBaseUrl = getApiBaseUrlWithLang(
         null,
@@ -438,7 +444,11 @@ describe('<FormRegister>', () => {
             .its('response.statusCode')
             .should('be.equal', httpSuccessfullStatus)
             .then(() => {
-              compareRegisterResponseWithStore(registerResponse);
+              compareRegisterResponseWithStore(
+                loginStore,
+                registerStore,
+                registerResponse,
+              );
             });
         },
       );
@@ -477,6 +487,8 @@ describe('<FormRegister>', () => {
     });
 
     it('allows to submit form after filling fields and accepting privacy policy', () => {
+      const registerStore = useRegisterStore();
+      const loginStore = useLoginStore();
       const challengeStore = useChallengeStore();
       expect(
         challengeStore.getIsChallengeInPhase(PhaseType.competition),
@@ -509,7 +521,11 @@ describe('<FormRegister>', () => {
             .its('response.statusCode')
             .should('be.equal', httpSuccessfullStatus)
             .then(() => {
-              compareRegisterResponseWithStore(registerResponse);
+              compareRegisterResponseWithStore(
+                loginStore,
+                registerStore,
+                registerResponse,
+              );
             });
         },
       );


### PR DESCRIPTION
Issue: Tests for `FormRegister` occasionally fail with following message:

```
  1) <FormRegister>
       no active challenge
         allows to submit form after filling fields:

      AssertionError: expected '' to equal 'foo@bar.org'
      + expected - actual

      +'foo@bar.org'
```

Solution:
* Initiate store variable at the beginning of the test and pass the instance into the `compareRegisterResponseWithStore` function when needed.
* Add `nextTick` function before checking the store state.