### PR TITLE
src/stores: fix printing date and time in human readable format

### DIFF
--- a/src/stores/challenge.ts
+++ b/src/stores/challenge.ts
@@ -2,6 +2,8 @@
 import { defineStore } from 'pinia';
 import { PhaseType } from '../components/types/Challenge';
 
+import { timestampToDatetimeString } from 'src/utils';
+
 // enums
 export enum ChallengeStatus {
   before = 'before',
@@ -69,10 +71,16 @@ export const useChallengeStore = defineStore('challenge', {
       if (phase) {
         const startDate: number = new Date(phase.date_from).getTime();
         const endDate: number = new Date(phase.date_to).getTime();
-        this.$log?.debug(`<${phaseType}> phase date from <${startDate}>.`);
-        this.$log?.debug(`<${phaseType}> phase date to <${endDate}>.`);
+        this.$log?.debug(
+          `<${phaseType}> phase date from <${timestampToDatetimeString(startDate / 1000)}>.`,
+        );
+        this.$log?.debug(
+          `<${phaseType}> phase date to <${timestampToDatetimeString(endDate / 1000)}>.`,
+        );
         const now: number = new Date().getTime();
-        this.$log?.debug(`Now date <${now}>.`);
+        this.$log?.debug(
+          `Current date and time is <${timestampToDatetimeString(now / 1000)}>.`,
+        );
         this.$log?.debug(
           `Is challenge in phase type <${phaseType}> <${now >= startDate && now <= endDate}>.`,
         );


### PR DESCRIPTION
Fix printing date and time in human readable format.

Browser web console debug info:

```
12:41:08.208 debug |  q-cache/vite/spa/deps/pinia |  <registration> phase date from <1721001600000>. vue3-logger.ts:91:23
12:41:08.208 debug |  q-cache/vite/spa/deps/pinia |  <registration> phase date to <1727568000000>. vue3-logger.ts:91:23
12:41:08.208 debug |  q-cache/vite/spa/deps/pinia |  Now date <1731238868208>.
```

Expected debug info with human readable date and time format:

```
12:42:44.976 debug |  q-cache/vite/spa/deps/pinia |  <competition> phase date from <16 Sep 2024 2:0:0>. vue3-logger.ts:91:23
12:42:44.976 debug |  q-cache/vite/spa/deps/pinia |  <competition> phase date to <29 Sep 2024 2:0:0>. vue3-logger.ts:91:23
12:42:44.976 debug |  q-cache/vite/spa/deps/pinia |  Current date and time is <10 Nov 2024 12:42:44>. vue3-logger.ts:91:23

```