### PR TITLE
config: fix incorrect url paths for challenge api endpoints

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -82,9 +82,9 @@ urlApiLoginGoogle = "auth/google/login/"
 urlApiOrganizations = "organizations/"
 urlApiRefresh = "auth/token/refresh/"
 urlApiRegister = "auth/registration/"
-urlApiRegisterCoordinator = "rest/challenge/registration/coordinator/"
+urlApiRegisterCoordinator = "challenge/registration/coordinator/"
 urlApiResetPassword = "auth/password/reset/"
-urlApiChallengeRegistrationUser = "rest/challenge/registration/user/"
+urlApiChallengeRegistrationUser = "challenge/registration/user/"
 
 checkIsEmailVerifiedInterval = 20 # seconds
 


### PR DESCRIPTION
Remove additional `/rest` component of the endpoint URLs for challenge registration.