### PR TITLE
src/components: update FormFieldCompanyAddress v-model type

### DIFF
--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -36,7 +36,10 @@ import DialogDefault from 'src/components/global/DialogDefault.vue';
 import { useValidation } from 'src/composables/useValidation';
 
 // types
-import type { FormOption } from 'src/components/types/Form';
+import type {
+  FormCompanyAddressFields,
+  FormOption,
+} from 'src/components/types/Form';
 
 export default defineComponent({
   name: 'FormFieldCompanyAddress',
@@ -49,15 +52,16 @@ export default defineComponent({
       required: true,
     },
     modelValue: {
-      type: String as () => string | null,
+      type: Object as () => FormCompanyAddressFields | null,
       required: true,
     },
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
-    const address = computed<string | null>({
+    const address = computed<FormCompanyAddressFields | null>({
       get: () => props.modelValue,
-      set: (value: string | null) => emit('update:modelValue', value),
+      set: (value: FormCompanyAddressFields | null) =>
+        emit('update:modelValue', value),
     });
 
     watch(

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -43,11 +43,15 @@ export default defineComponent({
     const organizations: Organization[] =
       formOrganizationOptions as Organization[];
 
-    const { addressId, addressOptions, organizationId, organizationOptions } =
-      useSelectedOrganization(organizations);
+    const {
+      selectedAddress,
+      addressOptions,
+      organizationId,
+      organizationOptions,
+    } = useSelectedOrganization(organizations);
 
     return {
-      addressId,
+      selectedAddress,
       addressOptions,
       organizationId,
       organizationOptions,
@@ -70,7 +74,7 @@ export default defineComponent({
       data-cy="form-select-table-company"
     />
     <form-field-company-address
-      v-model="addressId"
+      v-model="selectedAddress"
       :options="addressOptions"
       data-cy="form-company-address"
     />

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -15,6 +15,7 @@ export enum OrganizationLevel {
 
 export interface Organization {
   subsidiaries: OrganizationSubsidiary[];
+  address?: FormCompanyAddressFields;
   description?: string;
   id: number;
   identificationNumber: string;

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -50,12 +50,25 @@ export const useValidation = () => {
     return confirm === password;
   };
 
-  const isFilled = (val: string | number): boolean => {
-    if (typeof val === 'number') {
+  const isFilled = (val: string | number | object): boolean => {
+    // null is object so check first
+    if (val === null) {
+      return false;
+    } else if (typeof val === 'object') {
+      // array
+      if (Array.isArray(val)) {
+        return val.length > 0;
+      }
+      // object
+      return Object.keys(val).length > 0;
+    } else if (typeof val === 'number') {
+      // number
       return val !== 0;
-    } else {
-      return val?.length > 0;
+    } else if (typeof val === 'string') {
+      // string
+      return val.trim().length > 0;
     }
+    return false;
   };
 
   const isAboveZero = (val: string | number): boolean => {


### PR DESCRIPTION
Issue: Currently, the `FormFieldCompanyAddress` component accepts `number` type ID as the `modelValue` prop. However, in data, this will be the object with address fields - value needs to correspond with subsidiary address so that we can determine `subsidiaryId`.

Solution:
* Update type in `FormFieldCompanyAddress` component
* Update calculating option values in `useSelectedOrganization` composable and add behaviour that sets `subsidiaryId` based on selected address.

Additionally, based on data from endpoint, add optional `address` pro to `Organization` type.