### PR TITLE
test/cypress/e2e: add scope to cy.clock function to prevent issues with unresponsive UI elements

### DIFF
--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -339,7 +339,7 @@ describe('Home page', () => {
 
   context('before challenge', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive).then(() => {
+      cy.clock(systemTimeChallengeInactive, ['Date']).then(() => {
         cy.visit(Cypress.config('baseUrl'));
         cy.viewport('macbook-16');
 

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -147,7 +147,14 @@ describe('Login page', () => {
 
   context('login user flow', () => {
     beforeEach(() => {
-      cy.clock(systemTimeLoggedIn);
+      /**
+       * In this test, we need to extend the scope of the clock effect to
+       * the `setTimeout` function since we use it in
+       * the `scheduleTokenRefresh` in login store.
+       */
+      cy.clock(systemTimeLoggedIn, ['Date', 'setTimeout']).then((clock) => {
+        cy.wrap(clock).as('clock');
+      });
       cy.visit('#' + routesConf['login']['path']);
       cy.viewport('macbook-16');
 
@@ -188,7 +195,7 @@ describe('Login page', () => {
     });
 
     it('allows user to login and refreshes token 1 min before expiration', () => {
-      cy.clock(systemTimeLoggedIn).then((clock) => {
+      cy.get('@clock').then((clock) => {
         // fill in form
         loginWithUI();
         // wait for login API call

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -136,7 +136,6 @@ describe('Register page', () => {
           cy.wait('@registerRequest');
           // check error message
           cy.get('@i18n').then((i18n) => {
-            cy.tick(1000);
             cy.contains(
               i18n.global.t('register.apiMessageErrorWithMessage'),
             ).should('be.visible');
@@ -294,8 +293,6 @@ describe('Register page', () => {
           has_user_verified_email_address: false,
         });
       });
-      // tick to render screen size dependent components
-      cy.tick(1000);
       // it shows logout button
       cy.dataCy(selectorLogoutButton).should('be.visible');
       // click logout button
@@ -365,8 +362,6 @@ describe('Register page', () => {
           cy.dataCy(selectorUserSelectDesktop).within(() => {
             cy.dataCy(selectorUserSelectInput).should('be.visible').click();
           });
-          // tick to render animated component
-          cy.tick(1000);
           // logout
           cy.dataCy('menu-item')
             .contains(i18n.global.t('userSelect.logout'))

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -148,7 +148,7 @@ describe('Register page', () => {
 
   context('active challenge', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeActive).then(() => {
+      cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
         cy.visit('#' + routesConf['register']['path']);
         cy.viewport('macbook-16');
 

--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -10,7 +10,7 @@ import {
 describe('Router rules', () => {
   context('challenge inactive', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive);
+      cy.clock(systemTimeChallengeInactive, ['Date']);
       cy.visit('#' + routesConf['login']['path']);
       cy.viewport('macbook-16');
 
@@ -43,7 +43,7 @@ describe('Router rules', () => {
 
   context('challenge active', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeActive);
+      cy.clock(systemTimeChallengeActive, ['Date']);
       cy.visit('#' + routesConf['login']['path']);
       cy.viewport('macbook-16');
 
@@ -64,16 +64,13 @@ describe('Router rules', () => {
         cy.get('@i18n').then((i18n) => {
           setupApiChallengeActive(config, i18n, true);
           loginWithUI();
-          cy.clock().then((clock) => {
-            clock.tick(1000);
-            cy.url().should('not.include', routesConf['login']['path']);
-            cy.url().should('not.include', routesConf['verify_email']['path']);
-            cy.url().should(
-              'not.include',
-              routesConf['challenge_inactive']['path'],
-            );
-            cy.url().should('include', routesConf['home']['path']);
-          });
+          cy.url().should('not.include', routesConf['login']['path']);
+          cy.url().should('not.include', routesConf['verify_email']['path']);
+          cy.url().should(
+            'not.include',
+            routesConf['challenge_inactive']['path'],
+          );
+          cy.url().should('include', routesConf['home']['path']);
         });
       });
     });

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -384,9 +384,7 @@ export const setupApiChallengeInactive = (
     body: { has_user_verified_email_address: verifiedEmail },
   }).as('verifyEmail');
   // set system time to "before challenge"
-  cy.clock().then((clock) => {
-    clock.setSystemTime(systemTimeChallengeInactive);
-  });
+  cy.clock(systemTimeChallengeInactive, ['Date']);
 };
 
 export const interceptOrganizationsApi = (config: ConfigGlobal, i18n: I18n) => {

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -134,73 +134,68 @@ export const testDesktopSidebar = (): void => {
         cy.fixture('refreshTokensResponseChallengeActive.json').then(
           (refreshTokensResponse) => {
             cy.get('@config').then((config: unknown) => {
-              cy.clock().then((clock) => {
-                clock.setSystemTime(systemTimeLoggedIn);
-                let i18n: I18n | undefined;
-                cy.window().should('have.property', 'i18n');
-                cy.window()
-                  .then((win: AUTWindow) => {
-                    i18n = win.i18n;
-                  })
-                  .then(() => {
-                    cy.visit('#' + routesConf['login']['path']);
-                    const {
-                      apiBase,
-                      apiDefaultLang,
-                      urlApiLogin,
-                      urlApiRefresh,
-                    } = config as ConfigGlobal;
-                    const apiBaseUrl = getApiBaseUrlWithLang(
-                      null,
-                      apiBase,
-                      apiDefaultLang,
-                      i18n as I18n,
-                    );
-                    const apiLoginUrl = `${apiBaseUrl}${urlApiLogin}`;
-                    const apiRefreshUrl = `${apiBaseUrl}${urlApiRefresh}`;
-                    // intercept API login request
-                    cy.intercept('POST', apiLoginUrl, {
-                      statusCode: httpSuccessfullStatus,
-                      body: loginResponse,
-                    }).as('loginRequest');
-                    // intercept API refresh token request
-                    cy.intercept('POST', apiRefreshUrl, {
-                      statusCode: httpSuccessfullStatus,
-                      body: refreshTokensResponse,
-                    }).as('refreshTokens');
-                    cy.dataCy('form-login-email')
-                      .find('input')
-                      .type('test@example.com');
-                    cy.dataCy('form-login-password')
-                      .find('input')
-                      .type('password123');
-                    // submit form
-                    cy.dataCy('form-login-submit-login').click();
-                    // check if user is redirected to the home page
-                    cy.url().should('include', routesConf['home']['path']);
-                    cy.dataCy(selectorUserSelectDesktop).within(() => {
-                      cy.dataCy(selectorUserSelectInput)
-                        .should('be.visible')
-                        .and('contain', loginResponse.user.email);
-                    });
-                    // click on user select
-                    cy.dataCy(selectorUserSelectDesktop).within(() => {
-                      cy.dataCy(selectorUserSelectInput)
-                        .should('be.visible')
-                        .click();
-                    });
-                    // tick to render animated component
-                    cy.tick(1000).then(() => {
-                      // logout
-                      cy.dataCy('menu-item')
-                        .contains(i18n?.global.t('userSelect.logout'))
-                        .click();
-                      cy.dataCy(selectorUserSelectDesktop).should('not.exist');
-                      // redirected to login page
-                      cy.url().should('include', routesConf['login']['path']);
-                    });
+              cy.clock(systemTimeLoggedIn, ['Date']);
+              let i18n: I18n | undefined;
+              cy.window().should('have.property', 'i18n');
+              cy.window()
+                .then((win: AUTWindow) => {
+                  i18n = win.i18n;
+                })
+                .then(() => {
+                  cy.visit('#' + routesConf['login']['path']);
+                  const {
+                    apiBase,
+                    apiDefaultLang,
+                    urlApiLogin,
+                    urlApiRefresh,
+                  } = config as ConfigGlobal;
+                  const apiBaseUrl = getApiBaseUrlWithLang(
+                    null,
+                    apiBase,
+                    apiDefaultLang,
+                    i18n as I18n,
+                  );
+                  const apiLoginUrl = `${apiBaseUrl}${urlApiLogin}`;
+                  const apiRefreshUrl = `${apiBaseUrl}${urlApiRefresh}`;
+                  // intercept API login request
+                  cy.intercept('POST', apiLoginUrl, {
+                    statusCode: httpSuccessfullStatus,
+                    body: loginResponse,
+                  }).as('loginRequest');
+                  // intercept API refresh token request
+                  cy.intercept('POST', apiRefreshUrl, {
+                    statusCode: httpSuccessfullStatus,
+                    body: refreshTokensResponse,
+                  }).as('refreshTokens');
+                  cy.dataCy('form-login-email')
+                    .find('input')
+                    .type('test@example.com');
+                  cy.dataCy('form-login-password')
+                    .find('input')
+                    .type('password123');
+                  // submit form
+                  cy.dataCy('form-login-submit-login').click();
+                  // check if user is redirected to the home page
+                  cy.url().should('include', routesConf['home']['path']);
+                  cy.dataCy(selectorUserSelectDesktop).within(() => {
+                    cy.dataCy(selectorUserSelectInput)
+                      .should('be.visible')
+                      .and('contain', loginResponse.user.email);
                   });
-              });
+                  // click on user select
+                  cy.dataCy(selectorUserSelectDesktop).within(() => {
+                    cy.dataCy(selectorUserSelectInput)
+                      .should('be.visible')
+                      .click();
+                  });
+                  // logout
+                  cy.dataCy('menu-item')
+                    .contains(i18n?.global.t('userSelect.logout'))
+                    .click();
+                  cy.dataCy(selectorUserSelectDesktop).should('not.exist');
+                  // redirected to login page
+                  cy.url().should('include', routesConf['login']['path']);
+                });
             });
           },
         );
@@ -328,9 +323,7 @@ export const setupApiChallengeActive = (
     body: { has_user_verified_email_address: verifiedEmail },
   }).as('verifyEmail');
   // set system time to "during challenge"
-  cy.clock().then((clock) => {
-    clock.setSystemTime(systemTimeLoggedIn);
-  });
+  cy.clock(systemTimeLoggedIn, ['Date']);
 };
 
 export const setupApiChallengeInactive = (


### PR DESCRIPTION
Issue: when `cy.clock` is used in tests, some parts of UI become unresponsive.
Clock function overrides the `setTimeout` and other time-related methods and if components are dependent on them, they do not work as expected.

Example problem:
```
  1) Register page
       inactive challenge
         shows error message on registration failure:
     AssertionError: Timed out retrying after 60000ms: expected '<div.q-notification__message.col>' to be 'visible'
```

Solution:
Based on [GitHub Issue](https://github.com/cypress-io/cypress/issues/7455#issuecomment-635278631), explicitly select functions and object which should be controlled by cypress clock command.
Mostly, this is only the `Date` function to set the reference time for token validity.
This allows to run most tests without calling `cy.tick(1000)` for "moving" elements.