### PR TITLE
src/stores: set empty user in login store via deep object copy function

### DIFF
--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -27,6 +27,9 @@ import type {
   LoginResponse,
 } from 'src/components/types/Login';
 
+// utils
+import { deepObjectWithSimplePropsCopy } from '../utils';
+
 declare module 'pinia' {
   export interface PiniaCustomProperties {
     $router: Router;
@@ -63,7 +66,7 @@ export const useLoginStore = defineStore('login', {
   state: () => ({
     // property set in pinia.js boot file
     $log: null as Logger | null,
-    user: emptyUser as UserLogin, // persisted
+    user: deepObjectWithSimplePropsCopy(emptyUser) as UserLogin, // persisted
     accessToken: '',
     refreshToken: '', // persisted
     jwtExpiration: null as number | null, // persisted, unit: seconds, https://www.rfc-editor.org/rfc/rfc7519#section-2
@@ -273,7 +276,7 @@ export const useLoginStore = defineStore('login', {
       this.setAccessToken('');
       this.setRefreshToken('');
       this.setJwtExpiration(null);
-      this.setUser(emptyUser);
+      this.setUser(deepObjectWithSimplePropsCopy(emptyUser) as UserLogin);
       this.clearRefreshTokenTimeout();
       this.$log?.debug(`Login store access token <${this.getAccessToken}>.`);
       this.$log?.debug(`Login store refresh token <${this.getRefreshToken}>.`);

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -300,6 +300,8 @@ describe('Register page', () => {
       // redirected to login page
       cy.url().should('not.include', routesConf['verify_email']['path']);
       cy.url().should('include', routesConf['login']['path']);
+      // logout button is no longer visible
+      cy.dataCy(selectorLogoutButton).should('not.exist');
     });
 
     it('redirects to home page after registering and verifying email and allows logout', () => {


### PR DESCRIPTION
This change is up for discussion. Store is currently working as expected: Replacing user with an empty object.
This is most likely because we always mutate the `user` object as a whole.
However, based on JS logic (referencing a common object), if we mutate props individually, they get updated in the `emptyObject` which is pointed to by reference.
To prevent a possible issue in the future, I suggest using the deep object copy util, to never point by reference to the empty state.

Additionally, add a test for logout button visibility after logout.