### PR TITLE
src/components: refactor dynamic labels in FormFieldSelectTable to a composable

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -56,6 +56,11 @@ describe('<FormFieldSelectTable>', () => {
       i18n,
     );
     cy.testLanguageStringsInContext(
+      ['buttonAddSubsidiary', 'labelSubsidiary', 'titleAddSubsidiary'],
+      'form.subsidiary',
+      i18n,
+    );
+    cy.testLanguageStringsInContext(
       ['labelCity', 'labelHouseNumber', 'labelStreet', 'labelZip'],
       'form',
       i18n,
@@ -307,6 +312,38 @@ describe('<FormFieldSelectTable>', () => {
       // submit
       cy.dataCy('dialog-button-submit').click();
       cy.dataCy('dialog-add-option').should('not.exist');
+    });
+  });
+
+  context('subsidiary desktop', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldSelectTable, {
+        props: {
+          options: options.value,
+          organizationLevel: OrganizationLevel.subsidiary,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('renders HTML elements', () => {
+      // input label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.subsidiary.labelSubsidiary'));
+      // add new button
+      cy.dataCy('button-add-option')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.subsidiary.buttonAddSubsidiary'));
+      // open dialog
+      cy.dataCy('button-add-option').click();
+      cy.dataCy('dialog-add-option').should('be.visible');
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('have.css', 'font-size', '20px')
+        .and('have.css', 'font-weight', '500')
+        .and('contain', i18n.global.t('form.subsidiary.titleAddSubsidiary'));
     });
   });
 });

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -69,10 +69,6 @@ describe('<FormFieldSelectTable>', () => {
           options: options.value,
           organizationLevel: OrganizationLevel.organization,
           organizationType: OrganizationType.company,
-          label: i18n.global.t('form.company.labelCompany'),
-          labelButton: i18n.global.t('register.challenge.buttonAddCompany'),
-          labelButtonDialog: i18n.global.t('form.company.buttonAddCompany'),
-          titleDialog: i18n.global.t('form.company.titleAddCompany'),
         },
       });
       cy.viewport('macbook-16');
@@ -199,10 +195,6 @@ describe('<FormFieldSelectTable>', () => {
           organizationLevel: OrganizationLevel.organization,
           organizationType: OrganizationType.company,
           modelValue: options.value[0].value,
-          label: i18n.global.t('form.company.labelCompany'),
-          labelButton: i18n.global.t('register.challenge.buttonAddCompany'),
-          labelButtonDialog: i18n.global.t('form.company.buttonAddCompany'),
-          titleDialog: i18n.global.t('form.company.titleAddCompany'),
         },
       });
       cy.viewport('macbook-16');
@@ -222,10 +214,6 @@ describe('<FormFieldSelectTable>', () => {
         props: {
           options: options.value,
           organizationLevel: OrganizationLevel.team,
-          label: i18n.global.t('form.team.labelTeam'),
-          labelButton: i18n.global.t('form.team.buttonAddTeam'),
-          labelButtonDialog: i18n.global.t('form.team.buttonAddTeam'),
-          titleDialog: i18n.global.t('form.team.titleAddTeam'),
         },
       });
       cy.viewport('macbook-16');

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -14,11 +14,6 @@
  *   company.
  * - `options` (Array<FormSelectTableOption>, required): The object
  *   representing the options.
- * - `label` (string, required): The translation for the label.
- * - `labelButton` (string): The translation for the add button.
- * - `labelButtonDialog` (string): The translation for the add
- *   button inside the dialog.
- * - `titleDialog` (string): The translation for the dialog title.
  * - `organizationLevel` (OrganizationLevel, required): The organization
  *   level - table is used for organization or team selection.
  * - `organizationType` (OrganizationType,
@@ -33,7 +28,11 @@
  * - `FormAddTeam`: Used to render form for registering a new team.
  *
  * @example
- * <form-field-select-table />
+ * <form-field-select-table
+ *  v-model="organizationId"
+ *  :organization-level="OrganizationLevel.organization"
+ *  :options="organizationOptions"
+ * />
  *
  * @see [Figma Design](https://www.figma.com/file/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?type=design&node-id=5366%3A28607&mode=dev)
  */
@@ -51,6 +50,7 @@ import FormAddCompany from '../form/FormAddCompany.vue';
 import FormAddTeam from '../form/FormAddTeam.vue';
 
 // composables
+import { useSelectTable } from '../../composables/useSelectTable';
 import { useValidation } from '../../composables/useValidation';
 
 // enums
@@ -78,22 +78,6 @@ export default defineComponent({
     },
     options: {
       type: Array as () => FormSelectTableOption[] | FormOption[],
-      required: true,
-    },
-    label: {
-      type: String,
-      required: true,
-    },
-    labelButton: {
-      type: String,
-      required: true,
-    },
-    labelButtonDialog: {
-      type: String,
-      required: true,
-    },
-    titleDialog: {
-      type: String,
       required: true,
     },
     organizationLevel: {
@@ -187,6 +171,9 @@ export default defineComponent({
       }
     };
 
+    const { label, labelButton, labelButtonDialog, titleDialog } =
+      useSelectTable(props.organizationLevel);
+
     return {
       borderRadius,
       companyNew,
@@ -195,8 +182,12 @@ export default defineComponent({
       formRef,
       inputValue,
       isDialogOpen,
+      label,
+      labelButton,
+      labelButtonDialog,
       query,
       teamNew,
+      titleDialog,
       isFilled,
       onClose,
       onSubmit,

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -67,10 +67,6 @@ export default defineComponent({
       v-model="organizationId"
       :organization-level="OrganizationLevel.organization"
       :options="organizationOptions"
-      :label="$t('form.company.labelCompany')"
-      :label-button="$t('register.challenge.buttonAddCompany')"
-      :label-button-dialog="$t('form.company.buttonAddCompany')"
-      :title-dialog="$t('form.company.titleAddCompany')"
       data-cy="form-select-table-company"
     />
     <form-field-company-address

--- a/src/composables/useSelectTable.ts
+++ b/src/composables/useSelectTable.ts
@@ -1,0 +1,53 @@
+// libraries
+import { computed } from 'vue';
+
+// composables
+import { i18n } from '../boot/i18n';
+
+// enums
+import { OrganizationLevel } from '../components/types/Organization';
+
+export const useSelectTable = (organizationLevel: OrganizationLevel) => {
+  const label = computed(() => {
+    switch (organizationLevel) {
+      case OrganizationLevel.team:
+        return i18n.global.t('form.team.labelTeam');
+      default:
+        return i18n.global.t('form.company.labelCompany');
+    }
+  });
+
+  const labelButton = computed(() => {
+    switch (organizationLevel) {
+      case OrganizationLevel.team:
+        return i18n.global.t('form.team.buttonAddTeam');
+      default:
+        return i18n.global.t('register.challenge.buttonAddCompany');
+    }
+  });
+
+  const labelButtonDialog = computed(() => {
+    switch (organizationLevel) {
+      case OrganizationLevel.team:
+        return i18n.global.t('form.team.buttonAddTeam');
+      default:
+        return i18n.global.t('form.company.buttonAddCompany');
+    }
+  });
+
+  const titleDialog = computed(() => {
+    switch (organizationLevel) {
+      case OrganizationLevel.team:
+        return i18n.global.t('form.team.titleAddTeam');
+      default:
+        return i18n.global.t('form.company.titleAddCompany');
+    }
+  });
+
+  return {
+    label,
+    labelButton,
+    labelButtonDialog,
+    titleDialog,
+  };
+};

--- a/src/composables/useSelectTable.ts
+++ b/src/composables/useSelectTable.ts
@@ -12,6 +12,8 @@ export const useSelectTable = (organizationLevel: OrganizationLevel) => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
         return i18n.global.t('form.team.labelTeam');
+      case OrganizationLevel.subsidiary:
+        return i18n.global.t('form.subsidiary.labelSubsidiary');
       default:
         return i18n.global.t('form.company.labelCompany');
     }
@@ -21,6 +23,8 @@ export const useSelectTable = (organizationLevel: OrganizationLevel) => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
         return i18n.global.t('form.team.buttonAddTeam');
+      case OrganizationLevel.subsidiary:
+        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
       default:
         return i18n.global.t('register.challenge.buttonAddCompany');
     }
@@ -30,6 +34,8 @@ export const useSelectTable = (organizationLevel: OrganizationLevel) => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
         return i18n.global.t('form.team.buttonAddTeam');
+      case OrganizationLevel.subsidiary:
+        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
       default:
         return i18n.global.t('form.company.buttonAddCompany');
     }
@@ -39,6 +45,8 @@ export const useSelectTable = (organizationLevel: OrganizationLevel) => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
         return i18n.global.t('form.team.titleAddTeam');
+      case OrganizationLevel.subsidiary:
+        return i18n.global.t('form.subsidiary.titleAddSubsidiary');
       default:
         return i18n.global.t('form.company.titleAddCompany');
     }

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -307,6 +307,11 @@ titleAddSchool = "Přidat školu"
 titleAddFamily = "Přidat rodinu"
 titleSubsidiaryAddress = "Adresa vaší pobočky"
 
+[form.subsidiary]
+labelSubsidiary = "Název pobočky"
+buttonAddSubsidiary = "Přidat pobočku"
+titleAddSubsidiary = "Přidat pobočku"
+
 [form.team]
 buttonAddTeam = "Přidat tým"
 labelMembers = "člen | členů"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -304,6 +304,11 @@ titleAddFamily = "Add family"
 titleAddAddress = "Add your subsidiary"
 titleSubsidiaryAddress = "Your branch address"
 
+[form.subsidiary]
+labelSubsidiary = "Subsidiary name"
+buttonAddSubsidiary = "Add subsidiary"
+titleAddSubsidiary = "Add subsidiary"
+
 [form.team]
 buttonAddTeam = "Add team"
 labelMembers = "member | members"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -304,6 +304,11 @@ titleAddFamily = "Pridať rodinu"
 titleAddAddress = "Pridajte svoju pobočku"
 titleSubsidiaryAddress = "Adresa vašej pobočky"
 
+[form.subsidiary]
+labelSubsidiary = "Název pobočky"
+buttonAddSubsidiary = "Pridať pobočku"
+titleAddSubsidiary = "Pridať pobočku"
+
 [form.team]
 buttonAddTeam = "Pridať tím"
 labelMembers = "člen | členov"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -393,10 +393,6 @@ export default defineComponent({
                 v-model="team"
                 :organization-level="OrganizationLevel.team"
                 :options="teamOptions"
-                :label="$t('form.team.labelTeam')"
-                :label-button="$t('form.team.buttonAddTeam')"
-                :label-button-dialog="$t('form.team.buttonAddTeam')"
-                :title-dialog="$t('form.team.titleAddTeam')"
                 data-cy="form-select-table-team"
               />
             </q-form>


### PR DESCRIPTION
Refactor dynamic labels in `FormFieldSelectTable` to a composable `useSelectTable`.
This simplifies the usage of the component (no need to specify all the props on multiple places).
Update docs example.

Note: The `subsidiary` version is not currently used but translation strings and tests are provided for completeness.