### PR TITLE
src/components/__tests__: fix running FormFieldCompany tests after load Cypress JSON fixture (sync mode)  (#701)

### DIFF
--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import FormFieldCompany from 'components/global/FormFieldCompany.vue';
 import { vModelAdapter } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
@@ -38,8 +38,6 @@ describe('<FormFieldCompany>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      // reset model
-      model.value = '';
       // intercept api
       interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
       // mount component
@@ -53,6 +51,9 @@ describe('<FormFieldCompany>', () => {
     });
 
     it('renders input with label', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       // input wrapper
       cy.dataCy('form-company')
         .find('.q-field__control')
@@ -68,6 +69,9 @@ describe('<FormFieldCompany>', () => {
     });
 
     it('allows user to select option', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       testCompanyApiResponse();
 
       cy.dataCy('form-company').find('input').click();
@@ -77,14 +81,20 @@ describe('<FormFieldCompany>', () => {
         .within(() => {
           cy.get('.q-item').first().click();
         });
-      // test selected option
-      cy.dataCy('form-company')
-        .find('input')
-        .invoke('val')
-        .should('eq', 'Company 1');
+      // test selected option value
+      cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+        nextTick();
+        cy.wrap(model.value).should(
+          'eq',
+          formFieldCompanyResponse.results[0].id,
+        );
+      });
     });
 
     it('allows to search through options', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       testCompanyApiResponse();
 
       // search for option
@@ -104,6 +114,9 @@ describe('<FormFieldCompany>', () => {
     });
 
     it('validates company field correctly', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       cy.dataCy('form-company').find('input').focus();
       cy.dataCy('form-company').find('input').blur();
       cy.contains(
@@ -126,10 +139,16 @@ describe('<FormFieldCompany>', () => {
     });
 
     it('renders input and button in a column layout', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       cy.testElementsSideBySide('col-input', 'col-button');
     });
 
     it('allows to add a new company', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       cy.fixture('formFieldCompanyCreateRequest').then(
         (formFieldCompanyCreateRequest) => {
           cy.fixture('formFieldCompanyCreate').then(
@@ -203,6 +222,9 @@ describe('<FormFieldCompany>', () => {
     });
 
     it('renders input and button in a stacked layout', () => {
+      // reset model
+      model.value = '';
+      nextTick();
       cy.testElementPercentageWidth(cy.dataCy('col-input'), 100);
       cy.testElementPercentageWidth(cy.dataCy('col-button'), 100);
     });

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -241,8 +241,8 @@ describe('<FormFieldCompany>', () => {
     });
   });
 
-  function testCompanyApiResponse() {
-    cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+  const testCompanyApiResponse = async () => {
+    await cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
       cy.wait('@getOrganizations').then((interception) => {
         expect(interception.request.headers.authorization).to.include('Bearer');
         expect(interception.response.statusCode).to.equal(
@@ -253,5 +253,5 @@ describe('<FormFieldCompany>', () => {
         );
       });
     });
-  }
+  };
 });

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -74,15 +74,16 @@ describe('<FormFieldCompany>', () => {
       nextTick();
       testCompanyApiResponse();
 
-      cy.dataCy('form-company').find('input').click();
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').first().click();
-        });
-      // test selected option value
       cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+        cy.dataCy('form-company').find('input').click();
+        // select option
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            cy.get('.q-item').first().click();
+          });
+        cy.get('.q-menu').should('not.exist');
+        // test selected option value
         nextTick();
         cy.wrap(model)
           .its('value')
@@ -108,6 +109,7 @@ describe('<FormFieldCompany>', () => {
           .within(() => {
             cy.get('.q-item').first().click();
           });
+        cy.get('.q-menu').should('not.exist');
         // test selected option
         nextTick();
         cy.wrap(model)

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -84,10 +84,9 @@ describe('<FormFieldCompany>', () => {
       // test selected option value
       cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
         nextTick();
-        cy.wrap(model.value).should(
-          'eq',
-          formFieldCompanyResponse.results[0].id,
-        );
+        cy.wrap(model)
+          .its('value')
+          .should('eq', formFieldCompanyResponse.results[0].id);
       });
     });
 
@@ -98,19 +97,23 @@ describe('<FormFieldCompany>', () => {
       testCompanyApiResponse();
 
       // search for option
-      cy.dataCy('form-company').find('input').focus();
-      cy.dataCy('form-company').find('input').type('2');
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').first().click();
-        });
-      // test selected option
-      cy.dataCy('form-company')
-        .find('input')
-        .invoke('val')
-        .should('eq', 'Company 2');
+      cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+        cy.dataCy('form-company').find('input').focus();
+        cy.dataCy('form-company')
+          .find('input')
+          .type(formFieldCompanyResponse.results[1].name);
+        // select first option from filtered results
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            cy.get('.q-item').first().click();
+          });
+        // test selected option
+        nextTick();
+        cy.wrap(model)
+          .its('value')
+          .should('eq', formFieldCompanyResponse.results[1].id);
+      });
     });
 
     it('validates company field correctly', () => {

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -80,6 +80,10 @@ describe('<FormFieldCompany>', () => {
         cy.get('.q-menu')
           .should('be.visible')
           .within(() => {
+            cy.get('.q-item').should(
+              'have.length',
+              formFieldCompanyResponse.results.length,
+            );
             cy.get('.q-item').first().click();
           });
         cy.get('.q-menu').should('not.exist');
@@ -107,6 +111,8 @@ describe('<FormFieldCompany>', () => {
         cy.get('.q-menu')
           .should('be.visible')
           .within(() => {
+            // only shows the one filtered option
+            cy.get('.q-item').should('have.length', 1);
             cy.get('.q-item').first().click();
           });
         cy.get('.q-menu').should('not.exist');

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -394,7 +394,7 @@ export default defineComponent({
       class="text-caption text-bold"
       data-cy="form-field-company-label"
     >
-      {{ formFieldLabel }}
+      {{ formFieldLabel }}{{ company }}
     </label>
     <div class="row">
       <div class="col-12 col-sm" data-cy="col-input">

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -394,7 +394,7 @@ export default defineComponent({
       class="text-caption text-bold"
       data-cy="form-field-company-label"
     >
-      {{ formFieldLabel }}{{ company }}
+      {{ formFieldLabel }}
     </label>
     <div class="row">
       <div class="col-12 col-sm" data-cy="col-input">


### PR DESCRIPTION
Issue: `FormFieldCompany` test occasionally fails on value check.

```
<FormFieldCompany>
       desktop
         allows user to select option:

      Timed out retrying after 60000ms
      + expected - actual
```

Solution:
* Reset `model` variable before every test.
* Update value check based on used fixture and `model` variable while using `nextTick` for synchronicity.