### PR TITLE
src/components: use RegisterChallengePayment on registration page and fix voucher section behaviour

### DIFF
--- a/src/components/__tests__/FormFieldSliderNumber.cy.js
+++ b/src/components/__tests__/FormFieldSliderNumber.cy.js
@@ -14,7 +14,7 @@ const selectorFormFieldSliderNumberSlider = 'form-field-slider-number-slider';
 
 // variables
 const defaultValue = 500;
-const valueThousand = '1000';
+const valueThousand = 1000;
 
 describe('<FormFieldSliderNumber>', () => {
   it('has translation for all strings', () => {

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -214,9 +214,9 @@ function coreTests() {
       // custom amount is set to discount value
       cy.dataCy(getRadioOption(optionCustom)).click();
       cy.dataCy(getRadioOption(voucher.amount)).should('be.visible');
-      // clear input
+      // clear voucher
       cy.dataCy(selectorVoucherButtonRemove).click();
-      // invalid voucher is input
+      // input voucher is shown
       cy.dataCy(selectorVoucherInput).should('be.visible');
       // input amount is hidden
       cy.dataCy(selectorPaymentAmount).should('not.exist');
@@ -239,13 +239,11 @@ function coreTests() {
     cy.dataCy(selectorVoucherSubmit).click();
     cy.dataCy(selectorVoucherInput).find('input').should('have.value', 'ABCD');
     // option with default amount is available
-    cy.dataCy(getRadioOption(defaultPaymentAmountMin)).click();
-    cy.dataCy(getRadioOption(optionCustom)).click();
-    // custom amount is set to default value
-    cy.dataCy(selectorSliderNumberInput).should(
-      'have.value',
-      defaultPaymentAmountMin.toString(),
-    );
+    cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+    // after voucher is removed, default amount is reset
+    cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+    // default amount is shown
+    cy.contains(defaultPaymentAmountMin).should('be.visible');
   });
 
   it('if selected voucher - allows to apply voucher (FULL) + donate option', () => {

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -306,6 +306,31 @@ function coreTests() {
     });
   });
 
+  it('if selected voucher - resets prices after switching back to option individual (custom amount)', () => {
+    cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+    cy.dataCy(selectorPaymentAmount).should('not.exist');
+    cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+    // enter voucher HALF
+    cy.get('@voucherHalf').then((voucher) => {
+      cy.dataCy(selectorVoucherInput).type(voucher.code);
+      cy.dataCy(selectorVoucherSubmit).click();
+      // amount options and custom amount are hidden
+      cy.dataCy(selectorPaymentAmount).should('be.visible');
+      cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+      // HALF voucher value is shown
+      cy.dataCy(getRadioOption(voucher.amount)).should('be.visible');
+      // select custom amount
+      cy.dataCy(getRadioOption(optionCustom)).should('be.visible').click();
+      // switch back to individual
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      // amount options are shown
+      cy.dataCy(selectorPaymentAmount).should('be.visible');
+      cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+      // default amount is shown
+      cy.dataCy(getRadioOption(defaultPaymentAmountMin)).should('be.visible');
+    });
+  });
+
   it('if selected company - renders company select + donate option', () => {
     cy.dataCy(selectorCompany).should('not.exist');
     cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -39,7 +39,6 @@ const optionVoucher = 'voucher';
 const optionCompany = 'company';
 const optionIndividual = 'individual';
 const optionSchool = 'school';
-const optionIndividual = 'individual';
 const sliderClickTolerance = 10;
 const testNumberValue = 500;
 

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -222,9 +222,6 @@ function coreTests() {
       cy.dataCy(selectorPaymentAmount).should('not.exist');
       // input custom amount is hidden
       cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
-      // after voucher is removed, default amount is reset
-      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
-      cy.contains(defaultPaymentAmountMin).should('be.visible');
     });
   });
 
@@ -238,12 +235,10 @@ function coreTests() {
     cy.dataCy(selectorVoucherInput).type('ABCD');
     cy.dataCy(selectorVoucherSubmit).click();
     cy.dataCy(selectorVoucherInput).find('input').should('have.value', 'ABCD');
-    // option with default amount is available
+    // input amount is hidden
+    cy.dataCy(selectorPaymentAmount).should('not.exist');
+    // input custom amount is hidden
     cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
-    // after voucher is removed, default amount is reset
-    cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
-    // default amount is shown
-    cy.contains(defaultPaymentAmountMin).should('be.visible');
   });
 
   it('if selected voucher - allows to apply voucher (FULL) + donate option', () => {
@@ -286,6 +281,29 @@ function coreTests() {
       cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
       // shows voucher
       cy.dataCy(selectorVoucherBannerCode).should('be.visible');
+    });
+  });
+
+  it('if selected voucher - resets prices after switching back to option individual', () => {
+    cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+    cy.dataCy(selectorPaymentAmount).should('not.exist');
+    cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+    // enter voucher HALF
+    cy.get('@voucherHalf').then((voucher) => {
+      cy.dataCy(selectorVoucherInput).type(voucher.code);
+      cy.dataCy(selectorVoucherSubmit).click();
+      // amount options and custom amount are hidden
+      cy.dataCy(selectorPaymentAmount).should('be.visible');
+      cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+      // HALF voucher value is shown
+      cy.dataCy(getRadioOption(voucher.amount)).should('be.visible');
+      // switch back to individual
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      // amount options are shown
+      cy.dataCy(selectorPaymentAmount).should('be.visible');
+      cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+      // default amount is shown
+      cy.dataCy(getRadioOption(defaultPaymentAmountMin)).should('be.visible');
     });
   });
 

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -37,6 +37,7 @@ const defaultPaymentAmountMax = rideToWorkByBikeConfig.entryFeePaymentMax;
 const optionCustom = 'custom';
 const optionVoucher = 'voucher';
 const optionCompany = 'company';
+const optionIndividual = 'individual';
 const optionSchool = 'school';
 const optionIndividual = 'individual';
 const sliderClickTolerance = 10;
@@ -195,7 +196,7 @@ function coreTests() {
     );
   });
 
-  it('if selected voucher - allows to apply voucher (HALF)', () => {
+  it.only('if selected voucher - allows to apply voucher (HALF)', () => {
     cy.get('@voucherHalf').then((voucher) => {
       // option default amount is active
       cy.dataCy(getRadioOption(defaultPaymentAmountMin))
@@ -203,6 +204,8 @@ function coreTests() {
         .click();
       // option voucher payment is active
       cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+      // input amount is hidden
+      cy.dataCy(selectorPaymentAmount).should('not.exist');
       // input voucher
       cy.dataCy(selectorVoucherInput).type(voucher.code);
       cy.dataCy(selectorVoucherSubmit).click();
@@ -215,6 +218,13 @@ function coreTests() {
       cy.dataCy(selectorVoucherButtonRemove).click();
       // invalid voucher is input
       cy.dataCy(selectorVoucherInput).should('be.visible');
+      // input amount is hidden
+      cy.dataCy(selectorPaymentAmount).should('not.exist');
+      // input custom amount is hidden
+      cy.dataCy(selectorPaymentAmountCustom).should('not.exist');
+      // after voucher is removed, default amount is reset
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      cy.contains(defaultPaymentAmountMin).should('be.visible');
     });
   });
 

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -196,7 +196,7 @@ function coreTests() {
     );
   });
 
-  it.only('if selected voucher - allows to apply voucher (HALF)', () => {
+  it('if selected voucher - allows to apply voucher (HALF)', () => {
     cy.get('@voucherHalf').then((voucher) => {
       // option default amount is active
       cy.dataCy(getRadioOption(defaultPaymentAmountMin))

--- a/src/components/form/FormFieldDonation.vue
+++ b/src/components/form/FormFieldDonation.vue
@@ -34,7 +34,7 @@ export default defineComponent({
   },
   emits: ['update:donation'],
   setup(props, { emit }) {
-    const defaultPaymentAmountMin = Number(
+    const defaultPaymentAmountMin = parseInt(
       rideToWorkByBikeConfig.entryFeePaymentMin,
     );
     const amount = ref<number>(defaultPaymentAmountMin);

--- a/src/components/form/FormFieldSliderNumber.vue
+++ b/src/components/form/FormFieldSliderNumber.vue
@@ -43,18 +43,20 @@ export default defineComponent({
     },
     min: {
       type: Number,
-      required: true,
+      required: false,
       default: defaultMin,
     },
     max: {
       type: Number,
-      required: true,
+      required: false,
       default: defaultMax,
     },
   },
   setup(props, { emit }) {
     const model = computed({
-      get: (): number => props.modelValue,
+      get: (): number => {
+        return props.modelValue;
+      },
       set: (value: number) => {
         if (value < props.min) {
           value = props.min;
@@ -92,7 +94,7 @@ export default defineComponent({
         dense
         outlined
         type="number"
-        v-model="model"
+        v-model.number="model"
         :min="min"
         :max="max"
         data-cy="form-field-slider-number-input"

--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -148,7 +148,7 @@ export default defineComponent({
         <form-field-text-required
           v-model="code"
           name="voucher"
-          :label="$t('form.labelVoucher')"
+          label="form.labelVoucher"
           data-cy="form-field-voucher-input"
         />
       </div>

--- a/src/components/homepage/CardFollow.vue
+++ b/src/components/homepage/CardFollow.vue
@@ -82,9 +82,9 @@ export default defineComponent({
           <q-avatar size="56px">
             <q-img
               :src="card.image.src"
+              data-cy="card-follow-image"
               :alt="card.image.alt"
               ratio="1"
-              data-cy="card-follow-image"
             />
           </q-avatar>
         </q-item-section>

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -297,7 +297,7 @@ export default defineComponent({
      * for 'Entry fee amount' radio button element
      * custom option slider element, must be integer type
      *
-     * @param string val: Input string integer value e.g. '390'
+     * @param {string} val: Input string integer value e.g. '390'
      *
      * @returns void
      */

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -24,7 +24,7 @@
 
 // libraries
 import { colors, Notify } from 'quasar';
-import { computed, defineComponent, reactive, ref, watch } from 'vue';
+import { computed, defineComponent, inject, reactive, ref, watch } from 'vue';
 
 // composables
 import { i18n } from '../../boot/i18n';
@@ -71,13 +71,16 @@ export default defineComponent({
     FormFieldVoucher,
   },
   setup() {
+    const logger = inject('vuejs3-logger') as Logger | null;
     // constants
-    const defaultPaymentAmountMax = Number(
+    const defaultPaymentAmountMax = parseInt(
       rideToWorkByBikeConfig.entryFeePaymentMax,
     );
-    const defaultPaymentAmountMin = Number(
+    logger?.debug(`Default max. payement amount <${defaultPaymentAmountMax}>.`);
+    const defaultPaymentAmountMin = parseInt(
       rideToWorkByBikeConfig.entryFeePaymentMin,
     );
+    logger?.debug(`Default min. payement amount <${defaultPaymentAmountMin}>.`);
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
     const { getPaletteColor, lighten } = colors;
     const primaryColor = getPaletteColor('primary');
@@ -103,38 +106,64 @@ export default defineComponent({
         value: PaymentSubject.school,
       },
     ]);
+    logger?.debug(
+      `Default payment subject options <${JSON.stringify(optionsPaymentSubject, null, 2)}>` +
+        ` for <${i18n.global.t('register.challenge.labelPaymentSubject')}>` +
+        'radio button element.',
+    );
 
     const { formatPriceCurrency } = useFormatPrice();
     const defaultPaymentOption = {
       label: formatPriceCurrency(defaultPaymentAmountMin, Currency.CZK),
       value: String(defaultPaymentAmountMin),
     };
+    logger?.debug(
+      `Default payment options <${JSON.stringify(defaultPaymentOption, null, 2)}>` +
+        ` for <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+        ' radio button element.',
+    );
+
     // Build the optionsPaymentAmount array dynamically
     let paymentOptions: FormOption[] = [];
     try {
       paymentOptions = rideToWorkByBikeConfig.entryFeePaymentOptions
         .split(',')
         .map((option) => {
-          if (isNaN(Number(option))) {
-            throw new Error(`Invalid number: ${option}`);
+          if (isNaN(parseInt(option))) {
+            throw new Error(
+              i18n.global.t(
+                'register.challenge.parseEntryFeePaymentOptionsInvalidNumberError',
+                {
+                  value: option,
+                },
+              ),
+            );
           }
           return {
-            label: formatPriceCurrency(Number(option), Currency.CZK),
+            label: formatPriceCurrency(parseInt(option), Currency.CZK),
             value: String(option),
           };
         });
     } catch (error) {
       Notify.create({
-        message: `Error parsing entryFeePaymentOptions: ${error}`,
+        message: i18n.global.t(
+          'register.challenge.parseEntryFeePaymentOptionsError',
+          {
+            error: error,
+          },
+        ),
         type: 'negative',
       });
     }
 
     const activeVoucher = ref<FormPaymentVoucher | null>(null);
+    // Model for 'Entry fee amount' radio button element must be string type (options values '390', ..., 'custom')
     const selectedPaymentAmount = ref<string>(String(defaultPaymentAmountMin));
+    // Model for 'Entry fee amount' radio button element custom option slider element
     const selectedPaymentAmountCustom = ref<number>(defaultPaymentAmountMin);
     const paymentAmountMax = ref<number>(defaultPaymentAmountMax);
     const paymentAmountMin = ref<number>(defaultPaymentAmountMin);
+    //  Model for 'Entry fee payment' radio button element
     const selectedPaymentSubject = ref<string>(PaymentSubject.individual);
     const selectedCompany = ref<string>('');
     const isRegistrationCoordinator = ref<boolean>(false);
@@ -144,6 +173,7 @@ export default defineComponent({
       responsibility: false,
       terms: false,
     });
+
     const isVoucherValid = computed((): boolean => {
       return !!activeVoucher.value?.code;
     });
@@ -155,17 +185,6 @@ export default defineComponent({
     });
 
     /**
-     * Returns the payment amount based on the selected payment amount
-     * or the custom value.
-     */
-    const paymentAmount = computed((): number => {
-      if (selectedPaymentAmount.value === PaymentAmount.custom) {
-        return selectedPaymentAmountCustom.value;
-      }
-      return parseInt(selectedPaymentAmount.value);
-    });
-
-    /**
      * Handles voucher submission.
      * Updates payment options, minimum payment amount and current payment amount.
      * if entry fee is free, display voluntary contribution.
@@ -174,6 +193,7 @@ export default defineComponent({
       if (voucher.code) {
         // set active voucher
         activeVoucher.value = voucher;
+        logger?.debug(`Set active voucher code <${activeVoucher.value}>.`);
       }
     };
 
@@ -185,20 +205,36 @@ export default defineComponent({
     const onRemoveVoucher = (): void => {
       // clear active voucher
       activeVoucher.value = null;
+      logger?.debug(`Clear active voucher code <${activeVoucher.value}>.`);
     };
 
     const optionsPaymentAmountComputed = computed((): FormOption[] => {
+      logger?.debug(
+        'Compute payment amount options for' +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+          ' radio button element.',
+      );
+      let opts = [];
       if (
         selectedPaymentSubject.value === PaymentSubject.voucher &&
         isVoucherFreeEntry.value
       ) {
-        return [];
+        logger?.debug(
+          `Selected payement subject <${selectedPaymentSubject.value}>,` +
+            ` is voucher free entry <${isVoucherFreeEntry.value}>.`,
+        );
+        opts = [];
       } else if (
         selectedPaymentSubject.value === PaymentSubject.voucher &&
         isVoucherValid.value &&
         activeVoucher.value?.amount
       ) {
-        return [
+        logger?.debug(
+          `Selected payement subject <${selectedPaymentSubject.value}>,` +
+            ` is voucher valid <${isVoucherValid.value}>,` +
+            ` active voucher amount <${activeVoucher.value?.amount}>.`,
+        );
+        opts = [
           {
             label: formatPriceCurrency(
               activeVoucher.value?.amount,
@@ -215,7 +251,10 @@ export default defineComponent({
           },
         ];
       } else if (selectedPaymentSubject.value !== PaymentSubject.voucher) {
-        return [
+        logger?.debug(
+          `Selected payement subject <${selectedPaymentSubject.value}>.`,
+        );
+        opts = [
           // min option
           defaultPaymentOption,
           // other options
@@ -226,54 +265,138 @@ export default defineComponent({
             value: PaymentAmount.custom,
           },
         ];
-      } else {
-        return [];
       }
+      logger?.debug(
+        `Computed payment amount options <${JSON.stringify(opts, null, 2)}> for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+          ' radio button element.',
+      );
+      return opts;
     });
 
     watch(optionsPaymentAmountComputed, (options) => {
-      const optionValues = options.map((option) => option.value);
-      // reset to first option if selected amount is not in options or if it is custom
-      if (
-        !optionValues.includes(String(selectedPaymentAmount.value)) ||
-        selectedPaymentAmount.value === PaymentAmount.custom
-      ) {
-        if (optionValues.length) {
-          selectedPaymentAmount.value = String(optionValues[0]);
-        } else {
-          selectedPaymentAmount.value = String(defaultPaymentOption.value);
-        }
-      }
+      const optsVals = options.map((option) => option.value);
+      logger?.debug(
+        `Computed payment subject option change to <${selectedPaymentSubject.value}>` +
+          ` for <${i18n.global.t('register.challenge.labelPaymentSubject')}> radio element` +
+          ` and amount options changed to <${optsVals}> for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+          ' radio button element.',
+      );
+      logger?.debug(
+        `Default payment amount option changed from <${selectedPaymentAmount.value}>` +
+          ` to <${defaultPaymentOption.value}> for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+          ' radio button element.',
+      );
+      selectedPaymentAmount.value = defaultPaymentOption.value;
     });
+
+    /**
+     * Set selected custom payment amount model value
+     * for 'Entry fee amount' radio button element
+     * custom option slider element, must be integer type
+     *
+     * @param string val: Input string integer value e.g. '390'
+     *
+     * @returns void
+     */
+    const setSelectedPaymentAmountCustomVal = (val: string): void => {
+      selectedPaymentAmountCustom.value = parseInt(val);
+    };
 
     /**
      * After selecting a payment amount from the given options,
      * set it as the default value for custom payment amount.
      */
-    watch(selectedPaymentAmount, (newValue) => {
-      if (newValue !== PaymentAmount.custom) {
-        selectedPaymentAmountCustom.value = parseInt(
-          selectedPaymentAmount.value,
+    watch(selectedPaymentAmount, (newVal, oldVal) => {
+      logger?.debug(
+        `Selected payment amount option changed from <${oldVal}>` +
+          ` to <${newVal}> for <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+          ' radio button element.',
+      );
+      if (newVal !== PaymentAmount.custom) {
+        setSelectedPaymentAmountCustomVal(selectedPaymentAmount.value);
+        logger?.debug(
+          `Set new value <${selectedPaymentAmountCustom.value}> with` +
+            ` type <${typeof selectedPaymentAmountCustom.value}> for` +
+            ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+            ' radio button element custom option slider element.',
         );
       }
     });
 
-    /**
-     * Set first amount option
-     * Updates payment options and sets
-     */
+    const showVoucherElement = () => {
+      const show = selectedPaymentSubject.value === PaymentSubject.voucher;
+      logger?.debug(`Show voucher element <${show}>.`);
+      return show;
+    };
+
+    const showPaymentAmountOptionsElement = () => {
+      const show = optionsPaymentAmountComputed.value.length > 0;
+      logger?.debug(
+        `Show payment amount options <${show}> element for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}> radio button element.`,
+      );
+      return show;
+    };
+
+    const showCompanySchoolElement = () => {
+      const show = [PaymentSubject.company, PaymentSubject.school].includes(
+        selectedPaymentSubject.value,
+      );
+      logger?.debug(
+        `Show <${selectedPaymentSubject.value}> element <${show}> for` +
+          ` selected <${i18n.global.t('register.challenge.labelPaymentSubject')}>` +
+          ` radio button element <${selectedPaymentSubject.value}> option.`,
+      );
+      return show;
+    };
+
+    const showCustomPaymentAmountElement = () => {
+      const show =
+        ((selectedPaymentSubject.value === PaymentSubject.voucher &&
+          isVoucherDiscountedEntry.value) ||
+          selectedPaymentSubject.value !== PaymentSubject.voucher) &&
+        selectedPaymentAmount.value === PaymentAmount.custom;
+      logger?.debug(
+        `Show custom payment amount <${show}> slider element for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>,` +
+          ` radio button element with selected <${selectedPaymentAmount.value}> option.`,
+      );
+      return show;
+    };
+
+    const showDonationElement = () => {
+      const show =
+        (selectedPaymentSubject.value === PaymentSubject.voucher &&
+          isVoucherFreeEntry.value) ||
+        [PaymentSubject.company, PaymentSubject.school].includes(
+          selectedPaymentSubject.value,
+        );
+      logger?.debug(
+        `Show donation element <${show}> for` +
+          ` <${i18n.global.t('register.challenge.labelPaymentSubject')}>,` +
+          ` radio button element with selected <${selectedPaymentSubject.value}> option.`,
+      );
+      return show;
+    };
+
+    const showOrganizationAdminElement = () => {
+      const show = selectedPaymentSubject.value === PaymentSubject.company;
+      logger?.debug(
+        `Show <${selectedPaymentSubject.value}> admin element <${show}>.`,
+      );
+      return show;
+    };
 
     return {
       activeVoucher,
       borderRadius,
       formRegisterCoordinator,
-      isVoucherFreeEntry,
-      isVoucherValid,
-      isVoucherDiscountedEntry,
       isRegistrationCoordinator,
       optionsPaymentAmountComputed,
       optionsPaymentSubject,
-      paymentAmount,
       paymentAmountMax,
       paymentAmountMin,
       primaryLightColor,
@@ -281,10 +404,14 @@ export default defineComponent({
       selectedPaymentAmount,
       selectedPaymentAmountCustom,
       selectedPaymentSubject,
-      PaymentSubject,
       onRemoveVoucher,
       onUpdateVoucher,
-      PaymentAmount,
+      showCompanySchoolElement,
+      showCustomPaymentAmountElement,
+      showDonationElement,
+      showOrganizationAdminElement,
+      showPaymentAmountOptionsElement,
+      showVoucherElement,
     };
   },
 });
@@ -326,7 +453,7 @@ export default defineComponent({
       />
     </div>
     <!-- Input: Voucher -->
-    <div v-if="selectedPaymentSubject === PaymentSubject.voucher">
+    <div v-if="showVoucherElement()">
       <form-field-voucher
         :active-voucher="activeVoucher"
         @update:voucher="onUpdateVoucher"
@@ -334,7 +461,7 @@ export default defineComponent({
       />
     </div>
     <!-- Input: Payment amount -->
-    <div v-if="optionsPaymentAmountComputed.length" class="q-my-md">
+    <div v-if="showPaymentAmountOptionsElement()" class="q-my-md">
       <!-- Label -->
       <label
         for="paymentAmount"
@@ -354,12 +481,7 @@ export default defineComponent({
       />
     </div>
     <!-- Input: Company -->
-    <div
-      v-if="
-        selectedPaymentSubject === PaymentSubject.company ||
-        selectedPaymentSubject === PaymentSubject.school
-      "
-    >
+    <div v-if="showCompanySchoolElement()">
       <q-separator class="q-my-lg" />
       <!-- Input: Company -->
       <form-field-company
@@ -374,15 +496,7 @@ export default defineComponent({
       </p>
     </div>
     <!-- Input: Custom amount -->
-    <div
-      v-if="
-        (selectedPaymentSubject === PaymentSubject.voucher &&
-          isVoucherDiscountedEntry &&
-          selectedPaymentAmount === PaymentAmount.custom) ||
-        (selectedPaymentSubject !== PaymentSubject.voucher &&
-          selectedPaymentAmount === PaymentAmount.custom)
-      "
-    >
+    <div v-if="showCustomPaymentAmountElement()">
       <form-field-slider-number
         v-model="selectedPaymentAmountCustom"
         :min="paymentAmountMin"
@@ -392,22 +506,12 @@ export default defineComponent({
       />
     </div>
     <!-- Input: Donation -->
-    <div
-      v-if="
-        (selectedPaymentSubject === PaymentSubject.voucher &&
-          isVoucherFreeEntry) ||
-        selectedPaymentSubject === PaymentSubject.company ||
-        selectedPaymentSubject === PaymentSubject.school
-      "
-    >
+    <div v-if="showDonationElement()">
       <form-field-donation class="q-mt-md" data-cy="form-field-donation" />
     </div>
     <!-- Section: Register coordinator -->
     <!-- TODO: Add condition - NO COORDINATOR IN SELECTED COMPANY -->
-    <div
-      v-if="selectedPaymentSubject === PaymentSubject.company"
-      class="q-mt-md"
-    >
+    <div v-if="showOrganizationAdminElement()" class="q-mt-md">
       <!-- Checkbox: Register coordinator -->
       <q-checkbox
         dense

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -297,7 +297,7 @@ export default defineComponent({
      * for 'Entry fee amount' radio button element
      * custom option slider element, must be integer type
      *
-     * @param {string} val: Input string integer value e.g. '390'
+     * @param {string} val - Input string integer value e.g. '390'
      *
      * @returns void
      */

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -287,11 +287,20 @@ export default defineComponent({
         data-cy="form-field-payment-subject"
       />
     </div>
+    <!-- Input: Voucher -->
+    <div v-if="selectedPaymentSubject === PaymentSubject.voucher">
+      <form-field-voucher
+        @update:voucher="onUpdateVoucher"
+        @remove:voucher="onRemoveVoucher"
+      />
+    </div>
     <!-- Input: Payment amount -->
     <div
       v-if="
         selectedPaymentSubject === PaymentSubject.individual ||
-        (selectedPaymentSubject === PaymentSubject.voucher && !isEntryFeeFree)
+        (selectedPaymentSubject === PaymentSubject.voucher &&
+          activeVoucher?.code &&
+          !isEntryFeeFree)
       "
       class="q-my-md"
     >
@@ -343,7 +352,13 @@ export default defineComponent({
     </div>
     <!-- Input: Custom amount -->
     <div
-      v-if="selectedPaymentAmount === PaymentAmount.custom && !isEntryFeeFree"
+      v-if="
+        (selectedPaymentSubject === PaymentSubject.voucher &&
+          activeVoucher?.code &&
+          !isEntryFeeFree) ||
+        (selectedPaymentSubject !== PaymentSubject.voucher &&
+          selectedPaymentAmount === PaymentAmount.custom)
+      "
     >
       <form-field-slider-number
         v-model="selectedPaymentAmountCustom"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -672,6 +672,8 @@ titleStepParticipation = "Účast"
 titleStepCompany = "Firma / škola / skupina"
 titleStepMerch = "Startovací balíček"
 titleStepTeam = "Tým"
+parseEntryFeePaymentOptionsInvalidNumberError = "Neplatné číslo <{value}>."
+parseEntryFeePaymentOptionsError = "Chyba zpracování hodnot možností platby vstupního poplatku {error}."
 
 [register.coordinator]
 title.may = "Registrace koordinátora do&nbsp;Květnové výzvy"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -669,6 +669,8 @@ titleStepParticipation = "Participation"
 titleStepCompany = "Company / school / group"
 titleStepMerch = "Starter package"
 titleStepTeam = "Team"
+parseEntryFeePaymentOptionsInvalidNumberError = "Invalid number <{value}>."
+parseEntryFeePaymentOptionsError = "Error parsing entry fee payment options {error}."
 
 [register.coordinator]
 title.may = "Coordinator registration for&nbsp;the&nbsp;May Challenge"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -669,6 +669,8 @@ titleStepParticipation = "Účasť"
 titleStepCompany = "Spoločnosť / škola / skupina"
 titleStepMerch = "Štartovací balíček"
 titleStepTeam = "Tím"
+parseEntryFeePaymentOptionsInvalidNumberError = "Neplatné číslo {value}."
+parseEntryFeePaymentOptionsError = "Chyba spracovania hodnôt možností platby vstupného poplatku {error}."
 
 [register.coordinator]
 title.may = "Registrácia koordinátora na&nbsp;Májovú výzvu"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -36,6 +36,7 @@ import FormFieldOptionGroup from 'src/components/form/FormFieldOptionGroup.vue';
 import FormPersonalDetails from 'src/components/form/FormPersonalDetails.vue';
 import FormSelectOrganization from 'src/components/form/FormSelectOrganization.vue';
 import LoginRegisterHeader from 'components/global/LoginRegisterHeader.vue';
+import RegisterChallengePayment from 'src/components/register/RegisterChallengePayment.vue';
 import TopBarCountdown from 'src/components/global/TopBarCountdown.vue';
 
 // composables
@@ -62,6 +63,7 @@ export default defineComponent({
     FormPersonalDetails,
     FormSelectOrganization,
     LoginRegisterHeader,
+    RegisterChallengePayment,
     TopBarCountdown,
   },
   setup() {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,14 +41,11 @@ export default route(function (/* { store, ssrContext } */) {
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
 
-  const enabled = false;
-
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    (!window.Cypress ||
-      window.Cypress.spec.name === 'register.spec.cy.js' ||
-      window.Cypress.spec.name === 'router_rules.cy.js') &&
-    enabled
+    !window.Cypress ||
+    window.Cypress.spec.name === 'register.spec.cy.js' ||
+    window.Cypress.spec.name === 'router_rules.cy.js'
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,11 +41,14 @@ export default route(function (/* { store, ssrContext } */) {
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
 
+  const enabled = false;
+
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    !window.Cypress ||
-    window.Cypress.spec.name === 'register.spec.cy.js' ||
-    window.Cypress.spec.name === 'router_rules.cy.js'
+    (!window.Cypress ||
+      window.Cypress.spec.name === 'register.spec.cy.js' ||
+      window.Cypress.spec.name === 'router_rules.cy.js') &&
+    enabled
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;


### PR DESCRIPTION
Show `RegisterChallengePayment` component on the register challenge page.

Update order of the inputs in the voucher section of the form based on [WF](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-103791&t=C3qa44qIE3lwc0UC-1) showing first the voucher input and then the amount selection (if applicable).

Update behaviour of the voucher section in the following scenario:
- voucher "HALF" is added
- amount "Custom" is selected
- range slider input shows
- voucher "HALF" is removed

In this case, range slider input should be hidden and default amount option reset to 390.
Ensure this by updating the show condition for range input slider.
Add tests for this behaviour.