### PR TITLE
src/components: update fix FormFieldCompany component data fetching

### DIFF
--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -39,7 +39,7 @@ describe('<FormFieldCompany>', () => {
   context('desktop', () => {
     beforeEach(() => {
       // intercept api
-      interceptOrganizationsApi(rideToWorkByBikeConfig);
+      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
       // reset model value
       model.value = '';
       // mount component
@@ -212,7 +212,7 @@ describe('<FormFieldCompany>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      interceptOrganizationsApi(rideToWorkByBikeConfig);
+      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
       // reset model value
       model.value = '';
       // mount component

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -39,7 +39,7 @@ describe('<FormFieldCompany>', () => {
   context('desktop', () => {
     beforeEach(() => {
       // intercept api
-      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
+      interceptOrganizationsApi(rideToWorkByBikeConfig);
       // reset model value
       model.value = '';
       // mount component
@@ -69,33 +69,27 @@ describe('<FormFieldCompany>', () => {
 
     it('allows user to select option', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
-        cy.wait('@getOrganizations').then((interception) => {
-          expect(interception.request.headers.authorization).to.include(
-            'Bearer',
-          );
-          expect(interception.response.statusCode).to.equal(
-            httpSuccessfullStatus,
-          );
-          expect(interception.response.body).to.deep.equal(formFieldCompany);
-          cy.dataCy('form-company').find('input').click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item')
-                .should((opts) => {
-                  expect(opts.get(0)).to.have.property(
-                    'childElementCount',
-                    formFieldCompany.results.length,
-                  );
-                })
-                .first()
-                .click();
-            });
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[0].id);
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          cy.wait('@getOrganizations').then((interception) => {
+            expect(interception.request.headers.authorization).to.include(
+              'Bearer',
+            );
+            expect(interception.response.statusCode).to.equal(
+              httpSuccessfullStatus,
+            );
+            expect(interception.response.body).to.deep.equal(formFieldCompany);
+          });
+          cy.wait('@getOrganizationsNextPage').then((interception) => {
+            expect(interception.request.headers.authorization).to.include(
+              'Bearer',
+            );
+            expect(interception.response.statusCode).to.equal(
+              httpSuccessfullStatus,
+            );
+            expect(interception.response.body).to.deep.equal(
+              formFieldCompanyNext,
+            );
+          });
         });
       });
     });
@@ -218,7 +212,7 @@ describe('<FormFieldCompany>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
+      interceptOrganizationsApi(rideToWorkByBikeConfig);
       // reset model value
       model.value = '';
       // mount component

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -38,7 +38,7 @@ describe('<FormFieldCompany>', () => {
   context('desktop', () => {
     beforeEach(() => {
       // intercept api
-      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
+      interceptOrganizationsApi(rideToWorkByBikeConfig);
       // reset model value
       model.value = '';
       // mount component
@@ -226,7 +226,7 @@ describe('<FormFieldCompany>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
+      interceptOrganizationsApi(rideToWorkByBikeConfig);
       // reset model value
       model.value = '';
       // mount component

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -96,7 +96,7 @@ describe('<FormFieldCompany>', () => {
       });
     });
 
-    it('allows to search through options', () => {
+    it.only('allows to search through options', () => {
       // search for option
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
@@ -105,6 +105,9 @@ describe('<FormFieldCompany>', () => {
           cy.dataCy('form-company')
             .find('input')
             .type(formFieldCompany.results[1].name);
+          // blur to trigger search (typing occasionally doesn't trigger it)
+          cy.dataCy('form-company').find('input').blur();
+          cy.dataCy('form-company').find('input').focus();
           // select first option from filtered results
           cy.get('.q-menu')
             .should('be.visible')

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -77,7 +77,7 @@ describe('<FormFieldCompany>', () => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           cy.wrap(nextTick());
-          cy.dataCy('form-company').find('input').click();
+          cy.dataCy('form-company-input').click();
           // select option
           cy.get('.q-menu')
             .should('be.visible')
@@ -93,7 +93,7 @@ describe('<FormFieldCompany>', () => {
                 .first()
                 .click();
             });
-          cy.get('.q-menu').should('not.exist');
+          cy.wrap(nextTick());
           cy.wrap(model)
             .its('value')
             .should('eq', formFieldCompany.results[0].id);
@@ -107,8 +107,10 @@ describe('<FormFieldCompany>', () => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           cy.wrap(nextTick());
-          cy.dataCy('form-company').find('input').focus();
-          cy.focused().type(formFieldCompany.results[1].name);
+          cy.dataCy('form-company-input')
+            .closest('input')
+            .type(formFieldCompany.results[1].name);
+          cy.focused().trigger('input');
           cy.wrap(nextTick());
           // select first option from filtered results
           cy.get('.q-menu')
@@ -122,7 +124,7 @@ describe('<FormFieldCompany>', () => {
                 .first()
                 .click();
             });
-          cy.get('.q-menu').should('not.exist');
+          cy.wrap(nextTick());
           cy.wrap(model)
             .its('value')
             .should('eq', formFieldCompany.results[1].id);

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -96,7 +96,7 @@ describe('<FormFieldCompany>', () => {
       });
     });
 
-    it.only('allows to search through options', () => {
+    it('allows to search through options', () => {
       // search for option
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -74,26 +74,30 @@ describe('<FormFieldCompany>', () => {
 
     it('allows user to select option', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
-        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          nextTick();
-          cy.dataCy('form-company').find('input').click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item').should(
-                'have.length',
-                formFieldCompany.results.length +
-                  formFieldCompanyNext.results.length,
-              );
-              cy.get('.q-item').first().click();
-            });
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[0].id);
-        });
+        cy.fixture('formFieldCompanyNext').then(
+          async (formFieldCompanyNext) => {
+            waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+            cy.wrap(nextTick());
+            cy.dataCy('form-company').find('input').click();
+            // select option
+            cy.get('.q-menu')
+              .should('be.visible')
+              .within(() => {
+                cy.get('.q-item')
+                  .should('be.visible')
+                  .and(
+                    'have.length',
+                    formFieldCompany.results.length +
+                      formFieldCompanyNext.results.length,
+                  );
+                cy.get('.q-item').first().click();
+              });
+            cy.get('.q-menu').should('not.exist');
+            cy.wrap(model)
+              .its('value')
+              .should('eq', formFieldCompany.results[0].id);
+          },
+        );
       });
     });
 
@@ -102,11 +106,12 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          nextTick();
+          cy.wrap(nextTick());
           cy.dataCy('form-company').find('input').focus();
           cy.dataCy('form-company')
             .find('input')
             .type(formFieldCompany.results[1].name);
+          cy.wrap(nextTick());
           // blur to trigger search (typing occasionally doesn't trigger it)
           cy.dataCy('form-company').find('input').blur();
           cy.dataCy('form-company').find('input').focus();
@@ -115,7 +120,7 @@ describe('<FormFieldCompany>', () => {
             .should('be.visible')
             .within(() => {
               // only shows the one filtered option
-              cy.get('.q-item').should('have.length', 1);
+              cy.get('.q-item').should('be.visible').and('have.length', 1);
               cy.get('.q-item').first().click();
             });
           cy.get('.q-menu').should('not.exist');
@@ -130,7 +135,7 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          nextTick();
+          cy.wrap(nextTick());
           cy.dataCy('form-company').find('input').focus();
           cy.dataCy('form-company').find('input').blur();
           cy.contains(

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -83,13 +83,15 @@ describe('<FormFieldCompany>', () => {
             .should('be.visible')
             .within(() => {
               cy.get('.q-item')
-                .should('be.visible')
-                .and(
-                  'have.length',
-                  formFieldCompany.results.length +
-                    formFieldCompanyNext.results.length,
-                );
-              cy.get('.q-item').first().click();
+                .should((opts) => {
+                  expect(
+                    opts.length,
+                    formFieldCompany.results.length +
+                      formFieldCompanyNext.results.length,
+                  );
+                })
+                .first()
+                .click();
             });
           cy.get('.q-menu').should('not.exist');
           cy.wrap(model)
@@ -106,20 +108,19 @@ describe('<FormFieldCompany>', () => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           cy.wrap(nextTick());
           cy.dataCy('form-company').find('input').focus();
-          cy.dataCy('form-company')
-            .find('input')
-            .type(formFieldCompany.results[1].name);
+          cy.focused().type(formFieldCompany.results[1].name);
           cy.wrap(nextTick());
-          // blur to trigger search (typing occasionally doesn't trigger it)
-          cy.dataCy('form-company').find('input').blur();
-          cy.dataCy('form-company').find('input').focus();
           // select first option from filtered results
           cy.get('.q-menu')
             .should('be.visible')
             .within(() => {
               // only shows the one filtered option
-              cy.get('.q-item').should('be.visible').and('have.length', 1);
-              cy.get('.q-item').first().click();
+              cy.get('.q-item')
+                .should((opts) => {
+                  expect(opts.length, 1);
+                })
+                .first()
+                .click();
             });
           cy.get('.q-menu').should('not.exist');
           cy.wrap(model)
@@ -135,7 +136,7 @@ describe('<FormFieldCompany>', () => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           cy.wrap(nextTick());
           cy.dataCy('form-company').find('input').focus();
-          cy.dataCy('form-company').find('input').blur();
+          cy.focused().blur();
           cy.contains(
             i18n.global.t('form.messageFieldRequired', {
               fieldName: i18n.global.t('form.labelCompanyShort'),

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -89,11 +89,11 @@ describe('<FormFieldCompany>', () => {
               );
               cy.get('.q-item').first().click();
             });
+          cy.get('.q-menu').should('not.exist');
+          cy.wrap(model)
+            .its('value')
+            .should('eq', formFieldCompany.results[0].id);
         });
-        cy.get('.q-menu').should('not.exist');
-        cy.wrap(model)
-          .its('value')
-          .should('eq', formFieldCompany.results[0].id);
       });
     });
 

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -1,4 +1,3 @@
-import { ref } from 'vue';
 import FormFieldCompany from 'components/global/FormFieldCompany.vue';
 import { vModelAdapter } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
@@ -21,17 +20,17 @@ describe('<FormFieldCompany>', () => {
         'messageNoCompany',
       ],
       'form',
-      i18n,
+      i18n
     );
     cy.testLanguageStringsInContext(
       ['buttonAddCompany', 'titleAddCompany'],
       'form.company',
-      i18n,
+      i18n
     );
     cy.testLanguageStringsInContext(
       ['buttonAddCompany'],
       'register.challenge',
-      i18n,
+      i18n
     );
     cy.testLanguageStringsInContext(['discard'], 'navigation', i18n);
   });
@@ -91,6 +90,21 @@ describe('<FormFieldCompany>', () => {
             );
           });
         });
+        cy.dataCy('form-company').find('input').click();
+        // select option
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            cy.get('.q-item').should(
+              'have.length',
+              formFieldCompany.results.length
+            );
+            cy.get('.q-item').first().click();
+          });
+        cy.get('.q-menu').should('not.exist');
+        cy.wrap(model)
+          .its('value')
+          .should('eq', formFieldCompany.results[0].id);
       });
     });
 
@@ -99,10 +113,10 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.wait('@getOrganizations').then((interception) => {
           expect(interception.request.headers.authorization).to.include(
-            'Bearer',
+            'Bearer'
           );
           expect(interception.response.statusCode).to.equal(
-            httpSuccessfullStatus,
+            httpSuccessfullStatus
           );
           expect(interception.response.body).to.deep.equal(formFieldCompany);
           cy.dataCy('form-company').find('input').focus();
@@ -130,7 +144,7 @@ describe('<FormFieldCompany>', () => {
       cy.contains(
         i18n.global.t('form.messageFieldRequired', {
           fieldName: i18n.global.t('form.labelCompanyShort'),
-        }),
+        })
       ).should('be.visible');
       cy.dataCy('form-company').find('input').click();
       // select option
@@ -142,7 +156,7 @@ describe('<FormFieldCompany>', () => {
       cy.contains(
         i18n.global.t('form.messageFieldRequired', {
           fieldName: i18n.global.t('form.labelCompanyShort'),
-        }),
+        })
       ).should('not.exist');
     });
 
@@ -171,7 +185,7 @@ describe('<FormFieldCompany>', () => {
                 .should('be.visible')
                 .and(
                   'have.text',
-                  i18n.global.t('form.company.buttonAddCompany'),
+                  i18n.global.t('form.company.buttonAddCompany')
                 );
               // fill form
               cy.dataCy('form-add-company-name')
@@ -185,17 +199,17 @@ describe('<FormFieldCompany>', () => {
               // test response
               cy.wait('@createOrganization').then((interception) => {
                 expect(interception.request.headers.authorization).to.include(
-                  'Bearer',
+                  'Bearer'
                 );
                 expect(interception.response.statusCode).to.equal(
-                  httpSuccessfullStatus,
+                  httpSuccessfullStatus
                 );
                 expect(interception.request.body).to.deep.equal({
                   name: formFieldCompanyCreateRequest.name,
                   vatId: formFieldCompanyCreateRequest.vatId,
                 });
                 expect(interception.response.body).to.deep.equal(
-                  formFieldCompanyCreateResponse,
+                  formFieldCompanyCreateResponse
                 );
               });
               // test selected option
@@ -203,9 +217,9 @@ describe('<FormFieldCompany>', () => {
                 .find('input')
                 .invoke('val')
                 .should('eq', formFieldCompanyCreateResponse.name);
-            },
+            }
           );
-        },
+        }
       );
     });
   });

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -6,6 +6,7 @@ import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import {
   httpSuccessfullStatus,
   interceptOrganizationsApi,
+  waitForOrganizationsApi,
 } from '../../../test/cypress/support/commonTests';
 import { OrganizationType } from '../types/Organization';
 
@@ -236,17 +237,4 @@ describe('<FormFieldCompany>', () => {
       cy.testElementPercentageWidth(cy.dataCy('col-button'), 100);
     });
   });
-
-  function waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext) {
-    cy.wait('@getOrganizations').then((interception) => {
-      expect(interception.request.headers.authorization).to.include('Bearer');
-      expect(interception.response.statusCode).to.equal(httpSuccessfullStatus);
-      expect(interception.response.body).to.deep.equal(formFieldCompany);
-    });
-    cy.wait('@getOrganizationsNextPage').then((interception) => {
-      expect(interception.request.headers.authorization).to.include('Bearer');
-      expect(interception.response.statusCode).to.equal(httpSuccessfullStatus);
-      expect(interception.response.body).to.deep.equal(formFieldCompanyNext);
-    });
-  }
 });

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import FormFieldCompany from 'components/global/FormFieldCompany.vue';
 import { vModelAdapter } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
@@ -76,6 +76,7 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          nextTick();
           cy.dataCy('form-company').find('input').click();
           // select option
           cy.get('.q-menu')
@@ -101,6 +102,7 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          nextTick();
           cy.dataCy('form-company').find('input').focus();
           cy.dataCy('form-company')
             .find('input')
@@ -128,6 +130,7 @@ describe('<FormFieldCompany>', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          nextTick();
           cy.dataCy('form-company').find('input').focus();
           cy.dataCy('form-company').find('input').blur();
           cy.contains(

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -74,30 +74,28 @@ describe('<FormFieldCompany>', () => {
 
     it('allows user to select option', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
-        cy.fixture('formFieldCompanyNext').then(
-          async (formFieldCompanyNext) => {
-            waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-            cy.wrap(nextTick());
-            cy.dataCy('form-company').find('input').click();
-            // select option
-            cy.get('.q-menu')
-              .should('be.visible')
-              .within(() => {
-                cy.get('.q-item')
-                  .should('be.visible')
-                  .and(
-                    'have.length',
-                    formFieldCompany.results.length +
-                      formFieldCompanyNext.results.length,
-                  );
-                cy.get('.q-item').first().click();
-              });
-            cy.get('.q-menu').should('not.exist');
-            cy.wrap(model)
-              .its('value')
-              .should('eq', formFieldCompany.results[0].id);
-          },
-        );
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.wrap(nextTick());
+          cy.dataCy('form-company').find('input').click();
+          // select option
+          cy.get('.q-menu')
+            .should('be.visible')
+            .within(() => {
+              cy.get('.q-item')
+                .should('be.visible')
+                .and(
+                  'have.length',
+                  formFieldCompany.results.length +
+                    formFieldCompanyNext.results.length,
+                );
+              cy.get('.q-item').first().click();
+            });
+          cy.get('.q-menu').should('not.exist');
+          cy.wrap(model)
+            .its('value')
+            .should('eq', formFieldCompany.results[0].id);
+        });
       });
     });
 

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -196,6 +196,8 @@ describe('<FormFieldCompany>', () => {
                 expect(interception.request.body).to.deep.equal({
                   name: formFieldCompanyCreateRequest.name,
                   vatId: formFieldCompanyCreateRequest.vatId,
+                  organization_type:
+                    formFieldCompanyCreateRequest.organization_type,
                 });
                 expect(interception.response.body).to.deep.equal(
                   formFieldCompanyCreateResponse,

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -9,8 +9,10 @@ import {
   httpSuccessfullStatus,
   interceptOrganizationsApi,
   interceptRegisterCoordinatorApi,
+  waitForOrganizationsApi,
 } from '../../../test/cypress/support/commonTests';
 import { useRegisterStore } from '../../stores/register';
+import { OrganizationType } from '../../components/types/Organization';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
@@ -67,7 +69,11 @@ describe('<FormRegisterCoordinator>', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       // intercept organizations API call (before mounting component)
-      interceptOrganizationsApi(rideToWorkByBikeConfig, i18n);
+      interceptOrganizationsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        OrganizationType.company,
+      );
       // intercept register coordinator API call (before mounting component)
       interceptRegisterCoordinatorApi(rideToWorkByBikeConfig, i18n);
       // specify data for register coordinator request body
@@ -173,6 +179,12 @@ describe('<FormRegisterCoordinator>', () => {
     });
 
     it('validates checkboxes correctly', () => {
+      // wait for organizations API call
+      cy.fixture('formFieldCompany').then((formFieldCompany) => {
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+        });
+      });
       // fill in other parts of the form to be able to test password
       fillFormRegisterCoordinator();
       // test responsibility checkbox unchecked
@@ -213,6 +225,12 @@ describe('<FormRegisterCoordinator>', () => {
 
     it('submits form correctly', () => {
       cy.fixture('registerResponse').then(() => {
+        // wait for organizations API call
+        cy.fixture('formFieldCompany').then((formFieldCompany) => {
+          cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+            waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          });
+        });
         // fill in the form
         fillFormRegisterCoordinator();
         // check responsibility checkbox

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -185,6 +185,7 @@ describe('<FormRegisterCoordinator>', () => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
         });
       });
+      nextTick();
       // fill in other parts of the form to be able to test password
       fillFormRegisterCoordinator();
       // test responsibility checkbox unchecked
@@ -231,6 +232,7 @@ describe('<FormRegisterCoordinator>', () => {
             waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           });
         });
+        nextTick();
         // fill in the form
         fillFormRegisterCoordinator();
         // check responsibility checkbox

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -22,7 +22,7 @@ const compareRegisterResponseWithStore = () => {
     'be.visible',
   );
   const registerStore = useRegisterStore();
-  nextTick();
+  cy.wrap(nextTick());
   expect(registerStore.getIsRegistrationComplete).to.equal(true);
 };
 
@@ -185,7 +185,7 @@ describe('<FormRegisterCoordinator>', () => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
         });
       });
-      nextTick();
+      cy.wrap(nextTick());
       // fill in other parts of the form to be able to test password
       fillFormRegisterCoordinator();
       // test responsibility checkbox unchecked
@@ -232,7 +232,7 @@ describe('<FormRegisterCoordinator>', () => {
             waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           });
         });
-        nextTick();
+        cy.wrap(nextTick());
         // fill in the form
         fillFormRegisterCoordinator();
         // check responsibility checkbox

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -140,7 +140,6 @@ export default defineComponent({
         showSuccessMessage: false,
         headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
         logger,
-        localized: false,
       });
       if (data?.results?.length) {
         pushResultsToOptions(data);

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -142,7 +142,7 @@ export default defineComponent({
         method: 'get',
         translationKey: 'getOrganizations',
         showSuccessMessage: false,
-        headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
         logger,
       });
       if (data?.results?.length) {
@@ -170,7 +170,7 @@ export default defineComponent({
         method: 'get',
         translationKey: 'getOrganizations',
         showSuccessMessage: false,
-        headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
         logger,
       });
       // store results
@@ -306,7 +306,7 @@ export default defineComponent({
         endpoint: urlApiOrganizations,
         method: 'post',
         translationKey: 'createOrganization',
-        headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
         payload: payload,
         logger,
       });

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -465,7 +465,7 @@ export default defineComponent({
           fill-input
           hide-bottom-space
           input-debounce="0"
-          lazy-rules="true"
+          :lazy-rules="true"
           :model-value="company"
           :options="options"
           :loading="isOptionsLoading"

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -156,8 +156,8 @@ export default defineComponent({
     };
     /**
      * Fetch next page of organizations
-     * @param {string} url
-     * @returns {Promise<void>}
+     * @param {string} url - Get organizations next page API URL
+     * @returns {Promise<void>} - Promise
      */
     const fetchNextPage = async (url: string): Promise<void> => {
       logger?.debug(`Fetching next page of organizations from <${url}>.`);
@@ -264,7 +264,8 @@ export default defineComponent({
     };
     /**
      * Submit new company form
-     * Validates form and calls createOrganization API if valid
+     * Validates form and calls createOrganization() func
+     * API if valid
      * @returns {Promise<void>}
      */
     const onSubmit = async (): Promise<void> => {
@@ -284,7 +285,7 @@ export default defineComponent({
     };
     /**
      * Create organization
-     * Creates a new organization in database
+     * Creates a new organization, POST data
      * @returns {Promise<void>}
      */
     const createOrganization = async (): Promise<void> => {

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -148,7 +148,7 @@ export default defineComponent({
       isOptionsLoading.value = false;
     };
     /**
-     * Fetch next page
+     * Fetch next page of organizations
      * @param {string} url
      * @returns {Promise<void>}
      */

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -294,8 +294,9 @@ export default defineComponent({
       const payload: PostOrganizationPayload = {
         name: companyNew.name,
         vatId: companyNew.vatId,
+        organization_type: props.organizationType,
       };
-      // fetch organizations
+      // post organization
       const { data } = await apiFetch<PostOrganizationsResponse>({
         endpoint: urlApiOrganizations,
         method: 'post',

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -68,7 +68,6 @@ import {
   requestDefaultHeader,
   requestTokenHeader,
 } from 'src/utils';
-import { getApiBaseUrlWithLang } from 'src/utils/get_api_base_url_with_lang';
 
 export const emptyFormCompanyFields: FormCompanyFields = {
   name: '',
@@ -112,15 +111,7 @@ export default defineComponent({
     const loginStore = useLoginStore();
     const { apiFetch } = useApi();
     // get API base URL
-    const { apiBase, apiDefaultLang, urlApiOrganizations } =
-      rideToWorkByBikeConfig;
-    const apiBaseUrl = getApiBaseUrlWithLang(
-      null,
-      apiBase,
-      apiDefaultLang,
-      i18n,
-    );
-    const urlApiOrganizationsLocalized = `${apiBaseUrl}${urlApiOrganizations}`;
+    const { urlApiOrganizations } = rideToWorkByBikeConfig;
     /**
      * Load options
      * Fetches organizations and saves them into default options
@@ -134,7 +125,7 @@ export default defineComponent({
       requestTokenHeader_.Authorization += loginStore.getAccessToken;
       // fetch organizations
       const { data } = await apiFetch<GetOrganizationsResponse>({
-        endpoint: urlApiOrganizationsLocalized,
+        endpoint: urlApiOrganizations,
         method: 'get',
         translationKey: 'getOrganizations',
         showSuccessMessage: false,

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -136,7 +136,6 @@ export default defineComponent({
         showSuccessMessage: false,
         headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
         logger,
-        localized: false,
       });
       if (data?.results?.length) {
         pushResultsToOptions(data);
@@ -165,7 +164,6 @@ export default defineComponent({
         showSuccessMessage: false,
         headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
         logger,
-        localized: false,
       });
       // store results
       if (data?.results?.length) {
@@ -295,7 +293,7 @@ export default defineComponent({
       };
       // fetch organizations
       const { data } = await apiFetch<PostOrganizationsResponse>({
-        endpoint: urlApiOrganizationsLocalized,
+        endpoint: urlApiOrganizations,
         method: 'post',
         translationKey: 'createOrganization',
         headers: Object.assign(requestDefaultHeader, requestTokenHeader_),

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -10,8 +10,8 @@
  * Used in `FormRegisterCoordinator`, `RegisterChallengePayment`.
  *
  * @props
- * - `modelValue` (number, required): The object representing user input.
- *   It should be of type `string`.
+ * - `modelValue` (number|string, required): The object representing user input.
+ *   It should be of type `string` or `number`.
  * - `label` (string, optional): The label for the form field.
  * - `organizationType` (string['company'|'school'|'family'], optional): Organization type
  *
@@ -92,7 +92,7 @@ export default defineComponent({
   },
   props: {
     modelValue: {
-      type: Number,
+      type: [Number, String],
       required: true,
     },
     label: {
@@ -113,6 +113,9 @@ export default defineComponent({
     const { apiFetch } = useApi();
     // get API base URL
     const { urlApiOrganizations } = rideToWorkByBikeConfig;
+    logger.debug(
+      `Initial organization ID model value is <${props.modelValue}>.`,
+    );
     /**
      * Load options
      * Fetches organizations and saves them into default options
@@ -205,9 +208,9 @@ export default defineComponent({
     loadOptions();
 
     // company v-model
-    const company = computed<number>({
-      get: (): number => props.modelValue,
-      set: (value: number) => {
+    const company = computed<number | string>({
+      get: (): number | string => props.modelValue,
+      set: (value: number | string) => {
         logger?.debug(`Company set to <${value}>.`);
         emit('update:modelValue', value);
       },
@@ -417,7 +420,7 @@ export default defineComponent({
         `New organization type was selected, new value is  <${newValue}>, old value was <${oldValue}>.`,
       );
       // Erase select organization widget value
-      company.value = 0;
+      company.value = '';
       logger?.debug(
         `Erase select organization widget value <${company.value}>.`,
       );

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -515,11 +515,7 @@ export default defineComponent({
       </div>
     </div>
     <!-- Dialog: Add company -->
-    <dialog-default
-      v-model="isDialogOpen"
-      :form-ref="formRef"
-      data-cy="dialog-add-company"
-    >
+    <dialog-default v-model="isDialogOpen" data-cy="dialog-add-company">
       <template #title>
         {{ addNewOrganizationDialogTitle }}
       </template>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -101,6 +101,7 @@ export default defineComponent({
     },
     organizationType: {
       type: String as () => OrganizationType,
+      required: true,
     },
   },
   setup(props, { emit }) {
@@ -204,9 +205,9 @@ export default defineComponent({
     loadOptions();
 
     // company v-model
-    const company = computed({
-      get: () => props.modelValue,
-      set: (value: string) => {
+    const company = computed<number>({
+      get: (): number => props.modelValue,
+      set: (value: number) => {
         logger?.debug(`Company set to <${value}>.`);
         emit('update:modelValue', value);
       },
@@ -313,7 +314,7 @@ export default defineComponent({
         logger?.info('Close add company modal dialog.');
         // set company to new organization
         logger?.debug(`Setting organization to ID <${data.id}>.`);
-        const newCompanyOption: FormSelectOption = {
+        const newCompanyOption: { label: string; value: number } = {
           label: data.name,
           value: data.id,
         };

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -118,6 +118,11 @@ export default defineComponent({
      * @returns {Promise<void>}
      */
     const loadOptions = async (): Promise<void> => {
+      // reset default options
+      logger?.debug(`Reseting default options <${optionsDefault.value}>`);
+      optionsDefault.value = [];
+      logger?.debug(`Default options set to <${optionsDefault.value}>`);
+      // get organizations
       logger?.info('Get organizations from the API.');
       isOptionsLoading.value = true;
       // append access token into HTTP header

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -136,6 +136,7 @@ export default defineComponent({
         showSuccessMessage: false,
         headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
         logger,
+        localized: false,
       });
       if (data?.results?.length) {
         pushResultsToOptions(data);

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -311,9 +311,6 @@ export default defineComponent({
         // close dialog
         isDialogOpen.value = false;
         logger?.info('Close add company modal dialog.');
-        // refetch organizations
-        logger?.info('Refetching organizations.');
-        await loadOptions();
         // set company to new organization
         logger?.debug(`Setting organization to ID <${data.id}>.`);
         const newCompanyOption: FormSelectOption = {
@@ -322,6 +319,12 @@ export default defineComponent({
         };
         options.value.push(newCompanyOption);
         company.value = newCompanyOption.value;
+        logger?.debug(
+          `Append newly created organization <${JSON.stringify(newCompanyOption, null, 2)}>` +
+            ' into select organizations widget options.',
+        );
+        // Append newly created organization option into all organization select widget options
+        optionsDefault.value.push(newCompanyOption);
       }
     };
 

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -20,7 +20,7 @@ export interface FormSelectTableOption extends FormOption {
 
 export type FormSelectOption = {
   label: string;
-  value: string;
+  value: string | number;
 };
 
 export type FormCompanyFields = {

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -64,9 +64,10 @@ export interface GetOrganizationsResponse {
 export interface PostOrganizationPayload {
   name: string;
   vatId: string;
+  organization_type: OrganizationType;
 }
 
 export interface PostOrganizationsResponse {
-  id: string;
+  id: number;
   name: string;
 }

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -55,6 +55,9 @@ export interface OrganizationOption {
 }
 
 export interface GetOrganizationsResponse {
+  count: number;
+  next: string;
+  previous: string;
   results: OrganizationOption[];
 }
 

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -148,6 +148,8 @@ export const useApi = () => {
       logger?.error(`Call to <api()> function raise error <${error}>.`);
       if (axios.isAxiosError(error)) {
         let errorMessage = error.message;
+        if (error.response?.data)
+          errorMessage += `. ${Object.values(error.response?.data).join('. ')}`;
         const apiErrorMessage = getResponseDataErrorMessage(error);
         if (apiErrorMessage) errorMessage += `. ${apiErrorMessage}`;
         Notify.create({

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -82,7 +82,7 @@ export const useApi = () => {
     payload,
     translationKey,
     method = 'get',
-    headers = requestDefaultHeader,
+    headers = requestDefaultHeader(),
     logger,
     showSuccessMessage = true,
   }: {

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -76,6 +76,18 @@ const injectAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
   );
 };
 
+/**
+ * Remove Axios base API URL with lang (internationalization)
+ * @param {(Logger|null)} logger - Logger instance
+ * @returns {void}
+ */
+const removeAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
+  logger?.debug(
+    `Removed base API URL <${api.defaults.baseURL}> with language <${i18n.global.locale}>.`,
+  );
+  api.defaults.baseURL = apiBase;
+};
+
 export const useApi = () => {
   const apiFetch = async <T>({
     endpoint,
@@ -85,6 +97,7 @@ export const useApi = () => {
     headers = requestDefaultHeader,
     logger,
     showSuccessMessage = true,
+    localized = true,
   }: {
     endpoint: string;
     payload?: object;
@@ -93,6 +106,7 @@ export const useApi = () => {
     headers?: AxiosRequestHeaders;
     logger: Logger | null;
     showSuccessMessage?: boolean;
+    localized?: boolean;
   }): Promise<ApiResponse<T>> => {
     try {
       logger?.info('Call <api()> function with parameters arguments.');
@@ -104,8 +118,13 @@ export const useApi = () => {
       logger?.debug(
         `<api()> function headers parameter argument <${JSON.stringify(headers)}>.`,
       );
-      // Inject Axios base API URL with lang (internationalization)
-      injectAxioBaseApiUrlWithLang(logger);
+      if (localized) {
+        // Inject Axios base API URL with lang (internationalization)
+        injectAxioBaseApiUrlWithLang(logger);
+      } else {
+        // Remove Axios base API URL with lang (internationalization)
+        removeAxioBaseApiUrlWithLang(logger);
+      }
       const startTime = performance.now();
       const data: apiData = {
         url: endpoint,

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -76,6 +76,18 @@ const injectAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
   );
 };
 
+/**
+ * Remove Axios base API URL with lang (internationalization)
+ * @param {(Logger|null)} logger - Logger instance
+ * @returns {void}
+ */
+const removeAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
+  logger?.debug(
+    `Removed base API URL <${api.defaults.baseURL}> with language <${i18n.global.locale}>.`,
+  );
+  api.defaults.baseURL = apiBase;
+};
+
 export const useApi = () => {
   const apiFetch = async <T>({
     endpoint,
@@ -85,6 +97,7 @@ export const useApi = () => {
     headers = requestDefaultHeader,
     logger,
     showSuccessMessage = true,
+    localized = true,
   }: {
     endpoint: string;
     payload?: object;
@@ -105,8 +118,13 @@ export const useApi = () => {
       logger?.debug(
         `<api()> function headers parameter argument <${JSON.stringify(headers)}>.`,
       );
-      // Inject Axios base API URL with lang (internationalization)
-      injectAxioBaseApiUrlWithLang(logger);
+      if (localized) {
+        // Inject Axios base API URL with lang (internationalization)
+        injectAxioBaseApiUrlWithLang(logger);
+      } else {
+        // Remove Axios base API URL with lang (internationalization)
+        removeAxioBaseApiUrlWithLang(logger);
+      }
       const startTime = performance.now();
       const data: apiData = {
         url: endpoint,

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -76,18 +76,6 @@ const injectAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
   );
 };
 
-/**
- * Remove Axios base API URL with lang (internationalization)
- * @param {(Logger|null)} logger - Logger instance
- * @returns {void}
- */
-const removeAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
-  logger?.debug(
-    `Removed base API URL <${api.defaults.baseURL}> with language <${i18n.global.locale}>.`,
-  );
-  api.defaults.baseURL = apiBase;
-};
-
 export const useApi = () => {
   const apiFetch = async <T>({
     endpoint,
@@ -97,7 +85,6 @@ export const useApi = () => {
     headers = requestDefaultHeader,
     logger,
     showSuccessMessage = true,
-    localized = true,
   }: {
     endpoint: string;
     payload?: object;
@@ -106,7 +93,6 @@ export const useApi = () => {
     headers?: AxiosRequestHeaders;
     logger: Logger | null;
     showSuccessMessage?: boolean;
-    localized?: boolean;
   }): Promise<ApiResponse<T>> => {
     try {
       logger?.info('Call <api()> function with parameters arguments.');
@@ -118,13 +104,8 @@ export const useApi = () => {
       logger?.debug(
         `<api()> function headers parameter argument <${JSON.stringify(headers)}>.`,
       );
-      if (localized) {
-        // Inject Axios base API URL with lang (internationalization)
-        injectAxioBaseApiUrlWithLang(logger);
-      } else {
-        // Remove Axios base API URL with lang (internationalization)
-        removeAxioBaseApiUrlWithLang(logger);
-      }
+      // Inject Axios base API URL with lang (internationalization)
+      injectAxioBaseApiUrlWithLang(logger);
       const startTime = performance.now();
       const data: apiData = {
         url: endpoint,

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -83,7 +83,7 @@ const injectAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
  */
 const removeAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
   logger?.debug(
-    `Removed base API URL <${api.defaults.baseURL}> with language <${i18n.global.locale}>.`,
+    `Reset base API URL <${api.defaults.baseURL}> for unlocalized API call.`,
   );
   api.defaults.baseURL = apiBase;
 };

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -76,18 +76,6 @@ const injectAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
   );
 };
 
-/**
- * Remove Axios base API URL with lang (internationalization)
- * @param {(Logger|null)} logger - Logger instance
- * @returns {void}
- */
-const removeAxioBaseApiUrlWithLang = (logger: Logger | null): void => {
-  logger?.debug(
-    `Reset base API URL <${api.defaults.baseURL}> for unlocalized API call.`,
-  );
-  api.defaults.baseURL = apiBase;
-};
-
 export const useApi = () => {
   const apiFetch = async <T>({
     endpoint,
@@ -97,7 +85,6 @@ export const useApi = () => {
     headers = requestDefaultHeader,
     logger,
     showSuccessMessage = true,
-    localized = true,
   }: {
     endpoint: string;
     payload?: object;
@@ -118,13 +105,8 @@ export const useApi = () => {
       logger?.debug(
         `<api()> function headers parameter argument <${JSON.stringify(headers)}>.`,
       );
-      if (localized) {
-        // Inject Axios base API URL with lang (internationalization)
-        injectAxioBaseApiUrlWithLang(logger);
-      } else {
-        // Remove Axios base API URL with lang (internationalization)
-        removeAxioBaseApiUrlWithLang(logger);
-      }
+      // Inject Axios base API URL with lang (internationalization)
+      injectAxioBaseApiUrlWithLang(logger);
       const startTime = performance.now();
       const data: apiData = {
         url: endpoint,

--- a/src/stores/register.ts
+++ b/src/stores/register.ts
@@ -142,7 +142,7 @@ export const useRegisterStore = defineStore('register', {
         method: 'get',
         translationKey: 'checkEmailVerification',
         showSuccessMessage: false,
-        headers: Object.assign(requestDefaultHeader, requestTokenHeader_),
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
         logger: this.$log,
       });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,10 +2,15 @@
 import type { AxiosRequestHeaders } from 'axios';
 import { ConfigGlobal } from '../components/types';
 
-// config
-const rideToWorkByBikeConfig: ConfigGlobal = JSON.parse(
-  process.env.RIDE_TO_WORK_BY_BIKE_CONFIG,
-);
+/**
+ * Get global app config as lazy function allow to use
+ * this TS module inside Cypress e2e tests, where global
+ * app config is available via Cypress task('getAppConfig')
+ * command.
+ */
+const getAppConfig = (): ConfigGlobal => {
+  return JSON.parse(process.env.RIDE_TO_WORK_BY_BIKE_CONFIG) as ConfigGlobal;
+};
 
 interface RgbaI {
   r: number;
@@ -53,9 +58,11 @@ const timestampToDatetimeString = (timestamp: number): string => {
 
 const bearerTokeAuth = 'Bearer';
 
-const requestDefaultHeader = {
-  Accept: `application/json; version=${rideToWorkByBikeConfig.apiVersion}`,
-} as AxiosRequestHeaders;
+const requestDefaultHeader = (): AxiosRequestHeaders => {
+  return {
+    Accept: `application/json; version=${getAppConfig().apiVersion}`,
+  } as AxiosRequestHeaders;
+};
 
 const requestTokenHeader = {
   Authorization: `${bearerTokeAuth} `,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,12 +51,14 @@ const timestampToDatetimeString = (timestamp: number): string => {
   return formatedDateTime;
 };
 
+const bearerTokeAuth = 'Bearer';
+
 const requestDefaultHeader = {
   Accept: `application/json; version=${rideToWorkByBikeConfig.apiVersion}`,
 } as AxiosRequestHeaders;
 
 const requestTokenHeader = {
-  Authorization: 'Bearer ',
+  Authorization: `${bearerTokeAuth} `,
 } as AxiosRequestHeaders;
 
 /*
@@ -84,6 +86,7 @@ const deepObjectWithSimplePropsCopy = (obj: object): object => {
 };
 
 export {
+  bearerTokeAuth,
   deepObjectWithSimplePropsCopy,
   requestDefaultHeader,
   requestTokenHeader,

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -7,6 +7,7 @@ import {
   testBackgroundImage,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
+import { OrganizationType } from '../../../src/components/types/Organization';
 
 describe('Login page', () => {
   context('desktop', () => {
@@ -109,7 +110,11 @@ describe('Login page', () => {
               cy.wrap(win.i18n).as('i18n');
 
               // Set up API intercepts
-              interceptOrganizationsApi(config, win.i18n);
+              interceptOrganizationsApi(
+                config,
+                win.i18n,
+                OrganizationType.company,
+              );
               interceptRegisterCoordinatorApi(config, win.i18n);
 
               // Load fixtures and set up request body
@@ -141,17 +146,28 @@ describe('Login page', () => {
     });
 
     it('fills in the form, submits it, and redirects to homepage on success', () => {
-      cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
-        cy.wait('@getOrganizations').then((interception) => {
-          expect(interception.request.headers.authorization).to.include(
-            'Bearer',
-          );
-          expect(interception.response.statusCode).to.equal(
-            httpSuccessfullStatus,
-          );
-          expect(interception.response.body).to.deep.equal(
-            formFieldCompanyResponse,
-          );
+      cy.fixture('formFieldCompany').then((formFieldCompany) => {
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          cy.wait('@getOrganizations').then((interception) => {
+            expect(interception.request.headers.authorization).to.include(
+              'Bearer',
+            );
+            expect(interception.response.statusCode).to.equal(
+              httpSuccessfullStatus,
+            );
+            expect(interception.response.body).to.deep.equal(formFieldCompany);
+          });
+          cy.wait('@getOrganizationsNextPage').then((interception) => {
+            expect(interception.request.headers.authorization).to.include(
+              'Bearer',
+            );
+            expect(interception.response.statusCode).to.equal(
+              httpSuccessfullStatus,
+            );
+            expect(interception.response.body).to.deep.equal(
+              formFieldCompanyNext,
+            );
+          });
           // fill in the form
           fillFormRegisterCoordinator();
           // check responsibility checkbox

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -109,7 +109,7 @@ describe('Login page', () => {
               cy.wrap(win.i18n).as('i18n');
 
               // Set up API intercepts
-              interceptOrganizationsApi(config);
+              interceptOrganizationsApi(config, win.i18n);
               interceptRegisterCoordinatorApi(config, win.i18n);
 
               // Load fixtures and set up request body

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -5,6 +5,7 @@ import {
   interceptRegisterCoordinatorApi,
   testLanguageSwitcher,
   testBackgroundImage,
+  waitForOrganizationsApi,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 import { OrganizationType } from '../../../src/components/types/Organization';
@@ -148,26 +149,7 @@ describe('Login page', () => {
     it('fills in the form, submits it, and redirects to homepage on success', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          cy.wait('@getOrganizations').then((interception) => {
-            expect(interception.request.headers.authorization).to.include(
-              'Bearer',
-            );
-            expect(interception.response.statusCode).to.equal(
-              httpSuccessfullStatus,
-            );
-            expect(interception.response.body).to.deep.equal(formFieldCompany);
-          });
-          cy.wait('@getOrganizationsNextPage').then((interception) => {
-            expect(interception.request.headers.authorization).to.include(
-              'Bearer',
-            );
-            expect(interception.response.statusCode).to.equal(
-              httpSuccessfullStatus,
-            );
-            expect(interception.response.body).to.deep.equal(
-              formFieldCompanyNext,
-            );
-          });
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           // fill in the form
           fillFormRegisterCoordinator();
           // check responsibility checkbox

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -109,7 +109,7 @@ describe('Login page', () => {
               cy.wrap(win.i18n).as('i18n');
 
               // Set up API intercepts
-              interceptOrganizationsApi(config, win.i18n);
+              interceptOrganizationsApi(config);
               interceptRegisterCoordinatorApi(config, win.i18n);
 
               // Load fixtures and set up request body

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -150,6 +150,7 @@ describe('Login page', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          nextTick();
           // fill in the form
           fillFormRegisterCoordinator();
           // check responsibility checkbox

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -151,7 +151,7 @@ describe('Login page', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          nextTick();
+          cy.wrap(nextTick());
           // fill in the form
           fillFormRegisterCoordinator();
           // check responsibility checkbox

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import {
   fillFormRegisterCoordinator,
   httpSuccessfullStatus,

--- a/test/cypress/fixtures/formFieldCompany.json
+++ b/test/cypress/fixtures/formFieldCompany.json
@@ -1,6 +1,6 @@
 {
   "count": 10,
-  "next": "https://test.dopracenakole.cz/rest/organizations/?limit=10&offset=10",
+  "next": "https://test.dopracenakole.cz/rest/organizations/company/?limit=10&offset=10",
   "previous": null,
   "results": [
     {

--- a/test/cypress/fixtures/formFieldCompany.json
+++ b/test/cypress/fixtures/formFieldCompany.json
@@ -1,12 +1,47 @@
 {
+  "count": 10,
+  "next": "https://test.dopracenakole.cz/rest/organizations/?limit=10&offset=10",
+  "previous": null,
   "results": [
     {
-      "name": "Company 1",
-      "id": 12345671
+      "id": 987,
+      "name": "100MEGA Distribution s.r.o."
     },
     {
-      "name": "Company 2",
-      "id": 12345672
+      "id": 774,
+      "name": "13. Základní škola Plzeň, Habrmannova 45; 326 00"
+    },
+    {
+      "id": 2545,
+      "name": "13.ZŠ Plzeň"
+    },
+    {
+      "id": 2397,
+      "name": "1415 Baťův Institut"
+    },
+    {
+      "id": 538,
+      "name": "1.MŠ KV, Komenského 7, přísp. org."
+    },
+    {
+      "id": 3776,
+      "name": "1. podzemní antikvariát"
+    },
+    {
+      "id": 2272,
+      "name": "1.SDZP družstvo"
+    },
+    {
+      "id": 1707,
+      "name": "1. Slovanské gymnázium "
+    },
+    {
+      "id": 1113,
+      "name": "1.Vlasové závody Praha"
+    },
+    {
+      "id": 2874,
+      "name": "1. ZŠ Plzeň, Západní 18, příspěvková organizace"
     }
   ]
 }

--- a/test/cypress/fixtures/formFieldCompanyCreateRequest.json
+++ b/test/cypress/fixtures/formFieldCompanyCreateRequest.json
@@ -1,4 +1,5 @@
 {
   "name": "Test Company",
-  "vatId": "12345678"
+  "vatId": "12345678",
+  "organization_type": "company"
 }

--- a/test/cypress/fixtures/formFieldCompanyNext.json
+++ b/test/cypress/fixtures/formFieldCompanyNext.json
@@ -1,0 +1,47 @@
+{
+  "count": 10,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 3619,
+      "name": "23pm, s. r. o."
+    },
+    {
+      "id": 2003,
+      "name": "24. základna dopravního letectva Praha Kbely"
+    },
+    {
+      "id": 3993,
+      "name": "27.materska skola"
+    },
+    {
+      "id": 2778,
+      "name": "2. lékařská fakulta Univerzita Karlovy"
+    },
+    {
+      "id": 603,
+      "name": "2N TELEKOMUNIKACE a.s."
+    },
+    {
+      "id": 3303,
+      "name": "2. ZŠ Napajedla"
+    },
+    {
+      "id": 1569,
+      "name": "3G Consulting Engineers s.r.o."
+    },
+    {
+      "id": 1846,
+      "name": "3. Základní škola Jindřichův Hradec, Jarošovská 746/II"
+    },
+    {
+      "id": 3283,
+      "name": "4mushing"
+    },
+    {
+      "id": 3417,
+      "name": "4. základní škola Plzeň, Kralovická 12, p. o"
+    }
+  ]
+}

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -5,9 +5,14 @@ import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_
 const layoutBackgroundImageSelector = 'layout-background-image';
 
 // types
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { Interception } from 'cypress/types/net-stubbing';
 import type { I18n } from 'vue-i18n';
 import type { ConfigGlobal } from '../../../src/components/types/Config';
-import { OrganizationType } from 'src/components/types/Organization';
+import type {
+  GetOrganizationsResponse,
+  OrganizationType,
+} from 'src/components/types/Organization';
 
 type AUTWindow = Window & typeof globalThis & ApplicationWindow;
 
@@ -415,6 +420,35 @@ export const interceptOrganizationsApi = (
     },
   );
 };
+
+export function waitForOrganizationsApi(
+  formFieldCompany: GetOrganizationsResponse,
+  formFieldCompanyNext: GetOrganizationsResponse,
+) {
+  cy.wait('@getOrganizations').then(
+    (
+      interception: Interception<
+        AxiosRequestConfig,
+        AxiosResponse<GetOrganizationsResponse>
+      >,
+    ) => {
+      expect(interception.request.headers.authorization).to.include('Bearer');
+      if (interception.response) {
+        expect(interception.response.statusCode).to.equal(
+          httpSuccessfullStatus,
+        );
+        expect(interception.response.body).to.deep.equal(formFieldCompany);
+      }
+    },
+  );
+  cy.wait('@getOrganizationsNextPage').then((interception) => {
+    expect(interception.request.headers.authorization).to.include('Bearer');
+    if (interception.response) {
+      expect(interception.response.statusCode).to.equal(httpSuccessfullStatus);
+      expect(interception.response.body).to.deep.equal(formFieldCompanyNext);
+    }
+  });
+}
 
 export const interceptRegisterCoordinatorApi = (
   config: ConfigGlobal,

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -7,6 +7,7 @@ const layoutBackgroundImageSelector = 'layout-background-image';
 // types
 import type { I18n } from 'vue-i18n';
 import type { ConfigGlobal } from '../../../src/components/types/Config';
+import { OrganizationType } from 'src/components/types/Organization';
 
 type AUTWindow = Window & typeof globalThis & ApplicationWindow;
 
@@ -380,15 +381,20 @@ export const setupApiChallengeInactive = (
   cy.clock(systemTimeChallengeInactive, ['Date']);
 };
 
-export const interceptOrganizationsApi = (config: ConfigGlobal, i18n: I18n) => {
+export const interceptOrganizationsApi = (
+  config: ConfigGlobal,
+  i18n: I18n,
+  type: OrganizationType,
+) => {
   const { apiBase, apiDefaultLang, urlApiOrganizations } = config;
   // get API base URL
   const apiBaseUrl = getApiBaseUrlWithLang(null, apiBase, apiDefaultLang, i18n);
   const urlApiOrganizationsLocalized = `${apiBaseUrl}${urlApiOrganizations}`;
+  const urlApiOrganizationsLocalizedWithType = `${urlApiOrganizationsLocalized}${type}/`;
   cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
     cy.fixture('formFieldCompanyNext').then((formFieldCompanyNextResponse) => {
       // intercept organizations API call (before mounting component)
-      cy.intercept('GET', urlApiOrganizationsLocalized, {
+      cy.intercept('GET', urlApiOrganizationsLocalizedWithType, {
         statusCode: httpSuccessfullStatus,
         body: formFieldCompanyResponse,
       }).as('getOrganizations');

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -380,22 +380,28 @@ export const setupApiChallengeInactive = (
   cy.clock(systemTimeChallengeInactive, ['Date']);
 };
 
-export const interceptOrganizationsApi = (config: ConfigGlobal, i18n: I18n) => {
-  const { apiBase, apiDefaultLang, urlApiOrganizations } = config;
+export const interceptOrganizationsApi = (config: ConfigGlobal) => {
+  const { apiBase, urlApiOrganizations } = config;
   // get API base URL
-  const apiBaseUrl = getApiBaseUrlWithLang(null, apiBase, apiDefaultLang, i18n);
-  const urlApiOrganizationsLocalized = `${apiBaseUrl}${urlApiOrganizations}`;
-  // intercept organizations API call (before mounting component)
+  const urlApiOrganizationsPath = `${apiBase}${urlApiOrganizations}`;
   cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
-    cy.intercept('GET', urlApiOrganizationsLocalized, {
-      statusCode: httpSuccessfullStatus,
-      body: formFieldCompanyResponse,
-    }).as('getOrganizations');
+    cy.fixture('formFieldCompanyNext').then((formFieldCompanyNextResponse) => {
+      // intercept organizations API call (before mounting component)
+      cy.intercept('GET', urlApiOrganizationsPath, {
+        statusCode: httpSuccessfullStatus,
+        body: formFieldCompanyResponse,
+      }).as('getOrganizations');
+      // intercept next page API call
+      cy.intercept('GET', formFieldCompanyResponse.next, {
+        statusCode: httpSuccessfullStatus,
+        body: formFieldCompanyNextResponse,
+      }).as('getOrganizationsNextPage');
+    });
   });
   // intercept create organization API call (before mounting component)
   cy.fixture('formFieldCompanyCreate').then(
     (formFieldCompanyCreateResponse) => {
-      cy.intercept('POST', urlApiOrganizationsLocalized, {
+      cy.intercept('POST', urlApiOrganizationsPath, {
         statusCode: httpSuccessfullStatus,
         body: formFieldCompanyCreateResponse,
       }).as('createOrganization');

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -380,14 +380,15 @@ export const setupApiChallengeInactive = (
   cy.clock(systemTimeChallengeInactive, ['Date']);
 };
 
-export const interceptOrganizationsApi = (config: ConfigGlobal) => {
-  const { apiBase, urlApiOrganizations } = config;
+export const interceptOrganizationsApi = (config: ConfigGlobal, i18n: I18n) => {
+  const { apiBase, apiDefaultLang, urlApiOrganizations } = config;
   // get API base URL
-  const urlApiOrganizationsPath = `${apiBase}${urlApiOrganizations}`;
+  const apiBaseUrl = getApiBaseUrlWithLang(null, apiBase, apiDefaultLang, i18n);
+  const urlApiOrganizationsLocalized = `${apiBaseUrl}${urlApiOrganizations}`;
   cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
     cy.fixture('formFieldCompanyNext').then((formFieldCompanyNextResponse) => {
       // intercept organizations API call (before mounting component)
-      cy.intercept('GET', urlApiOrganizationsPath, {
+      cy.intercept('GET', urlApiOrganizationsLocalized, {
         statusCode: httpSuccessfullStatus,
         body: formFieldCompanyResponse,
       }).as('getOrganizations');
@@ -401,7 +402,7 @@ export const interceptOrganizationsApi = (config: ConfigGlobal) => {
   // intercept create organization API call (before mounting component)
   cy.fixture('formFieldCompanyCreate').then(
     (formFieldCompanyCreateResponse) => {
-      cy.intercept('POST', urlApiOrganizationsPath, {
+      cy.intercept('POST', urlApiOrganizationsLocalized, {
         statusCode: httpSuccessfullStatus,
         body: formFieldCompanyCreateResponse,
       }).as('createOrganization');

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { routesConf } from '../../../src/router/routes_conf';
 import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_lang';
 import { bearerTokeAuth } from 'src/utils';
@@ -20,6 +21,10 @@ type AUTWindow = Window & typeof globalThis & ApplicationWindow;
 interface ApplicationWindow {
   i18n?: I18n;
 }
+
+export const syncNextTick = async (): Promise<void> => {
+  await nextTick();
+};
 
 /**
  * Basic tests for Language Switcher


### PR DESCRIPTION
Update data fetching for `FormFieldCompany` component by connecting to a new API endpoint.
Endpoint provides **unlocalized, paged** results.

To serve this:

* Update fixture `formFieldCompany` and add a fixture for next page `formFieldCompanyNext`.
* In `commonTests` update interception init function so that the `next` endpoint is also intercepted. Remove localization.
* Extend `useApi` composable by adding a localization reset function if parameter `localized: false` is passed.
* Update `GetOrganizationsResponse` and `FormSelectOption` types.
* Remove incorrect localization from `loadOptions` function in `FormFieldCompany`.
* In `FormFieldCompany` enable cummulative saving of data in `optionsDefault` variable with functions `pushResultsToOptions` and `fetchNextPage`.
* Update component tests to check for paged requests.