### PR TITLE
src/i18n: fix social media registration buttons widgets labels

### DIFF
--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -639,8 +639,8 @@ titleEmailVerification = "Pokračujte potvrzením e-mailu"
 titleRegister = "Registrace"
 
 [register.buttons]
-buttonGoogle = "Registrovat přes Facebook"
-buttonFacebook = "Registrovat přes Google"
+buttonGoogle = "Registrovat přes Google"
+buttonFacebook = "Registrovat přes Facebook"
 
 [register.challenge]
 buttonAddCompany = "Přidat novou"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -636,8 +636,8 @@ titleEmailVerification = "Continue by confirming your email"
 titleRegister = "Registration"
 
 [register.buttons]
-buttonGoogle = "Register via Facebook"
-buttonFacebook = "Register via Google"
+buttonGoogle = "Register via Google"
+buttonFacebook = "Register via Facebook"
 
 [register.challenge]
 buttonAddCompany = "Add new"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -636,8 +636,8 @@ titleEmailVerification = "Pokračujte potvrdením e-mailu"
 titleRegister = "Registrácia"
 
 [register.buttons]
-buttonGoogle = "Registrácia cez Facebook"
-buttonFacebook = "Registrácia cez Google"
+buttonGoogle = "Registrácia cez Google"
+buttonFacebook = "Registrácia cez Facebook"
 
 [register.challenge]
 buttonAddCompany = "Pridanie novej"


### PR DESCRIPTION
Fix social media registration buttons widgets labels.

Screenshot:

![registration_social_media_btns_widgets_labes](https://github.com/user-attachments/assets/bdc021d9-085d-4821-8922-5f44e51576f2)
