### PR TITLE
src/components: in FormFieldVoucher add activeVoucher prop to show voucher info

### DIFF
--- a/src/components/__tests__/FormFieldVoucher.cy.js
+++ b/src/components/__tests__/FormFieldVoucher.cy.js
@@ -35,6 +35,50 @@ describe('<FormFieldVoucher>', () => {
     coreTests();
   });
 
+  context('desktop - active voucher HALF', () => {
+    beforeEach(() => {
+      cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
+        cy.mount(FormFieldVoucher, {
+          props: {
+            activeVoucher: voucherHalf,
+          },
+        });
+        cy.viewport('macbook-16');
+      });
+    });
+
+    it('renders active voucher if passed in', () => {
+      cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
+        cy.dataCy(selectorVoucherBannerCode)
+          .should('be.visible')
+          .and('contain', voucherHalf.code)
+          .and('contain', i18n.global.t('form.textVoucher'));
+      });
+    });
+  });
+
+  context('desktop - active voucher FULL', () => {
+    beforeEach(() => {
+      cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
+        cy.mount(FormFieldVoucher, {
+          props: {
+            activeVoucher: voucherFull,
+          },
+        });
+        cy.viewport('macbook-16');
+      });
+    });
+
+    it('renders active voucher if passed in', () => {
+      cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
+        cy.dataCy(selectorVoucherBannerCode)
+          .should('be.visible')
+          .and('contain', voucherFull.code)
+          .and('contain', i18n.global.t('form.textVoucher'));
+      });
+    });
+  });
+
   context('mobile', () => {
     beforeEach(() => {
       cy.mount(FormFieldVoucher, {

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -261,7 +261,7 @@ function coreTests() {
     });
   });
 
-  it('if selected voucher - retains shown voucher after switching back to individual', () => {
+  it('if selected voucher - retains shown voucher after switching between payment subjects', () => {
     cy.get('@voucherHalf').then((voucher) => {
       // select voucher
       cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -25,6 +25,7 @@ const selectorCoordinatorTerms = 'register-coordinator-terms';
 const selectorSliderNumberInput = 'form-field-slider-number-input';
 const selectorSliderNumberSlider = 'form-field-slider-number-slider';
 const selectorTextPaymentOrganizer = 'text-payment-organizer';
+const selectorVoucherBannerCode = 'voucher-banner-code';
 const selectorVoucherButtonRemove = 'voucher-button-remove';
 const selectorVoucherInput = 'form-field-voucher-input';
 const selectorVoucherSubmit = 'form-field-voucher-submit';
@@ -37,6 +38,7 @@ const optionCustom = 'custom';
 const optionVoucher = 'voucher';
 const optionCompany = 'company';
 const optionSchool = 'school';
+const optionIndividual = 'individual';
 const sliderClickTolerance = 10;
 const testNumberValue = 500;
 
@@ -256,6 +258,26 @@ function coreTests() {
 
       // if voucher FULL is applied, user still has option to add donation
       testDonation();
+    });
+  });
+
+  it('if selected voucher - retains shown voucher after switching back to individual', () => {
+    cy.get('@voucherHalf').then((voucher) => {
+      // select voucher
+      cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+      cy.dataCy(selectorVoucherInput).type(voucher.code);
+      cy.dataCy(selectorVoucherSubmit).click();
+      // shows voucher
+      cy.dataCy(selectorVoucherBannerCode).should('be.visible');
+      // switch back to individual
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      // shows amount selection but not voucher
+      cy.dataCy(selectorPaymentAmount).should('be.visible');
+      cy.dataCy(selectorVoucherBannerCode).should('not.exist');
+      // switch back to voucher
+      cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+      // shows voucher
+      cy.dataCy(selectorVoucherBannerCode).should('be.visible');
     });
   });
 

--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -15,7 +15,7 @@
  * - `FormFieldTextRequired`: Component to render required text field.
  *
  * @example
- * <form-field-voucher @update:voucher="onUpdateVoucher" />
+ * <form-field-voucher :voucher="voucher" @update:voucher="onUpdateVoucher" />
  *
  * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=6410-2305&t=gB7ERmDZorpD4TdE-1)
  */
@@ -45,10 +45,18 @@ export default defineComponent({
   components: {
     FormFieldTextRequired,
   },
+  props: {
+    activeVoucher: {
+      type: Object as () => FormPaymentVoucher | null,
+      default: null,
+    },
+  },
   emits: ['remove:voucher', 'update:voucher'],
   setup(props, { emit }) {
     const code = ref('');
-    const voucher = ref<FormPaymentVoucher | null>(null);
+    const voucher = ref<FormPaymentVoucher | null>(
+      props.activeVoucher ? props.activeVoucher : null,
+    );
 
     /**
      * Submits voucher data to API

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -137,6 +137,7 @@ export default defineComponent({
       },
     ]);
 
+    const activeVoucher = ref<FormPaymentVoucher | null>(null);
     const selectedPaymentAmount = ref<string>(String(defaultPaymentAmountMin));
     const selectedPaymentAmountCustom = ref<number>(defaultPaymentAmountMin);
     const paymentAmountMax = ref<number>(defaultPaymentAmountMax);
@@ -181,6 +182,10 @@ export default defineComponent({
      * if entry fee is free, display voluntary contribution.
      */
     const onUpdateVoucher = (voucher: FormPaymentVoucher): void => {
+      if (voucher.code) {
+        // set active voucher
+        activeVoucher.value = voucher;
+      }
       // amount = discounted price
       if (voucher.amount) {
         // discount the lowest price in the price options
@@ -209,6 +214,8 @@ export default defineComponent({
      * @return {void}
      */
     const onRemoveVoucher = (): void => {
+      // clear active voucher
+      activeVoucher.value = null;
       isEntryFeeFree.value = false;
       optionsPaymentAmount.shift();
       optionsPaymentAmount.unshift(defaultPaymentOption);
@@ -221,6 +228,7 @@ export default defineComponent({
     };
 
     return {
+      activeVoucher,
       borderRadius,
       formRegisterCoordinator,
       isEntryFeeFree,
@@ -308,6 +316,7 @@ export default defineComponent({
     <!-- Input: Voucher -->
     <div v-if="selectedPaymentSubject === PaymentSubject.voucher">
       <form-field-voucher
+        :active-voucher="activeVoucher"
         @update:voucher="onUpdateVoucher"
         @remove:voucher="onRemoveVoucher"
       />


### PR DESCRIPTION
Issue: switching between payment subjects (e.g. `individual` and `voucher`) clears the voucher info box and instead, shows input again.

Solution:
* Add `activeVoucher` prop to `FormFieldVoucher` so we can pass voucher info by default.
* In `RegisterChallengePayment` component, store activeVoucher value and pass it into the `FormFieldVoucher` component (on init - when switching subjects).
* Add tests for this behaviour.

Note: Subsequent PR will address showing correct min. prices when switching between subjects.