### PR TITLE
src/components/__tests__: fix run Cypress command serially in FormFieldCompany component tests

### DIFF
--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -107,23 +107,23 @@ describe('<FormFieldCompany>', () => {
             httpSuccessfullStatus,
           );
           expect(interception.response.body).to.deep.equal(formFieldCompany);
-          cy.dataCy('form-company').find('input').focus();
-          cy.dataCy('form-company')
-            .find('input')
-            .type(formFieldCompany.results[1].name);
-          // select first option from filtered results
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              // only shows the one filtered option
-              cy.get('.q-item').should('have.length', 1);
-              cy.get('.q-item').first().click();
-            });
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[1].id);
         });
+        cy.dataCy('form-company').find('input').focus();
+        cy.dataCy('form-company')
+          .find('input')
+          .type(formFieldCompany.results[1].name);
+        // select first option from filtered results
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            // only shows the one filtered option
+            cy.get('.q-item').should('have.length', 1);
+            cy.get('.q-item').first().click();
+          });
+        cy.get('.q-menu').should('not.exist');
+        cy.wrap(model)
+          .its('value')
+          .should('eq', formFieldCompany.results[1].id);
       });
     });
 

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -77,22 +77,22 @@ describe('<FormFieldCompany>', () => {
             httpSuccessfullStatus,
           );
           expect(interception.response.body).to.deep.equal(formFieldCompany);
-          cy.dataCy('form-company').find('input').click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item').should(
-                'have.length',
-                formFieldCompany.results.length,
-              );
-              cy.get('.q-item').first().click();
-            });
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[0].id);
         });
+        cy.dataCy('form-company').find('input').click();
+        // select option
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            cy.get('.q-item').should(
+              'have.length',
+              formFieldCompany.results.length,
+            );
+            cy.get('.q-item').first().click();
+          });
+        cy.get('.q-menu').should('not.exist');
+        cy.wrap(model)
+          .its('value')
+          .should('eq', formFieldCompany.results[0].id);
       });
     });
 


### PR DESCRIPTION
Issue: Component test for `FormFieldCompany` occasionally fails with message:

```
  1) <FormFieldCompany>
       desktop
         allows to search through options:
     AssertionError: Timed out retrying after 60000ms: expected '<div#f_9409d467-5078-4ac6-9962-587d04fbbf26_lb.q-menu.q-position-engine.scroll>' to be 'visible'

This element `<div#f_9409d467-5078-4ac6-9962-587d04fbbf26_lb.q-menu.q-position-engine.scroll>` is not visible because it has CSS property: `visibility: collapse`
```

Solution:
* Run cypress commands **after** closing of the `.then()` function which follows awaiting API request and interception checks).