### PR TITLE
src/components/__tests__:  fix FormRegisterCoordinator component command sequencing and message visibility checks

### DIFF
--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { colors } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 import FormRegisterCoordinator from 'components/register/FormRegisterCoordinator.vue';
@@ -19,6 +20,7 @@ const compareRegisterResponseWithStore = () => {
     'be.visible',
   );
   const registerStore = useRegisterStore();
+  nextTick();
   expect(registerStore.getIsRegistrationComplete).to.equal(true);
 };
 
@@ -197,17 +199,15 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-submit')
         .should('be.visible')
         .click();
-      cy.dataCy('form-register-coordinator-terms')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t('register.coordinator.form.messageTermsRequired'),
-        );
+      // required message is visible
+      cy.contains(
+        i18n.global.t('register.coordinator.form.messageTermsRequired'),
+      ).should('be.visible');
       // test terms checkbox checked
       cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
       // testing non-existence of element fails on .find() method
-      cy.get(
-        '*[data-cy="form-register-coordinator-terms] .q-field__messages',
+      cy.contains(
+        i18n.global.t('register.coordinator.form.messageTermsRequired'),
       ).should('not.exist');
     });
 
@@ -225,19 +225,23 @@ describe('<FormRegisterCoordinator>', () => {
           .click();
         // submit form
         cy.dataCy('form-register-coordinator-submit').click();
-        cy.wait('@registerCoordinator').then((interception) => {
-          // request body
-          cy.get('@registerRequestBody').then((registerRequestBody) => {
-            expect(interception.request.body).to.deep.equal(
-              registerRequestBody,
-            );
-          });
-          // status code
-          expect(interception.response.statusCode).to.equal(
-            httpSuccessfullStatus,
-          );
-          // check state in store
-          compareRegisterResponseWithStore();
+        // wait for API call to finish
+        cy.get('@registerRequestBody').then((registerRequestBody) => {
+          cy.wait('@registerCoordinator')
+            .then((interception) => {
+              // request body
+              expect(interception.request.body).to.deep.equal(
+                registerRequestBody,
+              );
+              // status code
+              expect(interception.response.statusCode).to.equal(
+                httpSuccessfullStatus,
+              );
+            })
+            .then(() => {
+              // check state in store
+              compareRegisterResponseWithStore();
+            });
         });
       });
     });

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -179,33 +179,33 @@ describe('<FormRegisterCoordinator>', () => {
       cy.dataCy('form-register-coordinator-submit')
         .should('be.visible')
         .click();
-      cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-field__messages')
-        .should(
-          'contain',
-          i18n.global.t(
-            'register.coordinator.form.messageResponsibilityRequired',
-          ),
-        );
+      // responsibility - required message shown
+      cy.contains(
+        i18n.global.t(
+          'register.coordinator.form.messageResponsibilityRequired',
+        ),
+      ).should('be.visible');
       // test responsibility checkbox checked
       cy.dataCy('form-register-coordinator-responsibility')
         .find('.q-checkbox')
         .click();
-      // testing non-existence of element fails on .find() method
-      cy.get(
-        '*[data-cy="form-register-coordinator-responsibility] .q-field__messages',
+      // responsibility - required message hidden
+      cy.contains(
+        i18n.global.t(
+          'register.coordinator.form.messageResponsibilityRequired',
+        ),
       ).should('not.exist');
       // test terms checkbox unchecked
       cy.dataCy('form-register-coordinator-submit')
         .should('be.visible')
         .click();
-      // required message is visible
+      // terms - required message shown
       cy.contains(
         i18n.global.t('register.coordinator.form.messageTermsRequired'),
       ).should('be.visible');
       // test terms checkbox checked
       cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
-      // testing non-existence of element fails on .find() method
+      // terms - required message hidden
       cy.contains(
         i18n.global.t('register.coordinator.form.messageTermsRequired'),
       ).should('not.exist');


### PR DESCRIPTION
Issue: `FormRegisterCoordinator` component tests occasionally fail with following problems:

```
  1) <FormRegisterCoordinator>
       desktop
         validates checkboxes correctly:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `.q-field__messages`, but never found it. 

...

  2) <FormRegisterCoordinator>
       desktop
         submits form correctly:
     CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `registerCoordinator`. No request ever occurred.
```

Solution:
1. Switch to a more robust check for UI messages using `cy.contains` to find element by content.
2. Update sequencing of tests, placing the `compareRegisterResponseWithStore` function to its own `.then` block (also add `nextTick` function before checking for store value).