### PR TITLE
src/components/__tests__: await CardFollow image load before testing height and taking snapshot

### DIFF
--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -151,23 +151,21 @@ function coreTests() {
           .should('exist')
           .and('be.visible')
           .find('.q-img__loading')
-          .should('not.exist')
-          .then(() => {
-            // test image height
-            cy.dataCy(selectorCardFollowImage)
-              .find('img')
-              .should('exist')
-              .and('be.visible')
-              .then(($img) => {
-                cy.testImageHeight($img);
-                expect($img.attr('src')).to.equal(card.image.src);
-              });
-            // take a snapshot
-            cy.matchImageSnapshotNamed(
-              selectorCardFollowImage,
-              `${Cypress.currentTest.titlePath[0]}-avatar`,
-            );
+          .should('not.exist');
+        // test image height
+        cy.dataCy(selectorCardFollowImage)
+          .find('img')
+          .should('exist')
+          .and('be.visible')
+          .then(($img) => {
+            cy.testImageHeight($img);
+            expect($img.attr('src')).to.equal(card.image.src);
           });
+        // take a snapshot
+        cy.matchImageSnapshotNamed(
+          selectorCardFollowImage,
+          `${Cypress.currentTest.titlePath[0]}-avatar`,
+        );
       });
     });
   });

--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -146,17 +146,25 @@ function coreTests() {
           .find(classSelectorAvatar)
           .should('have.css', 'border-radius', imageBorderRadius)
           .should('have.css', 'width', imageWidth);
+        // wait until image has no loading indicator
         cy.dataCy(selectorCardFollowImage)
-          .find('img')
-          .should('be.visible')
-          .then(($img) => {
-            cy.testImageHeight($img);
-            expect($img.attr('src')).to.equal(card.image.src);
+          .find('.q-img__loading')
+          .should('not.exist')
+          .then(() => {
+            // test image height
+            cy.dataCy(selectorCardFollowImage)
+              .find('img')
+              .should('be.visible')
+              .then(($img) => {
+                cy.testImageHeight($img);
+                expect($img.attr('src')).to.equal(card.image.src);
+              });
+            // take a snapshot
+            cy.matchImageSnapshotNamed(
+              selectorCardFollowImage,
+              `${Cypress.currentTest.titlePath[0]}-avatar`,
+            );
           });
-        cy.matchImageSnapshotNamed(
-          selectorCardFollowImage,
-          `${Cypress.currentTest.titlePath[0]}-avatar`,
-        );
       });
     });
   });

--- a/src/components/__tests__/CardFollow.cy.js
+++ b/src/components/__tests__/CardFollow.cy.js
@@ -148,13 +148,16 @@ function coreTests() {
           .should('have.css', 'width', imageWidth);
         // wait until image has no loading indicator
         cy.dataCy(selectorCardFollowImage)
+          .should('exist')
+          .and('be.visible')
           .find('.q-img__loading')
           .should('not.exist')
           .then(() => {
             // test image height
             cy.dataCy(selectorCardFollowImage)
               .find('img')
-              .should('be.visible')
+              .should('exist')
+              .and('be.visible')
               .then(($img) => {
                 cy.testImageHeight($img);
                 expect($img.attr('src')).to.equal(card.image.src);

--- a/src/components/homepage/CardFollow.vue
+++ b/src/components/homepage/CardFollow.vue
@@ -82,9 +82,9 @@ export default defineComponent({
           <q-avatar size="56px">
             <q-img
               :src="card.image.src"
-              data-cy="card-follow-image"
               :alt="card.image.alt"
               ratio="1"
+              data-cy="card-follow-image"
             />
           </q-avatar>
         </q-item-section>


### PR DESCRIPTION
Issue: `CardFollow` test occasionally fails with the following message:

```
 1) <CardFollow>
       desktop
         renders image:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `img`, but never found it. Queried from:

              > cy.get([data-cy=card-follow-image], [object Object])
      at Context.<anonymous> (D:/a/ride-to-work-by-bike-frontend/ride-to-work-by-bike-frontend/src/components/__tests__/CardFollow.cy.js:151:12)
```

Solution:
Wait for `CardFollow` image loader to not exist, to ensure `img` element existence before testing height and taking a snapshot.