### PR TITLE
src/i18n: fix waiting for reading locales files content

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -10,7 +10,7 @@ export const loadLocaleMessages = async () => {
     if (matched && matched.length > 1) {
       const locale = matched[1];
       // Dynamic import TOML translation file content
-      localesFiles[localeFile]().then((content) => {
+      await localesFiles[localeFile]().then((content) => {
         messages[locale] = content.default;
       });
     }
@@ -38,5 +38,13 @@ export const getDateTimeFormats = (locales) => {
   locales.forEach((locale) => {
     dateTimeFormats[locale] = dateTimeFormatsAllLocales;
   });
+  if (process.env.NODE_ENV === 'development') {
+    console.log(
+      `Set date time formats for available locales <${locales.join(', ')}>.`,
+    );
+    console.log(
+      `Date time formats <${JSON.stringify(dateTimeFormats, null, 2)}>.`,
+    );
+  }
   return dateTimeFormats;
 };


### PR DESCRIPTION
Fix web browser console warning message:

```
[intlify] Not found 'monthYear' key in 'en' locale messages.
```

Screenshot:

App URL page: /#/coordinator/tasks/

![coordinator_fix_missing_localized_date_time_string](https://github.com/user-attachments/assets/40d34fc5-5e16-491e-9ae9-e146cd946917)
