### PR TITLE
src/composables: define dynamic labels for organization selects

### DIFF
--- a/src/components/__tests__/FormAddCompany.cy.js
+++ b/src/components/__tests__/FormAddCompany.cy.js
@@ -29,6 +29,8 @@ describe('<FormAddCompany>', () => {
     cy.testLanguageStringsInContext(
       [
         'labelCompanyShort',
+        'labelFamilyShort',
+        'labelSchoolShort',
         'company.textCompanyPermission',
         'labelTitle',
         'labelBusinessId',
@@ -43,8 +45,6 @@ describe('<FormAddCompany>', () => {
         'company.hintCityChallenge',
         'company.labelDepartment',
         'company.hintDepartment',
-        'labelSchoolShort',
-        'labelFamilyShort',
       ],
       'form',
       i18n,

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -29,16 +29,22 @@ describe('<FormFieldSelectTable>', () => {
     cy.testLanguageStringsInContext(
       [
         'buttonAddCompany',
+        'buttonAddFamily',
+        'buttonAddSchool',
         'hintCityChallenge',
         'hintDepartment',
         'labelCityChallenge',
         'labelCompany',
         'labelDepartment',
+        'labelFamily',
+        'labelSchool',
         'textCompanyPermission',
         'textCoordinator',
         'textSubsidiaryAddress',
         'textUserExperience',
         'titleAddCompany',
+        'titleAddFamily',
+        'titleAddSchool',
         'titleSubsidiaryAddress',
       ],
       'form.company',
@@ -67,7 +73,7 @@ describe('<FormFieldSelectTable>', () => {
     );
   });
 
-  context('company desktop', () => {
+  context('organization company', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -194,7 +200,7 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('company selected', () => {
+  context('organization company selected', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -215,7 +221,79 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('team desktop', () => {
+  context('organization school', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldSelectTable, {
+        props: {
+          options: options.value,
+          organizationLevel: OrganizationLevel.organization,
+          organizationType: OrganizationType.school,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('shows correct labels', () => {
+      // label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.labelSchool'));
+      // button add new
+      cy.dataCy('form-select-table-button')
+        .should('be.visible')
+        .and('contain', i18n.global.t('register.challenge.buttonAddCompany'));
+      cy.dataCy('form-select-table-button').click();
+      // title dialog
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.titleAddSchool'));
+      // scroll to bottom
+      cy.dataCy('dialog-body').scrollTo('bottom', { ensureScrollable: false });
+      // button dialog
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.buttonAddSchool'));
+    });
+  });
+
+  context('organization family', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldSelectTable, {
+        props: {
+          options: options.value,
+          organizationLevel: OrganizationLevel.organization,
+          organizationType: OrganizationType.family,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('shows correct labels', () => {
+      // label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.labelFamily'));
+      // button add new
+      cy.dataCy('form-select-table-button')
+        .should('be.visible')
+        .and('contain', i18n.global.t('register.challenge.buttonAddCompany'));
+      cy.dataCy('form-select-table-button').click();
+      // title dialog
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.titleAddFamily'));
+      // scroll to bottom
+      cy.dataCy('dialog-body').scrollTo('bottom', { ensureScrollable: false });
+      // button dialog
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.buttonAddFamily'));
+    });
+  });
+
+  context('team', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -317,7 +395,7 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('subsidiary desktop', () => {
+  context('subsidiary', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -87,9 +87,6 @@ export default defineComponent({
     const addressIndex = 0;
 
     const isOrganizationCompany = computed((): boolean => {
-      if (!props.organizationType) {
-        return true;
-      }
       return props.organizationType === OrganizationType.company;
     });
 

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -86,7 +86,7 @@ export default defineComponent({
 
     const addressIndex = 0;
 
-    const isOrganizationCompany = computed((): boolean => {
+    const isVatShown = computed((): boolean => {
       return props.organizationType === OrganizationType.company;
     });
 
@@ -101,7 +101,7 @@ export default defineComponent({
       company,
       titleDialog,
       OrganizationType,
-      isOrganizationCompany,
+      isVatShown,
       isFilled,
       onUpdate,
       FormAddCompanyVariantProp,
@@ -128,7 +128,7 @@ export default defineComponent({
       </p>
     </div>
     <div class="row q-col-gutter-lg">
-      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
+      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
         <!-- Input: Company name -->
         <form-field-text-required
           v-model="company.name"
@@ -138,10 +138,10 @@ export default defineComponent({
           data-cy="form-add-company-name"
         />
       </div>
-      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
+      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
         <!-- Input: VAT ID -->
         <form-field-business-id
-          v-if="isOrganizationCompany"
+          v-if="isVatShown"
           v-model="company.vatId"
           name="vatId"
           :label="$t('form.labelBusinessId')"

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -12,10 +12,11 @@
  * @props
  * - `modelValue` (Object, required): The object representing the form state.
  * - `organizationType` (String as OrganizationType,
- *                       default: OrganizationType.company): The type of organization.
+ *     default: OrganizationType.company): The type of
+ *     organization.
  * - `variant` (String as FormAddCompanyVariantProp,
- *              default: FormAddCompanyVariantProp.default): The variant of the form.
- *                                                           `simple` only shows `name` and `vatId` fields.
+ *     default: FormAddCompanyVariantProp.default): The variant of the
+ *     form. `simple` only shows `name` and `vatId` fields.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
@@ -85,11 +86,15 @@ export default defineComponent({
 
     const addressIndex = 0;
 
-    const isVatShown = computed((): boolean => {
+    const isOrganizationCompany = computed((): boolean => {
+      if (!props.organizationType) {
+        return true;
+      }
       return props.organizationType === OrganizationType.company;
     });
 
     const { getOrganizationLabels } = useOrganizations();
+
     const titleDialog = computed((): string => {
       return getOrganizationLabels(props.organizationType).labelShort;
     });
@@ -99,7 +104,7 @@ export default defineComponent({
       company,
       titleDialog,
       OrganizationType,
-      isVatShown,
+      isOrganizationCompany,
       isFilled,
       onUpdate,
       FormAddCompanyVariantProp,
@@ -118,7 +123,7 @@ export default defineComponent({
         {{ titleDialog }}
       </h3>
       <p
-        v-if="variant === FormAddCompanyVariantProp.default"
+        v-if="variant === FormAddCompanyVariantProp.default && isOrganizationCompany"
         class="q-mt-sm"
         data-cy="form-add-company-permission"
       >
@@ -126,7 +131,7 @@ export default defineComponent({
       </p>
     </div>
     <div class="row q-col-gutter-lg">
-      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
+      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
         <!-- Input: Company name -->
         <form-field-text-required
           v-model="company.name"
@@ -136,10 +141,10 @@ export default defineComponent({
           data-cy="form-add-company-name"
         />
       </div>
-      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
+      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
         <!-- Input: VAT ID -->
         <form-field-business-id
-          v-if="isVatShown"
+          v-if="isOrganizationCompany"
           v-model="company.vatId"
           name="vatId"
           :label="$t('form.labelBusinessId')"

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -86,7 +86,7 @@ export default defineComponent({
 
     const addressIndex = 0;
 
-    const isVatShown = computed((): boolean => {
+    const isOrganizationCompany = computed((): boolean => {
       return props.organizationType === OrganizationType.company;
     });
 
@@ -101,7 +101,7 @@ export default defineComponent({
       company,
       titleDialog,
       OrganizationType,
-      isVatShown,
+      isOrganizationCompany,
       isFilled,
       onUpdate,
       FormAddCompanyVariantProp,
@@ -120,7 +120,9 @@ export default defineComponent({
         {{ titleDialog }}
       </h3>
       <p
-        v-if="variant === FormAddCompanyVariantProp.default && isOrganizationCompany"
+        v-if="
+          variant === FormAddCompanyVariantProp.default && isOrganizationCompany
+        "
         class="q-mt-sm"
         data-cy="form-add-company-permission"
       >
@@ -128,7 +130,7 @@ export default defineComponent({
       </p>
     </div>
     <div class="row q-col-gutter-lg">
-      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
+      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
         <!-- Input: Company name -->
         <form-field-text-required
           v-model="company.name"
@@ -138,10 +140,10 @@ export default defineComponent({
           data-cy="form-add-company-name"
         />
       </div>
-      <div class="col-12" :class="{ 'col-sm-6': isVatShown }">
+      <div class="col-12" :class="{ 'col-sm-6': isOrganizationCompany }">
         <!-- Input: VAT ID -->
         <form-field-business-id
-          v-if="isVatShown"
+          v-if="isOrganizationCompany"
           v-model="company.vatId"
           name="vatId"
           :label="$t('form.labelBusinessId')"

--- a/src/components/form/FormFieldOptionGroup.vue
+++ b/src/components/form/FormFieldOptionGroup.vue
@@ -82,7 +82,7 @@ export default defineComponent({
         icon: 'flight_takeoff',
       },
       {
-        label: i18n.global.t('form.participation.labelFamilyShort'),
+        label: i18n.global.t('form.participation.labelFamily'),
         value: OrganizationType.family,
         icon: 'flight_land',
       },

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -16,7 +16,7 @@
  *   representing the options.
  * - `organizationLevel` (OrganizationLevel, required): The organization
  *   level - table is used for organization or team selection.
- * - `organizationType` (OrganizationType,
+ * - `organizationType` (OrganizationType, required,
  *   default: OrganizationType.organization): The organization type.
  *
  * @events
@@ -50,6 +50,7 @@ import FormAddCompany from '../form/FormAddCompany.vue';
 import FormAddTeam from '../form/FormAddTeam.vue';
 
 // composables
+import { useOrganization } from '../../composables/useOrganization';
 import { useSelectTable } from '../../composables/useSelectTable';
 import { useValidation } from '../../composables/useValidation';
 
@@ -87,6 +88,7 @@ export default defineComponent({
     },
     organizationType: {
       type: String as () => OrganizationType,
+      required: true,
       default: OrganizationType.company,
     },
   },
@@ -172,8 +174,42 @@ export default defineComponent({
       }
     };
 
-    const { label, labelButton, labelButtonDialog, titleDialog } =
-      useSelectTable(props.organizationLevel);
+    const { getOrganizationLabels } = useOrganization();
+    const { getSelectTableLabels } = useSelectTable();
+
+    const label = computed(() => {
+      // if level is organization, show label for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).labelName;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).label;
+    });
+
+    const buttonAddNew = computed(() => {
+      return getSelectTableLabels(props.organizationLevel).buttonAddNew;
+    });
+
+    const buttonDialog = computed(() => {
+      // if level is organization, show button label for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).buttonDialog;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).buttonDialog;
+    });
+
+    const titleDialog = computed(() => {
+      // if level is organization, show title for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).titleDialog;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).titleDialog;
+    });
 
     return {
       borderRadius,
@@ -184,8 +220,8 @@ export default defineComponent({
       inputValue,
       isDialogOpen,
       label,
-      labelButton,
-      labelButtonDialog,
+      buttonAddNew,
+      buttonDialog,
       query,
       teamNew,
       titleDialog,
@@ -304,7 +340,7 @@ export default defineComponent({
           >
             <!-- Label -->
             <span class="inline-block q-pl-xs">
-              {{ labelButton }}
+              {{ buttonAddNew }}
             </span>
           </q-btn>
         </q-card-section>
@@ -348,7 +384,7 @@ export default defineComponent({
                   data-cy="dialog-button-submit"
                   @click="onSubmit"
                 >
-                  {{ labelButtonDialog }}
+                  {{ buttonDialog }}
                 </q-btn>
               </div>
             </div>

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -18,7 +18,7 @@
  */
 
 // libraries
-import { defineComponent, computed } from 'vue';
+import { computed, defineComponent } from 'vue';
 
 // components
 import FormFieldSelectTable from '../form/FormFieldSelectTable.vue';

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -252,9 +252,7 @@ export default defineComponent({
     const { getOrganizationLabels } = useOrganizations();
 
     const formFieldLabel = computed(() => {
-      return props.label
-        ? props.label
-        : getOrganizationLabels(props.organizationType).label;
+      return getOrganizationLabels(props.organizationType).label;
     });
 
     const addNewOrganizationDialogTitle = computed(() => {

--- a/src/composables/useOrganization.ts
+++ b/src/composables/useOrganization.ts
@@ -8,6 +8,7 @@ import { OrganizationType } from '../components/types/Organization';
 export type OrganizationLabels = {
   titleDialog: string;
   label: string;
+  labelName: string;
   labelShort: string;
   buttonDialog: string;
 };
@@ -21,6 +22,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddCompany'),
           label: i18n.global.t('form.labelCompany'), // used in register coordinator form
+          labelName: i18n.global.t('form.company.labelCompany'),
           labelShort: i18n.global.t('form.labelCompanyShort'), // used in "add new" dialog
           buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
         };
@@ -28,6 +30,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddSchool'),
           label: i18n.global.t('form.labelSchool'), // used in register coordinator form
+          labelName: i18n.global.t('form.company.labelSchool'),
           labelShort: i18n.global.t('form.labelSchoolShort'), // used in "add new" dialog
           buttonDialog: i18n.global.t('form.company.buttonAddSchool'),
         };
@@ -35,6 +38,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddFamily'),
           label: i18n.global.t('form.labelFamily'), // used in register coordinator form
+          labelName: i18n.global.t('form.company.labelFamily'),
           labelShort: i18n.global.t('form.labelFamilyShort'), // used in "add new" dialog
           buttonDialog: i18n.global.t('form.company.buttonAddFamily'),
         };

--- a/src/composables/useOrganization.ts
+++ b/src/composables/useOrganization.ts
@@ -1,0 +1,54 @@
+// composables
+import { i18n } from '../boot/i18n';
+
+// enums
+import { OrganizationType } from '../components/types/Organization';
+
+// types
+export type OrganizationLabels = {
+  titleDialog: string;
+  label: string;
+  labelShort: string;
+  buttonDialog: string;
+};
+
+export const useOrganization = () => {
+  const getOrganizationLabels = (
+    organizationType: OrganizationType,
+  ): OrganizationLabels => {
+    switch (organizationType) {
+      case OrganizationType.company:
+        return {
+          titleDialog: i18n.global.t('form.company.titleAddCompany'),
+          label: i18n.global.t('form.labelCompany'), // used in register coordinator form
+          labelShort: i18n.global.t('form.labelCompanyShort'), // used in "add new" dialog
+          buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
+        };
+      case OrganizationType.school:
+        return {
+          titleDialog: i18n.global.t('form.company.titleAddSchool'),
+          label: i18n.global.t('form.labelSchool'), // used in register coordinator form
+          labelShort: i18n.global.t('form.labelSchoolShort'), // used in "add new" dialog
+          buttonDialog: i18n.global.t('form.company.buttonAddSchool'),
+        };
+      case OrganizationType.family:
+        return {
+          titleDialog: i18n.global.t('form.company.titleAddFamily'),
+          label: i18n.global.t('form.labelFamily'), // used in register coordinator form
+          labelShort: i18n.global.t('form.labelFamilyShort'), // used in "add new" dialog
+          buttonDialog: i18n.global.t('form.company.buttonAddFamily'),
+        };
+      default:
+        return {
+          titleDialog: '',
+          label: '',
+          labelShort: '',
+          buttonDialog: '',
+        };
+    }
+  };
+
+  return {
+    getOrganizationLabels,
+  };
+};

--- a/src/composables/useOrganization.ts
+++ b/src/composables/useOrganization.ts
@@ -23,7 +23,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddCompany'),
           label: i18n.global.t('form.labelCompany'), // used in register coordinator form
-          labelName: i18n.global.t('form.company.labelCompany'),
+          labelName: i18n.global.t('form.company.labelCompany'), // used in SelectTable
           labelShort: i18n.global.t('form.labelCompanyShort'), // used in "add new" dialog
           messageNoResult: i18n.global.t('form.messageNoCompany'),
           buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
@@ -32,7 +32,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddSchool'),
           label: i18n.global.t('form.labelSchool'), // used in register coordinator form
-          labelName: i18n.global.t('form.company.labelSchool'),
+          labelName: i18n.global.t('form.company.labelSchool'), // used in SelectTable
           labelShort: i18n.global.t('form.labelSchoolShort'), // used in "add new" dialog
           messageNoResult: i18n.global.t('form.messageNoSchool'),
           buttonDialog: i18n.global.t('form.company.buttonAddSchool'),
@@ -41,7 +41,7 @@ export const useOrganization = () => {
         return {
           titleDialog: i18n.global.t('form.company.titleAddFamily'),
           label: i18n.global.t('form.labelFamily'), // used in register coordinator form
-          labelName: i18n.global.t('form.company.labelFamily'),
+          labelName: i18n.global.t('form.company.labelFamily'), // used in SelectTable
           labelShort: i18n.global.t('form.labelFamilyShort'), // used in "add new" dialog
           messageNoResult: i18n.global.t('form.messageNoFamily'),
           buttonDialog: i18n.global.t('form.company.buttonAddFamily'),

--- a/src/composables/useOrganization.ts
+++ b/src/composables/useOrganization.ts
@@ -10,6 +10,7 @@ export type OrganizationLabels = {
   label: string;
   labelName: string;
   labelShort: string;
+  messageNoResult: string;
   buttonDialog: string;
 };
 
@@ -24,6 +25,7 @@ export const useOrganization = () => {
           label: i18n.global.t('form.labelCompany'), // used in register coordinator form
           labelName: i18n.global.t('form.company.labelCompany'),
           labelShort: i18n.global.t('form.labelCompanyShort'), // used in "add new" dialog
+          messageNoResult: i18n.global.t('form.messageNoCompany'),
           buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
         };
       case OrganizationType.school:
@@ -32,6 +34,7 @@ export const useOrganization = () => {
           label: i18n.global.t('form.labelSchool'), // used in register coordinator form
           labelName: i18n.global.t('form.company.labelSchool'),
           labelShort: i18n.global.t('form.labelSchoolShort'), // used in "add new" dialog
+          messageNoResult: i18n.global.t('form.messageNoSchool'),
           buttonDialog: i18n.global.t('form.company.buttonAddSchool'),
         };
       case OrganizationType.family:
@@ -40,13 +43,16 @@ export const useOrganization = () => {
           label: i18n.global.t('form.labelFamily'), // used in register coordinator form
           labelName: i18n.global.t('form.company.labelFamily'),
           labelShort: i18n.global.t('form.labelFamilyShort'), // used in "add new" dialog
+          messageNoResult: i18n.global.t('form.messageNoFamily'),
           buttonDialog: i18n.global.t('form.company.buttonAddFamily'),
         };
       default:
         return {
           titleDialog: '',
           label: '',
+          labelName: '',
           labelShort: '',
+          messageNoResult: '',
           buttonDialog: '',
         };
     }

--- a/src/composables/useSelectTable.ts
+++ b/src/composables/useSelectTable.ts
@@ -1,61 +1,54 @@
-// libraries
-import { computed } from 'vue';
-
 // composables
 import { i18n } from '../boot/i18n';
 
 // enums
 import { OrganizationLevel } from '../components/types/Organization';
 
-export const useSelectTable = (organizationLevel: OrganizationLevel) => {
-  const label = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.labelTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.labelSubsidiary');
-      default:
-        return i18n.global.t('form.company.labelCompany');
-    }
-  });
+// types
+export type SelectTableLabels = {
+  label: string;
+  buttonAddNew: string;
+  buttonDialog: string;
+  titleDialog: string;
+};
 
-  const labelButton = computed(() => {
+export const useSelectTable = () => {
+  const getSelectTableLabels = (
+    organizationLevel: OrganizationLevel,
+  ): SelectTableLabels => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
-        return i18n.global.t('form.team.buttonAddTeam');
+        return {
+          label: i18n.global.t('form.team.labelTeam'),
+          buttonAddNew: i18n.global.t('form.team.buttonAddTeam'),
+          buttonDialog: i18n.global.t('form.team.buttonAddTeam'),
+          titleDialog: i18n.global.t('form.team.titleAddTeam'),
+        };
       case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
+        return {
+          label: i18n.global.t('form.subsidiary.labelSubsidiary'),
+          buttonAddNew: i18n.global.t('form.subsidiary.buttonAddSubsidiary'),
+          buttonDialog: i18n.global.t('form.subsidiary.buttonAddSubsidiary'),
+          titleDialog: i18n.global.t('form.subsidiary.titleAddSubsidiary'),
+        };
+      case OrganizationLevel.organization:
+        return {
+          label: i18n.global.t('form.company.labelCompany'),
+          buttonAddNew: i18n.global.t('register.challenge.buttonAddCompany'),
+          buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
+          titleDialog: i18n.global.t('form.company.titleAddCompany'),
+        };
       default:
-        return i18n.global.t('register.challenge.buttonAddCompany');
+        return {
+          label: '',
+          buttonAddNew: '',
+          buttonDialog: '',
+          titleDialog: '',
+        };
     }
-  });
-
-  const labelButtonDialog = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.buttonAddTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
-      default:
-        return i18n.global.t('form.company.buttonAddCompany');
-    }
-  });
-
-  const titleDialog = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.titleAddTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.titleAddSubsidiary');
-      default:
-        return i18n.global.t('form.company.titleAddCompany');
-    }
-  });
+  };
 
   return {
-    label,
-    labelButton,
-    labelButtonDialog,
-    titleDialog,
+    getSelectTableLabels,
   };
 };

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -127,6 +127,9 @@ export default defineComponent({
     const { getOrganizationLabels } = useOrganization();
 
     const organizationStepTitle = computed(() => {
+      if (!organizationType.value) {
+        return getOrganizationLabels(OrganizationType.company).labelShort;
+      }
       return getOrganizationLabels(organizationType.value).labelShort;
     });
 

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -41,7 +41,7 @@ import TopBarCountdown from 'src/components/global/TopBarCountdown.vue';
 
 // composables
 import { useStepperValidation } from 'src/composables/useStepperValidation';
-
+import { useOrganization } from 'src/composables/useOrganization';
 // enums
 import { OrganizationType } from 'src/components/types/Organization';
 
@@ -124,6 +124,12 @@ export default defineComponent({
       },
     });
 
+    const { getOrganizationLabels } = useOrganization();
+
+    const organizationStepTitle = computed(() => {
+      return getOrganizationLabels(organizationType.value).labelShort;
+    });
+
     const step = ref(1);
     const stepperRef = ref<typeof QStepper | null>(null);
     const stepCompanyRef = ref<typeof QForm | null>(null);
@@ -170,6 +176,7 @@ export default defineComponent({
       iconImgSrcStepper6,
       activeIconImgSrcStepper6,
       doneIconImgSrcStepper6,
+      organizationStepTitle,
       organizationType,
       onBack,
       onContinue,
@@ -322,7 +329,7 @@ export default defineComponent({
           <!-- Step: Company -->
           <q-step
             :name="4"
-            :title="$t('register.challenge.titleStepCompany')"
+            :title="organizationStepTitle"
             :icon="iconImgSrcStepper4"
             :active-icon="activeIconImgSrcStepper4"
             :done-icon="doneIconImgSrcStepper4"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,13 +40,12 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
-  const enabled = false;
+
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    (!window.Cypress ||
-      window.Cypress.spec.name === 'register.spec.cy.js' ||
-      window.Cypress.spec.name === 'router_rules.cy.js') &&
-    enabled
+    !window.Cypress ||
+    window.Cypress.spec.name === 'register.spec.cy.js' ||
+    window.Cypress.spec.name === 'router_rules.cy.js'
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,12 +40,13 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
-
+  const enabled = false;
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    !window.Cypress ||
-    window.Cypress.spec.name === 'register.spec.cy.js' ||
-    window.Cypress.spec.name === 'router_rules.cy.js'
+    (!window.Cypress ||
+      window.Cypress.spec.name === 'register.spec.cy.js' ||
+      window.Cypress.spec.name === 'router_rules.cy.js') &&
+    enabled
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,14 +41,11 @@ export default route(function (/* { store, ssrContext } */) {
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
 
-  const enabled = false;
-
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    (!window.Cypress ||
-      window.Cypress.spec.name === 'register.spec.cy.js' ||
-      window.Cypress.spec.name === 'router_rules.cy.js') &&
-    enabled
+    !window.Cypress ||
+    window.Cypress.spec.name === 'register.spec.cy.js' ||
+    window.Cypress.spec.name === 'router_rules.cy.js'
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,11 +41,14 @@ export default route(function (/* { store, ssrContext } */) {
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
 
+  const enabled = false;
+
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    !window.Cypress ||
-    window.Cypress.spec.name === 'register.spec.cy.js' ||
-    window.Cypress.spec.name === 'router_rules.cy.js'
+    (!window.Cypress ||
+      window.Cypress.spec.name === 'register.spec.cy.js' ||
+      window.Cypress.spec.name === 'router_rules.cy.js') &&
+    enabled
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -49,7 +49,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     setPersonalDetails(personalDetails: RegisterChallengePersonalDetailsForm) {
       Object.assign(this.personalDetails, personalDetails);
     },
-    setOrganizationType(organizationType: OrganizationType) {
+    setOrganizationType(organizationType: OrganizationType | null) {
       this.organizationType = organizationType;
     },
     setOrganizationId(organizationId: number | null) {


### PR DESCRIPTION
Since these changes became quite extensive again, and there are other concerns related to the interdependency of `organizationType` property, I will split this PR into smaller incremental changes.

---

~* Define dynamic labels for organization selects in `useOrganization.ts`.~
~* Update labels in `useSelectTable.ts` to use the same pattern as useOrganization (export object with translated strings).~
~* Use the translated labels to compute dynamic labels based on `OrganizationType`.~

~This is done in:~
~* FormAddCompany.vue~
~* FormFieldSelectTable.vue~
~* FormFieldCompany.vue~

~Where appropriate, also update `organizationType` prop, make it required and specify default (`company`).~

~In `RegisterChallengePage.vue` and `FormSelectOrganization.vue` use the `organizationType` data from `registerChallenge` store, to ensure correct working in the registration process.~