### PR TITLE
src/components: add  FormAddSubsidiary component for displaying subsidiary (address) form fields

### DIFF
--- a/src/components/__tests__/FormAddCompany.cy.js
+++ b/src/components/__tests__/FormAddCompany.cy.js
@@ -13,12 +13,12 @@ const selectorFormTitle = 'form-add-company-title';
 const selectorFormPermission = 'form-add-company-permission';
 const selectorFormName = 'form-add-company-name';
 const selectorFormVatId = 'form-add-company-vat-id';
-const selectorFormStreet = 'form-add-company-street';
-const selectorFormHouseNumber = 'form-add-company-house-number';
-const selectorFormCity = 'form-add-company-city';
-const selectorFormZip = 'form-add-company-zip';
-const selectorFormCityChallenge = 'form-add-company-city-challenge';
-const selectorFormDepartment = 'form-add-company-department';
+const selectorFormStreet = 'form-add-subsidiary-street';
+const selectorFormHouseNumber = 'form-add-subsidiary-house-number';
+const selectorFormCity = 'form-add-subsidiary-city';
+const selectorFormZip = 'form-add-subsidiary-zip';
+const selectorFormCityChallenge = 'form-add-subsidiary-city-challenge';
+const selectorFormDepartment = 'form-add-subsidiary-department';
 
 describe('<FormAddCompany>', () => {
   // default form state (make a deep copy of empty state)

--- a/src/components/__tests__/FormAddSubsidiary.cy.js
+++ b/src/components/__tests__/FormAddSubsidiary.cy.js
@@ -44,13 +44,11 @@ describe('<FormAddSubsidiary>', () => {
         testData.cityChallenge = cityChallengeResponse.results[0].id;
         cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
       });
+      model.value = deepObjectWithSimplePropsCopy(emptyData);
       cy.mount(FormAddSubsidiary, {
         props: {
           ...vModelAdapter(model),
         },
-      }).then(() => {
-        // wait for Vue instance to mount
-        model.value = deepObjectWithSimplePropsCopy(emptyData);
       });
       cy.viewport('macbook-16');
     });
@@ -65,13 +63,11 @@ describe('<FormAddSubsidiary>', () => {
         testData.cityChallenge = cityChallengeResponse.results[0].id;
         cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
       });
+      model.value = deepObjectWithSimplePropsCopy(emptyData);
       cy.mount(FormAddSubsidiary, {
         props: {
           ...vModelAdapter(model),
         },
-      }).then(() => {
-        // wait for Vue instance to mount
-        model.value = deepObjectWithSimplePropsCopy(emptyData);
       });
 
       cy.viewport('iphone-6');

--- a/src/components/__tests__/FormAddSubsidiary.cy.js
+++ b/src/components/__tests__/FormAddSubsidiary.cy.js
@@ -1,0 +1,141 @@
+import { ref, nextTick } from 'vue';
+import FormAddSubsidiary from 'components/form/FormAddSubsidiary.vue';
+import { i18n } from '../../boot/i18n';
+import { vModelAdapter } from '../../../test/cypress/utils';
+import { deepObjectWithSimplePropsCopy } from '../../../src/utils';
+
+// selectors
+const selectorFormStreet = 'form-add-subsidiary-street';
+const selectorFormHouseNumber = 'form-add-subsidiary-house-number';
+const selectorFormCity = 'form-add-subsidiary-city';
+const selectorFormZip = 'form-add-subsidiary-zip';
+const selectorFormCityChallenge = 'form-add-subsidiary-city-challenge';
+const selectorFormDepartment = 'form-add-subsidiary-department';
+
+// variables
+const testData = {
+  street: 'Main Street',
+  houseNumber: '42',
+  city: 'Praha',
+  zip: '11000',
+  cityChallenge: '', // added from fixture
+  department: 'IT Department',
+};
+
+const emptyData = {
+  street: '',
+  houseNumber: '',
+  city: '',
+  zip: '',
+  cityChallenge: '',
+  department: '',
+};
+
+const model = ref(deepObjectWithSimplePropsCopy(emptyData));
+
+describe('<FormAddSubsidiary>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext([], 'index.component', i18n);
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.fixture('cityChallengeResponse').then((cityChallengeResponse) => {
+        testData.cityChallenge = cityChallengeResponse.results[0].id;
+        cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
+      });
+
+      cy.mount(FormAddSubsidiary, {
+        props: {
+          ...vModelAdapter(model),
+        },
+      }).then(() => {
+        // wait for Vue instance to mount
+        model.value = deepObjectWithSimplePropsCopy(emptyData);
+      });
+
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+    desktopTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.fixture('cityChallengeResponse').then((cityChallengeResponse) => {
+        testData.cityChallenge = cityChallengeResponse.results[0].id;
+        cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
+      });
+
+      cy.mount(FormAddSubsidiary, {
+        props: {
+          ...vModelAdapter(model),
+        },
+      }).then(() => {
+        // wait for Vue instance to mount
+        model.value = deepObjectWithSimplePropsCopy(emptyData);
+      });
+
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    // address fields
+    cy.dataCy(selectorFormStreet).should('be.visible');
+    cy.dataCy(selectorFormHouseNumber).should('be.visible');
+    cy.dataCy(selectorFormCity).should('be.visible');
+    cy.dataCy(selectorFormZip).should('be.visible');
+    cy.dataCy(selectorFormCityChallenge).should('be.visible');
+    cy.dataCy(selectorFormDepartment).should('be.visible');
+  });
+
+  it('updates model when fields are filled', () => {
+    // street
+    cy.dataCy(selectorFormStreet).find('input').type(testData.street);
+    cy.wrap(nextTick());
+    cy.wrap(model).its('value.street').should('equal', testData.street);
+    // house number
+    cy.dataCy(selectorFormHouseNumber).find('input').type(testData.houseNumber);
+    cy.wrap(nextTick());
+    cy.wrap(model)
+      .its('value.houseNumber')
+      .should('equal', testData.houseNumber);
+    // city
+    cy.dataCy(selectorFormCity).find('input').type(testData.city);
+    cy.wrap(nextTick());
+    cy.wrap(model).its('value.city').should('equal', testData.city);
+    // ZIP
+    cy.dataCy(selectorFormZip).find('input').type(testData.zip);
+    cy.wrap(nextTick());
+    cy.wrap(model).its('value.zip').should('equal', testData.zip);
+    // city challenge
+    cy.get('@cityChallenge').then((city) => {
+      cy.dataCy(selectorFormCityChallenge).click();
+      cy.get('.q-menu').contains(city.name).click();
+      cy.wrap(nextTick());
+      cy.wrap(model)
+        .its('value.cityChallenge')
+        .should('equal', testData.cityChallenge);
+    });
+    // department
+    cy.dataCy(selectorFormDepartment).type(testData.department);
+    cy.wrap(nextTick());
+    cy.wrap(model).its('value.department').should('equal', testData.department);
+    cy.wrap(model).should('deep.include', {
+      value: testData,
+    });
+  });
+}
+
+function desktopTests() {
+  it('renders some fields side by side', () => {
+    cy.testElementsSideBySide(selectorFormStreet, selectorFormHouseNumber);
+    cy.testElementsSideBySide(selectorFormCity, selectorFormZip);
+  });
+}

--- a/src/components/__tests__/FormAddSubsidiary.cy.js
+++ b/src/components/__tests__/FormAddSubsidiary.cy.js
@@ -1,4 +1,4 @@
-import { ref, nextTick } from 'vue';
+import { ref } from 'vue';
 import FormAddSubsidiary from 'components/form/FormAddSubsidiary.vue';
 import { i18n } from '../../boot/i18n';
 import { vModelAdapter } from '../../../test/cypress/utils';
@@ -44,7 +44,6 @@ describe('<FormAddSubsidiary>', () => {
         testData.cityChallenge = cityChallengeResponse.results[0].id;
         cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
       });
-
       cy.mount(FormAddSubsidiary, {
         props: {
           ...vModelAdapter(model),
@@ -53,7 +52,6 @@ describe('<FormAddSubsidiary>', () => {
         // wait for Vue instance to mount
         model.value = deepObjectWithSimplePropsCopy(emptyData);
       });
-
       cy.viewport('macbook-16');
     });
 
@@ -67,7 +65,6 @@ describe('<FormAddSubsidiary>', () => {
         testData.cityChallenge = cityChallengeResponse.results[0].id;
         cy.wrap(cityChallengeResponse.results[0]).as('cityChallenge');
       });
-
       cy.mount(FormAddSubsidiary, {
         props: {
           ...vModelAdapter(model),
@@ -98,34 +95,28 @@ function coreTests() {
   it('updates model when fields are filled', () => {
     // street
     cy.dataCy(selectorFormStreet).find('input').type(testData.street);
-    cy.wrap(nextTick());
     cy.wrap(model).its('value.street').should('equal', testData.street);
     // house number
     cy.dataCy(selectorFormHouseNumber).find('input').type(testData.houseNumber);
-    cy.wrap(nextTick());
     cy.wrap(model)
       .its('value.houseNumber')
       .should('equal', testData.houseNumber);
     // city
     cy.dataCy(selectorFormCity).find('input').type(testData.city);
-    cy.wrap(nextTick());
     cy.wrap(model).its('value.city').should('equal', testData.city);
     // ZIP
     cy.dataCy(selectorFormZip).find('input').type(testData.zip);
-    cy.wrap(nextTick());
     cy.wrap(model).its('value.zip').should('equal', testData.zip);
     // city challenge
     cy.get('@cityChallenge').then((city) => {
       cy.dataCy(selectorFormCityChallenge).click();
       cy.get('.q-menu').contains(city.name).click();
-      cy.wrap(nextTick());
       cy.wrap(model)
         .its('value.cityChallenge')
         .should('equal', testData.cityChallenge);
     });
     // department
     cy.dataCy(selectorFormDepartment).type(testData.department);
-    cy.wrap(nextTick());
     cy.wrap(model).its('value.department').should('equal', testData.department);
     cy.wrap(model).should('deep.include', {
       value: testData,

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -36,6 +36,7 @@ describe('<FormFieldCompanyAddress>', () => {
         'buttonAddSubsidiary',
         'hintAddress',
         'labelAddress',
+        'textSubsidiaryAddress',
         'titleAddAddress',
       ],
       'form.company',
@@ -100,12 +101,20 @@ describe('<FormFieldCompanyAddress>', () => {
     it('renders dialog for adding a new address', () => {
       cy.dataCy('button-add-address').click();
       cy.dataCy('dialog-add-address').should('be.visible');
+      // title
       cy.dataCy('dialog-add-address')
         .find('h3')
         .should('be.visible')
         .and('have.css', 'font-size', '20px')
         .and('have.css', 'font-weight', '500')
         .and('contain', i18n.global.t('form.company.titleAddAddress'));
+      // message
+      cy.dataCy('add-subsidiary-text')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.textSubsidiaryAddress'));
+      // form
+      cy.dataCy('form-add-subsidiary').should('be.visible');
+      // buttons
       cy.dataCy('dialog-button-cancel')
         .should('be.visible')
         .and('have.text', i18n.global.t('navigation.discard'));

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -180,11 +180,13 @@ describe('<FormFieldSelectTable>', () => {
       // fill in form
       cy.dataCy('form-add-company-name').find('input').type('AutoMat');
       cy.dataCy('form-add-company-vat-id').find('input').type('87654321');
-      cy.dataCy('form-add-company-street').find('input').type('Slezská');
-      cy.dataCy('form-add-company-house-number').find('input').type('2033/11');
-      cy.dataCy('form-add-company-city').find('input').type('Praha');
-      cy.dataCy('form-add-company-zip').find('input').type('120 00');
-      cy.dataCy('form-add-company-city-challenge').click();
+      cy.dataCy('form-add-subsidiary-street').find('input').type('Slezská');
+      cy.dataCy('form-add-subsidiary-house-number')
+        .find('input')
+        .type('2033/11');
+      cy.dataCy('form-add-subsidiary-city').find('input').type('Praha');
+      cy.dataCy('form-add-subsidiary-zip').find('input').type('120 00');
+      cy.dataCy('form-add-subsidiary-city-challenge').click();
       cy.get('.q-menu').should('be.visible').find('.q-item').first().click();
       // submit
       cy.dataCy('dialog-button-submit').click();

--- a/src/components/enums/Form.ts
+++ b/src/components/enums/Form.ts
@@ -1,0 +1,8 @@
+export enum FormSubsidiaryAddressFields {
+  street = 'street',
+  houseNumber = 'houseNumber',
+  city = 'city',
+  zip = 'zip',
+  cityChallenge = 'cityChallenge',
+  department = 'deparment',
+}

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -32,6 +32,7 @@
 import { computed, defineComponent, nextTick, ref } from 'vue';
 
 // components
+import FormAddSubsidiary from './FormAddSubsidiary.vue';
 import FormFieldTextRequired from '../global/FormFieldTextRequired.vue';
 import FormFieldBusinessId from '../form/FormFieldBusinessId.vue';
 
@@ -42,11 +43,12 @@ import { useValidation } from '../../composables/useValidation';
 import { OrganizationType } from '../types/Organization';
 
 // types
-import type { FormCompanyFields, FormOption } from '../types/Form';
+import type { FormCompanyFields } from '../types/Form';
 
 export default defineComponent({
   name: 'FormAddCompany',
   components: {
+    FormAddSubsidiary,
     FormFieldTextRequired,
     FormFieldBusinessId,
   },
@@ -66,21 +68,6 @@ export default defineComponent({
   emits: ['update:modelValue'],
   setup(props, { emit }) {
     const company = ref(props.modelValue);
-
-    const optionsCityChallenge: FormOption[] = [
-      {
-        label: 'City 1',
-        value: 'city-1',
-      },
-      {
-        label: 'City 2',
-        value: 'city-2',
-      },
-      {
-        label: 'City 3',
-        value: 'city-3',
-      },
-    ];
 
     const onUpdate = (): void => {
       // wait for next tick to emit the value after update
@@ -103,7 +90,6 @@ export default defineComponent({
     return {
       addressIndex,
       company,
-      optionsCityChallenge,
       OrganizationType,
       isVatShown,
       isFilled,
@@ -168,90 +154,12 @@ export default defineComponent({
           {{ $t('form.company.textSubsidiaryAddress') }}
         </p>
       </div>
-      <div class="row q-col-gutter-lg">
-        <div class="col-12 col-sm-6">
-          <form-field-text-required
-            v-model="company.address[addressIndex].street"
-            name="street"
-            label="form.labelStreet"
-            @update:model-value="onUpdate"
-            data-cy="form-add-company-street"
-          />
-        </div>
-        <div class="col-12 col-sm-6">
-          <form-field-text-required
-            v-model="company.address[addressIndex].houseNumber"
-            name="houseNumber"
-            label="form.labelHouseNumber"
-            @update:model-value="onUpdate"
-            data-cy="form-add-company-house-number"
-          />
-        </div>
-        <div class="col-12 col-sm-6">
-          <form-field-text-required
-            v-model="company.address[addressIndex].city"
-            name="city"
-            label="form.labelCity"
-            @update:model-value="onUpdate"
-            data-cy="form-add-company-city"
-          />
-        </div>
-        <div class="col-12 col-sm-6">
-          <form-field-text-required
-            v-model="company.address[addressIndex].zip"
-            name="zip"
-            label="form.labelZip"
-            @update:model-value="onUpdate"
-            data-cy="form-add-company-zip"
-          />
-        </div>
-        <div class="col-12">
-          <label
-            for="form-city-challenge"
-            class="text-caption text-bold text-gray-10"
-            >{{ $t('form.company.labelCityChallenge') }}</label
-          >
-          <q-select
-            dense
-            outlined
-            emit-value
-            map-options
-            v-model="company.address[addressIndex].cityChallenge"
-            :rules="[
-              (val) =>
-                isFilled(val) ||
-                $t('form.messageFieldRequired', {
-                  fieldName: $t('form.labelCity'),
-                }),
-            ]"
-            id="form-city-challenge"
-            :hint="$t('form.company.hintCityChallenge')"
-            :options="optionsCityChallenge"
-            class="q-mt-sm"
-            data-cy="form-add-company-city-challenge"
-          ></q-select>
-        </div>
-        <div class="col-12">
-          <label
-            for="form-department"
-            class="text-caption text-bold text-gray-10"
-          >
-            {{ $t('form.company.labelDepartment') }}
-          </label>
-          <q-input
-            dense
-            outlined
-            lazy-rules
-            hide-bottom-space
-            v-model="company.address[addressIndex].department"
-            id="form-department"
-            name="department"
-            :hint="$t('form.company.hintDepartment')"
-            class="q-mt-sm"
-            data-cy="form-add-company-department"
-          />
-        </div>
-      </div>
+      <!-- TODO: validate the method of accessing address -->
+      <form-add-subsidiary
+        v-model="company.address[addressIndex]"
+        @update:model-value="onUpdate"
+        data-cy="form-add-company-subsidiary"
+      />
     </div>
   </div>
 </template>

--- a/src/components/form/FormAddSubsidiary.vue
+++ b/src/components/form/FormAddSubsidiary.vue
@@ -38,6 +38,9 @@ import cityChallengeResponse from '../../../test/cypress/fixtures/cityChallengeR
 // types
 import type { FormCompanyAddressFields, FormOption } from '../types/Form';
 
+// enums
+import { FormSubsidiaryAddressFields } from '../enums/Form';
+
 export default defineComponent({
   name: 'FormAddSubsidiary',
   components: {
@@ -74,6 +77,7 @@ export default defineComponent({
       subsidiary,
       isFilled,
       optionsCityChallenge,
+      FormSubsidiaryAddressFields,
     };
   },
 });
@@ -85,7 +89,7 @@ export default defineComponent({
       <!-- Street -->
       <form-field-text-required
         v-model="subsidiary.street"
-        name="street"
+        :name="FormSubsidiaryAddressFields.street"
         label="form.labelStreet"
         data-cy="form-add-subsidiary-street"
       />
@@ -94,7 +98,7 @@ export default defineComponent({
       <!-- House number -->
       <form-field-text-required
         v-model="subsidiary.houseNumber"
-        name="houseNumber"
+        :name="FormSubsidiaryAddressFields.houseNumber"
         label="form.labelHouseNumber"
         data-cy="form-add-subsidiary-house-number"
       />
@@ -103,7 +107,7 @@ export default defineComponent({
       <!-- City -->
       <form-field-text-required
         v-model="subsidiary.city"
-        name="city"
+        :name="FormSubsidiaryAddressFields.city"
         label="form.labelCity"
         data-cy="form-add-subsidiary-city"
       />
@@ -112,7 +116,7 @@ export default defineComponent({
       <!-- Zip -->
       <form-field-text-required
         v-model="subsidiary.zip"
-        name="zip"
+        :name="FormSubsidiaryAddressFields.zip"
         label="form.labelZip"
         data-cy="form-add-subsidiary-zip"
       />
@@ -142,6 +146,7 @@ export default defineComponent({
         :options="optionsCityChallenge"
         class="q-mt-sm"
         data-cy="form-add-subsidiary-city-challenge"
+        :name="FormSubsidiaryAddressFields.cityChallenge"
       ></q-select>
     </div>
     <div class="col-12">
@@ -156,7 +161,7 @@ export default defineComponent({
         hide-bottom-space
         v-model="subsidiary.department"
         id="form-department"
-        name="department"
+        :name="FormSubsidiaryAddressFields.department"
         :hint="$t('form.company.hintDepartment')"
         class="q-mt-sm"
         data-cy="form-add-subsidiary-department"

--- a/src/components/form/FormAddSubsidiary.vue
+++ b/src/components/form/FormAddSubsidiary.vue
@@ -1,0 +1,166 @@
+<script lang="ts">
+/**
+ * FormAddSubsidiary Component
+ *
+ * @description * Use this component to render form for adding subsidiary.
+ *
+ * Note: This component is used in `FormAddCompany` and
+ * `FormFieldCompanyAddress` components.
+ *
+ * @props
+ * - `modelValue` (FormCompanyAddressFields, required): The object representing
+ *   subsidiary address fields.
+ *
+ * @events
+ * - `update:modelValue`: Emitted as a part of v-model structure.
+ *
+ * @components
+ * - `FormFieldTextRequired`: Component to render required fields.
+ *
+ * @example
+ * <form-add-subsidiary v-model="subsidiaryAddress" />
+ *
+ * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=5366-25187&t=5mlrbbYMHyCGAh8l-1)
+ */
+
+// libraries
+import { computed, defineComponent, nextTick } from 'vue';
+
+// components
+import FormFieldTextRequired from '../global/FormFieldTextRequired.vue';
+
+// composables
+import { useValidation } from 'src/composables/useValidation';
+
+// fixtures
+import cityChallengeResponse from '../../../test/cypress/fixtures/cityChallengeResponse.json';
+
+// types
+import type { FormCompanyAddressFields, FormOption } from '../types/Form';
+
+export default defineComponent({
+  name: 'FormAddSubsidiary',
+  components: {
+    FormFieldTextRequired,
+  },
+  props: {
+    modelValue: {
+      type: Object as () => FormCompanyAddressFields,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const subsidiary = computed({
+      get(): FormCompanyAddressFields {
+        return props.modelValue;
+      },
+      set(value: FormCompanyAddressFields) {
+        nextTick((): void => {
+          emit('update:modelValue', value);
+        });
+      },
+    });
+
+    const optionsCityChallenge: FormOption[] =
+      cityChallengeResponse.results.map((city) => ({
+        label: city.name,
+        value: city.id,
+      }));
+
+    const { isFilled } = useValidation();
+
+    return {
+      subsidiary,
+      isFilled,
+      optionsCityChallenge,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="row q-col-gutter-lg" data-cy="form-add-subsidiary">
+    <div class="col-12 col-sm-6">
+      <!-- Street -->
+      <form-field-text-required
+        v-model="subsidiary.street"
+        name="street"
+        label="form.labelStreet"
+        data-cy="form-add-subsidiary-street"
+      />
+    </div>
+    <div class="col-12 col-sm-6">
+      <!-- House number -->
+      <form-field-text-required
+        v-model="subsidiary.houseNumber"
+        name="houseNumber"
+        label="form.labelHouseNumber"
+        data-cy="form-add-subsidiary-house-number"
+      />
+    </div>
+    <div class="col-12 col-sm-6">
+      <!-- City -->
+      <form-field-text-required
+        v-model="subsidiary.city"
+        name="city"
+        label="form.labelCity"
+        data-cy="form-add-subsidiary-city"
+      />
+    </div>
+    <div class="col-12 col-sm-6">
+      <!-- Zip -->
+      <form-field-text-required
+        v-model="subsidiary.zip"
+        name="zip"
+        label="form.labelZip"
+        data-cy="form-add-subsidiary-zip"
+      />
+    </div>
+    <div class="col-12">
+      <!-- City challenge -->
+      <label
+        for="form-city-challenge"
+        class="text-caption text-bold text-gray-10"
+        >{{ $t('form.company.labelCityChallenge') }}</label
+      >
+      <q-select
+        dense
+        outlined
+        emit-value
+        map-options
+        v-model="subsidiary.cityChallenge"
+        :rules="[
+          (val) =>
+            isFilled(val) ||
+            $t('form.messageFieldRequired', {
+              fieldName: $t('form.labelCity'),
+            }),
+        ]"
+        id="form-city-challenge"
+        :hint="$t('form.company.hintCityChallenge')"
+        :options="optionsCityChallenge"
+        class="q-mt-sm"
+        data-cy="form-add-subsidiary-city-challenge"
+      ></q-select>
+    </div>
+    <div class="col-12">
+      <!-- Department (note) -->
+      <label for="form-department" class="text-caption text-bold text-gray-10">
+        {{ $t('form.company.labelDepartment') }}
+      </label>
+      <q-input
+        dense
+        outlined
+        lazy-rules
+        hide-bottom-space
+        v-model="subsidiary.department"
+        id="form-department"
+        name="department"
+        :hint="$t('form.company.hintDepartment')"
+        class="q-mt-sm"
+        data-cy="form-add-subsidiary-department"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -27,10 +27,12 @@
  */
 
 // libraries
-import { computed, defineComponent, ref, watch } from 'vue';
+import { computed, defineComponent, inject, ref, watch } from 'vue';
+import { QForm } from 'quasar';
 
 // components
 import DialogDefault from 'src/components/global/DialogDefault.vue';
+import FormAddSubsidiary from 'src/components/form/FormAddSubsidiary.vue';
 
 // composables
 import { useValidation } from 'src/composables/useValidation';
@@ -40,10 +42,12 @@ import type {
   FormCompanyAddressFields,
   FormOption,
 } from 'src/components/types/Form';
+import type { Logger } from 'src/components/types/Logger';
 
 export default defineComponent({
   name: 'FormFieldCompanyAddress',
   components: {
+    FormAddSubsidiary,
     DialogDefault,
   },
   props: {
@@ -58,10 +62,22 @@ export default defineComponent({
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
+    const formRef = ref<typeof QForm | null>(null);
+    const logger = inject('vuejs3-logger') as Logger | null;
+
     const address = computed<FormCompanyAddressFields | null>({
       get: () => props.modelValue,
       set: (value: FormCompanyAddressFields | null) =>
         emit('update:modelValue', value),
+    });
+
+    const addressNew = ref<FormCompanyAddressFields>({
+      street: '',
+      houseNumber: '',
+      city: '',
+      zip: '',
+      cityChallenge: null,
+      department: '',
     });
 
     watch(
@@ -89,6 +105,10 @@ export default defineComponent({
       const isDialogOpen = ref<boolean>(false);
 
       const onClose = (): void => {
+        if (formRef.value) {
+          formRef.value.reset();
+          logger?.info('Close add company modal dialog and reset form.');
+        }
         isDialogOpen.value = false;
       };
 
@@ -100,6 +120,8 @@ export default defineComponent({
 
     return {
       address,
+      addressNew,
+      formRef,
       isDialogOpen,
       isFilled,
       onClose,
@@ -177,8 +199,11 @@ export default defineComponent({
       {{ $t('form.company.titleAddAddress') }}
     </template>
     <template #content>
-      <q-form>
-        <!-- TODO: add FormAddress -->
+      <q-form ref="formRef">
+        <p data-cy="add-subsidiary-text">
+          {{ $t('form.company.textSubsidiaryAddress') }}
+        </p>
+        <form-add-subsidiary v-model="addressNew" />
       </q-form>
       <!-- Action buttons -->
       <div class="flex justify-end q-mt-sm">

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -78,7 +78,7 @@ export const emptyFormCompanyFields: FormCompanyFields = {
       houseNumber: '',
       city: '',
       zip: '',
-      cityChallenge: '',
+      cityChallenge: null,
       department: '',
     },
   ],

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -34,7 +34,7 @@ export type FormCompanyAddressFields = {
   houseNumber: string;
   city: string;
   zip: string;
-  cityChallenge: string;
+  cityChallenge: number | null;
   department: string;
 };
 

--- a/test/cypress/fixtures/cityChallengeResponse.json
+++ b/test/cypress/fixtures/cityChallengeResponse.json
@@ -1,0 +1,16 @@
+{
+  "results": [
+    {
+      "id": 123123,
+      "name": "Praha"
+    },
+    {
+      "id": 123124,
+      "name": "Brno"
+    },
+    {
+      "id": 123125,
+      "name": "Liberec"
+    }
+  ]
+}

--- a/test/cypress/fixtures/companyAddress.json
+++ b/test/cypress/fixtures/companyAddress.json
@@ -7,7 +7,7 @@
       "houseNumber": "123",
       "city": "Test City",
       "zip": "12345",
-      "cityChallenge": "city-1",
+      "cityChallenge": 123123,
       "department": "Test Department"
     }
   ]


### PR DESCRIPTION
Add component FormAddSubsidiary for displaying subsidiary (address) form fields in `FormAddCompany` and `FormFieldCompanyAddress` components.
Update empty `v-model` data type (`"cityChallenge": number`) in the relevant components.
Add `cityChallenge` options fixture and update tests accordingly.