### PR TITLE
src/components/__tests__: update fillFormRegisterCoordinator func for register coordinator tests

### DIFF
--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -41,20 +41,17 @@ describe('<FormFieldCompany>', () => {
         i18n,
         OrganizationType.company,
       );
-      cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(
-        () => {
-          // reset model value
-          model.value = '';
-          // mount component
-          cy.mount(FormFieldCompany, {
-            props: {
-              ...vModelAdapter(model),
-              organizationType: OrganizationType.company,
-            },
-          });
-          cy.viewport('macbook-16');
+      cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n);
+      // reset model value
+      model.value = '';
+      // mount component
+      cy.mount(FormFieldCompany, {
+        props: {
+          ...vModelAdapter(model),
+          organizationType: OrganizationType.company,
         },
-      );
+      });
+      cy.viewport('macbook-16');
     });
 
     it('renders input with label', () => {
@@ -214,18 +211,17 @@ context('mobile', () => {
       i18n,
       OrganizationType.company,
     );
-    cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
-      // reset model value
-      model.value = '';
-      // mount component
-      cy.mount(FormFieldCompany, {
-        props: {
-          ...vModelAdapter(model),
-          organizationType: OrganizationType.company,
-        },
-      });
-      cy.viewport('iphone-6');
+    cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n);
+    // reset model value
+    model.value = '';
+    // mount component
+    cy.mount(FormFieldCompany, {
+      props: {
+        ...vModelAdapter(model),
+        organizationType: OrganizationType.company,
+      },
     });
+    cy.viewport('iphone-6');
   });
 
   it('renders input and button in a stacked layout', () => {

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -3,12 +3,7 @@ import FormFieldCompany from 'components/global/FormFieldCompany.vue';
 import { vModelAdapter } from '../../../test/cypress/utils';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
-import {
-  httpSuccessfullStatus,
-  interceptOrganizationsGetApi,
-  interceptOrganizationsPostApi,
-  waitForOrganizationsApi,
-} from '../../../test/cypress/support/commonTests';
+import { httpSuccessfullStatus } from '../../../test/cypress/support/commonTests';
 import { OrganizationType } from '../types/Organization';
 
 const model = ref('');
@@ -41,12 +36,13 @@ describe('<FormFieldCompany>', () => {
   context('desktop', () => {
     beforeEach(() => {
       // intercept api
-      interceptOrganizationsGetApi(
+      cy.interceptOrganizationsGetApi(
         rideToWorkByBikeConfig,
         i18n,
         OrganizationType.company,
-      ).then(() => {
-        interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
+      );
+      cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(
+        () => {
           // reset model value
           model.value = '';
           // mount component
@@ -57,8 +53,8 @@ describe('<FormFieldCompany>', () => {
             },
           });
           cy.viewport('macbook-16');
-        });
-      });
+        },
+      );
     });
 
     it('renders input with label', () => {
@@ -79,27 +75,24 @@ describe('<FormFieldCompany>', () => {
     it('allows user to select option', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
-            () => {
-              cy.dataCy('form-company').find('.q-field__append').click();
-              // select option
-              cy.get('.q-item__label')
-                .should('be.visible')
-                .and((opts) => {
-                  expect(
-                    opts.length,
-                    formFieldCompany.results.length +
-                      formFieldCompanyNext.results.length,
-                  );
-                })
-                .first()
-                .click();
-              cy.get('.q-menu').should('not.exist');
-              cy.wrap(model)
-                .its('value')
-                .should('eq', formFieldCompany.results[0].id);
-            },
-          );
+          cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.dataCy('form-company').find('.q-field__append').click();
+          // select option
+          cy.get('.q-item__label')
+            .should('be.visible')
+            .and((opts) => {
+              expect(
+                opts.length,
+                formFieldCompany.results.length +
+                  formFieldCompanyNext.results.length,
+              );
+            })
+            .first()
+            .click();
+          cy.get('.q-menu').should('not.exist');
+          cy.wrap(model)
+            .its('value')
+            .should('eq', formFieldCompany.results[0].id);
         });
       });
     });
@@ -108,19 +101,16 @@ describe('<FormFieldCompany>', () => {
       // search for option
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
-            () => {
-              cy.dataCy('form-company')
-                .find('.q-field__append')
-                .type(formFieldCompany.results[1].name);
-              // select first option from filtered results
-              cy.get('.q-item__label').should('have.length', 1).first().click();
-              cy.get('.q-menu').should('not.exist');
-              cy.wrap(model)
-                .its('value')
-                .should('eq', formFieldCompany.results[1].id);
-            },
-          );
+          cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.dataCy('form-company')
+            .find('.q-field__append')
+            .type(formFieldCompany.results[1].name);
+          // select first option from filtered results
+          cy.get('.q-item__label').should('have.length', 1).first().click();
+          cy.get('.q-menu').should('not.exist');
+          cy.wrap(model)
+            .its('value')
+            .should('eq', formFieldCompany.results[1].id);
         });
       });
     });
@@ -128,26 +118,23 @@ describe('<FormFieldCompany>', () => {
     it('validates company field correctly', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
-            () => {
-              cy.dataCy('form-company').find('input').focus();
-              cy.focused().blur();
-              cy.contains(
-                i18n.global.t('form.messageFieldRequired', {
-                  fieldName: i18n.global.t('form.labelCompanyShort'),
-                }),
-              ).should('be.visible');
-              cy.dataCy('form-company').find('input').click();
-              // select option
-              cy.get('.q-item__label').first().click();
-              cy.focused().blur();
-              cy.contains(
-                i18n.global.t('form.messageFieldRequired', {
-                  fieldName: i18n.global.t('form.labelCompanyShort'),
-                }),
-              ).should('not.exist');
-            },
-          );
+          cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.dataCy('form-company').find('input').focus();
+          cy.focused().blur();
+          cy.contains(
+            i18n.global.t('form.messageFieldRequired', {
+              fieldName: i18n.global.t('form.labelCompanyShort'),
+            }),
+          ).should('be.visible');
+          cy.dataCy('form-company').find('input').click();
+          // select option
+          cy.get('.q-item__label').first().click();
+          cy.focused().blur();
+          cy.contains(
+            i18n.global.t('form.messageFieldRequired', {
+              fieldName: i18n.global.t('form.labelCompanyShort'),
+            }),
+          ).should('not.exist');
         });
       });
     });
@@ -222,23 +209,22 @@ describe('<FormFieldCompany>', () => {
 context('mobile', () => {
   beforeEach(() => {
     // intercept api
-    interceptOrganizationsGetApi(
+    cy.interceptOrganizationsGetApi(
       rideToWorkByBikeConfig,
       i18n,
       OrganizationType.company,
-    ).then(() => {
-      interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
-        // reset model value
-        model.value = '';
-        // mount component
-        cy.mount(FormFieldCompany, {
-          props: {
-            ...vModelAdapter(model),
-            organizationType: OrganizationType.company,
-          },
-        });
-        cy.viewport('iphone-6');
+    );
+    cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
+      // reset model value
+      model.value = '';
+      // mount component
+      cy.mount(FormFieldCompany, {
+        props: {
+          ...vModelAdapter(model),
+          organizationType: OrganizationType.company,
+        },
       });
+      cy.viewport('iphone-6');
     });
   });
 

--- a/src/components/__tests__/FormFieldCompany.cy.js
+++ b/src/components/__tests__/FormFieldCompany.cy.js
@@ -5,7 +5,8 @@ import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import {
   httpSuccessfullStatus,
-  interceptOrganizationsApi,
+  interceptOrganizationsGetApi,
+  interceptOrganizationsPostApi,
   waitForOrganizationsApi,
 } from '../../../test/cypress/support/commonTests';
 import { OrganizationType } from '../types/Organization';
@@ -40,21 +41,24 @@ describe('<FormFieldCompany>', () => {
   context('desktop', () => {
     beforeEach(() => {
       // intercept api
-      interceptOrganizationsApi(
+      interceptOrganizationsGetApi(
         rideToWorkByBikeConfig,
         i18n,
         OrganizationType.company,
-      );
-      // reset model value
-      model.value = '';
-      // mount component
-      cy.mount(FormFieldCompany, {
-        props: {
-          ...vModelAdapter(model),
-          organizationType: OrganizationType.company,
-        },
+      ).then(() => {
+        interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
+          // reset model value
+          model.value = '';
+          // mount component
+          cy.mount(FormFieldCompany, {
+            props: {
+              ...vModelAdapter(model),
+              organizationType: OrganizationType.company,
+            },
+          });
+          cy.viewport('macbook-16');
+        });
       });
-      cy.viewport('macbook-16');
     });
 
     it('renders input with label', () => {
@@ -75,24 +79,27 @@ describe('<FormFieldCompany>', () => {
     it('allows user to select option', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          cy.dataCy('form-company').find('.q-field__append').click();
-          // select option
-          cy.get('.q-item__label')
-            .should('be.visible')
-            .and((opts) => {
-              expect(
-                opts.length,
-                formFieldCompany.results.length +
-                  formFieldCompanyNext.results.length,
-              );
-            })
-            .first()
-            .click();
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[0].id);
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
+            () => {
+              cy.dataCy('form-company').find('.q-field__append').click();
+              // select option
+              cy.get('.q-item__label')
+                .should('be.visible')
+                .and((opts) => {
+                  expect(
+                    opts.length,
+                    formFieldCompany.results.length +
+                      formFieldCompanyNext.results.length,
+                  );
+                })
+                .first()
+                .click();
+              cy.get('.q-menu').should('not.exist');
+              cy.wrap(model)
+                .its('value')
+                .should('eq', formFieldCompany.results[0].id);
+            },
+          );
         });
       });
     });
@@ -101,16 +108,19 @@ describe('<FormFieldCompany>', () => {
       // search for option
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          cy.dataCy('form-company')
-            .find('.q-field__append')
-            .type(formFieldCompany.results[1].name);
-          // select first option from filtered results
-          cy.get('.q-item__label').should('have.length', 1).first().click();
-          cy.get('.q-menu').should('not.exist');
-          cy.wrap(model)
-            .its('value')
-            .should('eq', formFieldCompany.results[1].id);
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
+            () => {
+              cy.dataCy('form-company')
+                .find('.q-field__append')
+                .type(formFieldCompany.results[1].name);
+              // select first option from filtered results
+              cy.get('.q-item__label').should('have.length', 1).first().click();
+              cy.get('.q-menu').should('not.exist');
+              cy.wrap(model)
+                .its('value')
+                .should('eq', formFieldCompany.results[1].id);
+            },
+          );
         });
       });
     });
@@ -118,23 +128,26 @@ describe('<FormFieldCompany>', () => {
     it('validates company field correctly', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          cy.dataCy('form-company').find('input').focus();
-          cy.focused().blur();
-          cy.contains(
-            i18n.global.t('form.messageFieldRequired', {
-              fieldName: i18n.global.t('form.labelCompanyShort'),
-            }),
-          ).should('be.visible');
-          cy.dataCy('form-company').find('input').click();
-          // select option
-          cy.get('.q-item__label').first().click();
-          cy.focused().blur();
-          cy.contains(
-            i18n.global.t('form.messageFieldRequired', {
-              fieldName: i18n.global.t('form.labelCompanyShort'),
-            }),
-          ).should('not.exist');
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
+            () => {
+              cy.dataCy('form-company').find('input').focus();
+              cy.focused().blur();
+              cy.contains(
+                i18n.global.t('form.messageFieldRequired', {
+                  fieldName: i18n.global.t('form.labelCompanyShort'),
+                }),
+              ).should('be.visible');
+              cy.dataCy('form-company').find('input').click();
+              // select option
+              cy.get('.q-item__label').first().click();
+              cy.focused().blur();
+              cy.contains(
+                i18n.global.t('form.messageFieldRequired', {
+                  fieldName: i18n.global.t('form.labelCompanyShort'),
+                }),
+              ).should('not.exist');
+            },
+          );
         });
       });
     });
@@ -208,21 +221,25 @@ describe('<FormFieldCompany>', () => {
 
 context('mobile', () => {
   beforeEach(() => {
-    interceptOrganizationsApi(
+    // intercept api
+    interceptOrganizationsGetApi(
       rideToWorkByBikeConfig,
       i18n,
       OrganizationType.company,
-    );
-    // reset model value
-    model.value = '';
-    // mount component
-    cy.mount(FormFieldCompany, {
-      props: {
-        ...vModelAdapter(model),
-        organizationType: OrganizationType.company,
-      },
+    ).then(() => {
+      interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
+        // reset model value
+        model.value = '';
+        // mount component
+        cy.mount(FormFieldCompany, {
+          props: {
+            ...vModelAdapter(model),
+            organizationType: OrganizationType.company,
+          },
+        });
+        cy.viewport('iphone-6');
+      });
     });
-    cy.viewport('iphone-6');
   });
 
   it('renders input and button in a stacked layout', () => {

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -5,12 +5,8 @@ import FormRegisterCoordinator from 'components/register/FormRegisterCoordinator
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import {
-  fillFormRegisterCoordinator,
   httpSuccessfullStatus,
-  interceptOrganizationsGetApi,
-  interceptOrganizationsPostApi,
   interceptRegisterCoordinatorApi,
-  waitForOrganizationsApi,
 } from '../../../test/cypress/support/commonTests';
 import { useRegisterStore } from '../../stores/register';
 import { OrganizationType } from '../../components/types/Organization';
@@ -71,39 +67,35 @@ describe('<FormRegisterCoordinator>', () => {
       setActivePinia(createPinia());
       // intercept organizations API call (before mounting component)
       // intercept api
-      interceptOrganizationsGetApi(
+      cy.interceptOrganizationsGetApi(
         rideToWorkByBikeConfig,
         i18n,
         OrganizationType.company,
-      ).then(() => {
-        interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n).then(() => {
-          // intercept register coordinator API call (before mounting component)
-          interceptRegisterCoordinatorApi(rideToWorkByBikeConfig, i18n);
-          // specify data for register coordinator request body
-          cy.fixture('formRegisterCoordinator').then(
-            (formRegisterCoordinatorData) => {
-              cy.fixture('formFieldCompany').then(
-                (formFieldCompanyResponse) => {
-                  cy.wrap({
-                    firstName: formRegisterCoordinatorData.firstName,
-                    jobTitle: formRegisterCoordinatorData.jobTitle,
-                    lastName: formRegisterCoordinatorData.lastName,
-                    newsletter: formRegisterCoordinatorData.newsletter,
-                    organizationId: formFieldCompanyResponse.results[0].id,
-                    phone: formRegisterCoordinatorData.phone,
-                    responsibility: true,
-                    terms: true,
-                  }).as('registerRequestBody');
-                },
-              );
-            },
-          );
-          cy.mount(FormRegisterCoordinator, {
-            props: {},
+      );
+      cy.interceptOrganizationsPostApi(rideToWorkByBikeConfig, i18n);
+      // intercept register coordinator API call (before mounting component)
+      interceptRegisterCoordinatorApi(rideToWorkByBikeConfig, i18n);
+      // specify data for register coordinator request body
+      cy.fixture('formRegisterCoordinator').then(
+        (formRegisterCoordinatorData) => {
+          cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+            cy.wrap({
+              firstName: formRegisterCoordinatorData.firstName,
+              jobTitle: formRegisterCoordinatorData.jobTitle,
+              lastName: formRegisterCoordinatorData.lastName,
+              newsletter: formRegisterCoordinatorData.newsletter,
+              organizationId: formFieldCompanyResponse.results[0].id,
+              phone: formRegisterCoordinatorData.phone,
+              responsibility: true,
+              terms: true,
+            }).as('registerRequestBody');
           });
-          cy.viewport('macbook-16');
-        });
+        },
+      );
+      cy.mount(FormRegisterCoordinator, {
+        props: {},
       });
+      cy.viewport('macbook-16');
     });
 
     it('renders title', () => {
@@ -189,53 +181,45 @@ describe('<FormRegisterCoordinator>', () => {
       // wait for organizations API call
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
-            () => {
-              // fill in other parts of the form to be able to test password
-              fillFormRegisterCoordinator().then(() => {
-                // test responsibility checkbox unchecked
-                cy.dataCy('form-register-coordinator-submit')
-                  .should('be.visible')
-                  .click();
-                // responsibility - required message shown
-                cy.contains(
-                  i18n.global.t(
-                    'register.coordinator.form.messageResponsibilityRequired',
-                  ),
-                ).should('be.visible');
-                // test responsibility checkbox checked
-                cy.dataCy('form-register-coordinator-responsibility')
-                  .find('.q-checkbox')
-                  .click();
-                // responsibility - required message hidden
-                cy.contains(
-                  i18n.global.t(
-                    'register.coordinator.form.messageResponsibilityRequired',
-                  ),
-                ).should('not.exist');
-                // test terms checkbox unchecked
-                cy.dataCy('form-register-coordinator-submit')
-                  .should('be.visible')
-                  .click();
-                // terms - required message shown
-                cy.contains(
-                  i18n.global.t(
-                    'register.coordinator.form.messageTermsRequired',
-                  ),
-                ).should('be.visible');
-                // test terms checkbox checked
-                cy.dataCy('form-register-coordinator-terms')
-                  .find('.q-checkbox')
-                  .click();
-                // terms - required message hidden
-                cy.contains(
-                  i18n.global.t(
-                    'register.coordinator.form.messageTermsRequired',
-                  ),
-                ).should('not.exist');
-              });
-            },
-          );
+          cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          // fill in other parts of the form to be able to test password
+          cy.fillFormRegisterCoordinator();
+          // test responsibility checkbox unchecked
+          cy.dataCy('form-register-coordinator-submit')
+            .should('be.visible')
+            .click();
+          // responsibility - required message shown
+          cy.contains(
+            i18n.global.t(
+              'register.coordinator.form.messageResponsibilityRequired',
+            ),
+          ).should('be.visible');
+          // test responsibility checkbox checked
+          cy.dataCy('form-register-coordinator-responsibility')
+            .find('.q-checkbox')
+            .click();
+          // responsibility - required message hidden
+          cy.contains(
+            i18n.global.t(
+              'register.coordinator.form.messageResponsibilityRequired',
+            ),
+          ).should('not.exist');
+          // test terms checkbox unchecked
+          cy.dataCy('form-register-coordinator-submit')
+            .should('be.visible')
+            .click();
+          // terms - required message shown
+          cy.contains(
+            i18n.global.t('register.coordinator.form.messageTermsRequired'),
+          ).should('be.visible');
+          // test terms checkbox checked
+          cy.dataCy('form-register-coordinator-terms')
+            .find('.q-checkbox')
+            .click();
+          // terms - required message hidden
+          cy.contains(
+            i18n.global.t('register.coordinator.form.messageTermsRequired'),
+          ).should('not.exist');
         });
       });
     });
@@ -245,41 +229,36 @@ describe('<FormRegisterCoordinator>', () => {
         // wait for organizations API call
         cy.fixture('formFieldCompany').then((formFieldCompany) => {
           cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-            waitForOrganizationsApi(
-              formFieldCompany,
-              formFieldCompanyNext,
-            ).then(() => {
-              // fill in the form
-              fillFormRegisterCoordinator().then(() => {
-                // check responsibility checkbox
-                cy.dataCy('form-register-coordinator-responsibility')
-                  .find('.q-checkbox')
-                  .click();
-                // check terms checkbox
-                cy.dataCy('form-register-coordinator-terms')
-                  .find('.q-checkbox')
-                  .click();
-                // submit form
-                cy.dataCy('form-register-coordinator-submit').click();
-                // wait for API call to finish
-                cy.get('@registerRequestBody').then((registerRequestBody) => {
-                  cy.wait('@registerCoordinator')
-                    .then((interception) => {
-                      // request body
-                      expect(interception.request.body).to.deep.equal(
-                        registerRequestBody,
-                      );
-                      // status code
-                      expect(interception.response.statusCode).to.equal(
-                        httpSuccessfullStatus,
-                      );
-                    })
-                    .then(() => {
-                      // check state in store
-                      compareRegisterResponseWithStore();
-                    });
+            cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+            // fill in the form
+            cy.fillFormRegisterCoordinator();
+            // check responsibility checkbox
+            cy.dataCy('form-register-coordinator-responsibility')
+              .find('.q-checkbox')
+              .click();
+            // check terms checkbox
+            cy.dataCy('form-register-coordinator-terms')
+              .find('.q-checkbox')
+              .click();
+            // submit form
+            cy.dataCy('form-register-coordinator-submit').click();
+            // wait for API call to finish
+            cy.get('@registerRequestBody').then((registerRequestBody) => {
+              cy.wait('@registerCoordinator')
+                .then((interception) => {
+                  // request body
+                  expect(interception.request.body).to.deep.equal(
+                    registerRequestBody,
+                  );
+                  // status code
+                  expect(interception.response.statusCode).to.equal(
+                    httpSuccessfullStatus,
+                  );
+                })
+                .then(() => {
+                  // check state in store
+                  compareRegisterResponseWithStore();
                 });
-              });
             });
           });
         });

--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -186,41 +186,48 @@ describe('<FormRegisterCoordinator>', () => {
         });
       });
       // fill in other parts of the form to be able to test password
-      fillFormRegisterCoordinator();
-      // test responsibility checkbox unchecked
-      cy.dataCy('form-register-coordinator-submit')
-        .should('be.visible')
-        .click();
-      // responsibility - required message shown
-      cy.contains(
-        i18n.global.t(
-          'register.coordinator.form.messageResponsibilityRequired',
-        ),
-      ).should('be.visible');
-      // test responsibility checkbox checked
-      cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-checkbox')
-        .click();
-      // responsibility - required message hidden
-      cy.contains(
-        i18n.global.t(
-          'register.coordinator.form.messageResponsibilityRequired',
-        ),
-      ).should('not.exist');
-      // test terms checkbox unchecked
-      cy.dataCy('form-register-coordinator-submit')
-        .should('be.visible')
-        .click();
-      // terms - required message shown
-      cy.contains(
-        i18n.global.t('register.coordinator.form.messageTermsRequired'),
-      ).should('be.visible');
-      // test terms checkbox checked
-      cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
-      // terms - required message hidden
-      cy.contains(
-        i18n.global.t('register.coordinator.form.messageTermsRequired'),
-      ).should('not.exist');
+      cy.fixture('formRegisterCoordinator').then(
+        (formRegisterCoordinatorData) => {
+          fillFormRegisterCoordinator(formRegisterCoordinatorData).then(() => {
+            // test responsibility checkbox unchecked
+            cy.dataCy('form-register-coordinator-submit')
+              .should('be.visible')
+              .click();
+            // responsibility - required message shown
+            cy.contains(
+              i18n.global.t(
+                'register.coordinator.form.messageResponsibilityRequired',
+              ),
+            ).should('be.visible');
+            // test responsibility checkbox checked
+            cy.dataCy('form-register-coordinator-responsibility')
+              .find('.q-checkbox')
+              .click();
+            // responsibility - required message hidden
+            cy.contains(
+              i18n.global.t(
+                'register.coordinator.form.messageResponsibilityRequired',
+              ),
+            ).should('not.exist');
+            // test terms checkbox unchecked
+            cy.dataCy('form-register-coordinator-submit')
+              .should('be.visible')
+              .click();
+            // terms - required message shown
+            cy.contains(
+              i18n.global.t('register.coordinator.form.messageTermsRequired'),
+            ).should('be.visible');
+            // test terms checkbox checked
+            cy.dataCy('form-register-coordinator-terms')
+              .find('.q-checkbox')
+              .click();
+            // terms - required message hidden
+            cy.contains(
+              i18n.global.t('register.coordinator.form.messageTermsRequired'),
+            ).should('not.exist');
+          });
+        },
+      );
     });
 
     it('submits form correctly', () => {
@@ -232,35 +239,42 @@ describe('<FormRegisterCoordinator>', () => {
           });
         });
         // fill in the form
-        fillFormRegisterCoordinator();
-        // check responsibility checkbox
-        cy.dataCy('form-register-coordinator-responsibility')
-          .find('.q-checkbox')
-          .click();
-        // check terms checkbox
-        cy.dataCy('form-register-coordinator-terms')
-          .find('.q-checkbox')
-          .click();
-        // submit form
-        cy.dataCy('form-register-coordinator-submit').click();
-        // wait for API call to finish
-        cy.get('@registerRequestBody').then((registerRequestBody) => {
-          cy.wait('@registerCoordinator')
-            .then((interception) => {
-              // request body
-              expect(interception.request.body).to.deep.equal(
-                registerRequestBody,
-              );
-              // status code
-              expect(interception.response.statusCode).to.equal(
-                httpSuccessfullStatus,
-              );
-            })
-            .then(() => {
-              // check state in store
-              compareRegisterResponseWithStore();
-            });
-        });
+        cy.fixture('formRegisterCoordinator').then(
+          (formRegisterCoordinatorData) => {
+            fillFormRegisterCoordinator(formRegisterCoordinatorData).then(
+              () => {
+                // check responsibility checkbox
+                cy.dataCy('form-register-coordinator-responsibility')
+                  .find('.q-checkbox')
+                  .click();
+                // check terms checkbox
+                cy.dataCy('form-register-coordinator-terms')
+                  .find('.q-checkbox')
+                  .click();
+                // submit form
+                cy.dataCy('form-register-coordinator-submit').click();
+                // wait for API call to finish
+                cy.get('@registerRequestBody').then((registerRequestBody) => {
+                  cy.wait('@registerCoordinator')
+                    .then((interception) => {
+                      // request body
+                      expect(interception.request.body).to.deep.equal(
+                        registerRequestBody,
+                      );
+                      // status code
+                      expect(interception.response.statusCode).to.equal(
+                        httpSuccessfullStatus,
+                      );
+                    })
+                    .then(() => {
+                      // check state in store
+                      compareRegisterResponseWithStore();
+                    });
+                });
+              },
+            );
+          },
+        );
       });
     });
   });

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -1,12 +1,8 @@
 import {
-  fillFormRegisterCoordinator,
   httpSuccessfullStatus,
-  interceptOrganizationsGetApi,
-  interceptOrganizationsPostApi,
   interceptRegisterCoordinatorApi,
   testLanguageSwitcher,
   testBackgroundImage,
-  waitForOrganizationsApi,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 import { OrganizationType } from '../../../src/components/types/Organization';
@@ -112,36 +108,32 @@ describe('Login page', () => {
               cy.wrap(win.i18n).as('i18n');
 
               // Set up API intercepts
-              interceptOrganizationsGetApi(
+              cy.interceptOrganizationsGetApi(
                 config,
                 win.i18n,
                 OrganizationType.company,
-              ).then(() => {
-                interceptOrganizationsPostApi(config, win.i18n).then(() => {
-                  interceptRegisterCoordinatorApi(config, win.i18n);
-
-                  // Load fixtures and set up request body
-                  cy.fixture('formRegisterCoordinator').then(
-                    (formRegisterCoordinatorData) => {
-                      cy.fixture('formFieldCompany').then(
-                        (formFieldCompanyResponse) => {
-                          cy.wrap({
-                            firstName: formRegisterCoordinatorData.firstName,
-                            jobTitle: formRegisterCoordinatorData.jobTitle,
-                            lastName: formRegisterCoordinatorData.lastName,
-                            newsletter: formRegisterCoordinatorData.newsletter,
-                            organizationId:
-                              formFieldCompanyResponse.results[0].id,
-                            phone: formRegisterCoordinatorData.phone,
-                            responsibility: true,
-                            terms: true,
-                          }).as('registerRequestBody');
-                        },
-                      );
+              );
+              cy.interceptOrganizationsPostApi(config, win.i18n);
+              interceptRegisterCoordinatorApi(config, win.i18n);
+              // Load fixtures and set up request body
+              cy.fixture('formRegisterCoordinator').then(
+                (formRegisterCoordinatorData) => {
+                  cy.fixture('formFieldCompany').then(
+                    (formFieldCompanyResponse) => {
+                      cy.wrap({
+                        firstName: formRegisterCoordinatorData.firstName,
+                        jobTitle: formRegisterCoordinatorData.jobTitle,
+                        lastName: formRegisterCoordinatorData.lastName,
+                        newsletter: formRegisterCoordinatorData.newsletter,
+                        organizationId: formFieldCompanyResponse.results[0].id,
+                        phone: formRegisterCoordinatorData.phone,
+                        responsibility: true,
+                        terms: true,
+                      }).as('registerRequestBody');
                     },
                   );
-                });
-              });
+                },
+              );
             });
           })
           .then(() => {
@@ -154,52 +146,48 @@ describe('Login page', () => {
     it('fills in the form, submits it, and redirects to homepage on success', () => {
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext).then(
-            () => {
-              // fill in the form
-              fillFormRegisterCoordinator().then(() => {
-                // check responsibility checkbox
-                cy.dataCy('form-register-coordinator-responsibility')
-                  .find('.q-checkbox')
-                  .click();
-                // prevent action on link to avoid accidental redirect
-                cy.dataCy('form-register-coordinator-terms')
-                  .find('a')
-                  .then(($el) => {
-                    $el[0].addEventListener('click', (event) => {
-                      event.preventDefault();
-                    });
-                  });
-                // check terms checkbox
-                cy.dataCy('form-register-coordinator-terms')
-                  .find('.q-checkbox')
-                  .click();
-                // reset the action on link
-                cy.dataCy('form-register-coordinator-terms')
-                  .find('a')
-                  .then(($el) => {
-                    $el[0].removeEventListener('click', (event) => {
-                      event.preventDefault();
-                    });
-                  });
-                // submit form
-                cy.dataCy('form-register-coordinator-submit').click();
-                // wait for the API call to complete
-                cy.wait('@registerCoordinator').then((interception) => {
-                  cy.get('@registerRequestBody').then((registerRequestBody) => {
-                    expect(interception.request.body).to.deep.equal(
-                      registerRequestBody,
-                    );
-                    expect(interception.response.statusCode).to.equal(
-                      httpSuccessfullStatus,
-                    );
-                    // check if redirected to homepage
-                    cy.url().should('include', routesConf['home']['path']);
-                  });
-                });
+          cy.waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          // fill in the form
+          cy.fillFormRegisterCoordinator();
+          // check responsibility checkbox
+          cy.dataCy('form-register-coordinator-responsibility')
+            .find('.q-checkbox')
+            .click();
+          // prevent action on link to avoid accidental redirect
+          cy.dataCy('form-register-coordinator-terms')
+            .find('a')
+            .then(($el) => {
+              $el[0].addEventListener('click', (event) => {
+                event.preventDefault();
               });
-            },
-          );
+            });
+          // check terms checkbox
+          cy.dataCy('form-register-coordinator-terms')
+            .find('.q-checkbox')
+            .click();
+          // reset the action on link
+          cy.dataCy('form-register-coordinator-terms')
+            .find('a')
+            .then(($el) => {
+              $el[0].removeEventListener('click', (event) => {
+                event.preventDefault();
+              });
+            });
+          // submit form
+          cy.dataCy('form-register-coordinator-submit').click();
+          // wait for the API call to complete
+          cy.wait('@registerCoordinator').then((interception) => {
+            cy.get('@registerRequestBody').then((registerRequestBody) => {
+              expect(interception.request.body).to.deep.equal(
+                registerRequestBody,
+              );
+              expect(interception.response.statusCode).to.equal(
+                httpSuccessfullStatus,
+              );
+              // check if redirected to homepage
+              cy.url().should('include', routesConf['home']['path']);
+            });
+          });
         });
       });
     });

--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -151,46 +151,55 @@ describe('Login page', () => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
           // fill in the form
-          fillFormRegisterCoordinator();
-          // check responsibility checkbox
-          cy.dataCy('form-register-coordinator-responsibility')
-            .find('.q-checkbox')
-            .click();
-          // prevent action on link to avoid accidental redirect
-          cy.dataCy('form-register-coordinator-terms')
-            .find('a')
-            .then(($el) => {
-              $el[0].addEventListener('click', (event) => {
-                event.preventDefault();
-              });
-            });
-          // check terms checkbox
-          cy.dataCy('form-register-coordinator-terms')
-            .find('.q-checkbox')
-            .click();
-          // reset the action on link
-          cy.dataCy('form-register-coordinator-terms')
-            .find('a')
-            .then(($el) => {
-              $el[0].removeEventListener('click', (event) => {
-                event.preventDefault();
-              });
-            });
-          // submit form
-          cy.dataCy('form-register-coordinator-submit').click();
-          // wait for the API call to complete
-          cy.wait('@registerCoordinator').then((interception) => {
-            cy.get('@registerRequestBody').then((registerRequestBody) => {
-              expect(interception.request.body).to.deep.equal(
-                registerRequestBody,
+          cy.fixture('formRegisterCoordinator').then(
+            (formRegisterCoordinatorData) => {
+              fillFormRegisterCoordinator(formRegisterCoordinatorData).then(
+                () => {
+                  // check responsibility checkbox
+                  cy.dataCy('form-register-coordinator-responsibility')
+                    .find('.q-checkbox')
+                    .click();
+                  // prevent action on link to avoid accidental redirect
+                  cy.dataCy('form-register-coordinator-terms')
+                    .find('a')
+                    .then(($el) => {
+                      $el[0].addEventListener('click', (event) => {
+                        event.preventDefault();
+                      });
+                    });
+                  // check terms checkbox
+                  cy.dataCy('form-register-coordinator-terms')
+                    .find('.q-checkbox')
+                    .click();
+                  // reset the action on link
+                  cy.dataCy('form-register-coordinator-terms')
+                    .find('a')
+                    .then(($el) => {
+                      $el[0].removeEventListener('click', (event) => {
+                        event.preventDefault();
+                      });
+                    });
+                  // submit form
+                  cy.dataCy('form-register-coordinator-submit').click();
+                  // wait for the API call to complete
+                  cy.wait('@registerCoordinator').then((interception) => {
+                    cy.get('@registerRequestBody').then(
+                      (registerRequestBody) => {
+                        expect(interception.request.body).to.deep.equal(
+                          registerRequestBody,
+                        );
+                        expect(interception.response.statusCode).to.equal(
+                          httpSuccessfullStatus,
+                        );
+                        // check if redirected to homepage
+                        cy.url().should('include', routesConf['home']['path']);
+                      },
+                    );
+                  });
+                },
               );
-              expect(interception.response.statusCode).to.equal(
-                httpSuccessfullStatus,
-              );
-              // check if redirected to homepage
-              cy.url().should('include', routesConf['home']['path']);
-            });
-          });
+            },
+          );
         });
       });
     });

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -554,22 +554,20 @@ export const interceptFacebookLoginApi = (
   );
 };
 
-export const fillFormRegisterCoordinator = (): void => {
-  cy.fixture('formRegisterCoordinator').then((formRegisterCoordinatorData) => {
+export const fillFormRegisterCoordinator = (): Cypress.Chainable => {
+  return cy.fixture('formRegisterCoordinator').then((data) => {
     cy.dataCy('form-register-coordinator-first-name')
       .find('input')
-      .type(formRegisterCoordinatorData.firstName);
+      .type(data.firstName);
     cy.dataCy('form-register-coordinator-last-name')
       .find('input')
-      .type(formRegisterCoordinatorData.lastName);
+      .type(data.lastName);
     cy.dataCy('form-register-coordinator-company').find('input').click();
     cy.get('.q-menu .q-item').first().click();
     cy.dataCy('form-register-coordinator-job-title')
       .find('input')
-      .type(formRegisterCoordinatorData.jobTitle);
-    cy.dataCy('form-register-coordinator-phone')
-      .find('input')
-      .type(formRegisterCoordinatorData.phone);
+      .type(data.jobTitle);
+    cy.dataCy('form-register-coordinator-phone').find('input').type(data.phone);
   });
 };
 


### PR DESCRIPTION
Issue: `FormRegisterCoordinator` tests occasionally fail with the following message:

```
1) <FormRegisterCoordinator>
       desktop
         validates checkboxes correctly:
     AssertionError: Timed out retrying after 60000ms: Expected to find content: 'Musíte súhlasiť s poskytnutím štartovného.' but never did.
```

Problem:
Based on video artifact, interception is not registered correctly so filling out form fails.
Issue is probably the synchronous nature of functions shared via `commonTests`.

Solution: Rewrite relevant functions from `commonTests` to return `Cypress.Chainable` type and use `.then` to await the result.

I split the `interceptOrganizationsApi` function into `interceptOrganizationsGetApi` and `interceptOrganizationsPostApi` to make them simpler and avoid `.then` chaining within the function.