### PR TITLE
test/cypress/support: add Cypress cypress-terminal-report plugin

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -149,6 +149,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+      - name: Archive runned cypress tests log files
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: cypress-tests-log-files-${{ matrix.os }}
+          path: test/cypress/logs
+          if-no-files-found: ignore
+          retention-days: 3
+
   # dump-github-context:
   #   name: Dump GitHub context
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -47,7 +47,7 @@ module.exports = defineConfig({
       addMatchImageSnapshotPlugin(on, config);
       require('cypress-terminal-report/src/installLogsPrinter')(on, {
         printLogsToConsole: 'onFail',
-        includeSuccessfulHookLogs: true,
+        includeSuccessfulHookLogs: false,
         printLogsToFile: 'OnFail',
         outputRoot: config.projectRoot + '/test/cypress/logs/',
         specRoot: 'component/',

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -48,7 +48,7 @@ module.exports = defineConfig({
       require('cypress-terminal-report/src/installLogsPrinter')(on, {
         printLogsToConsole: 'onFail',
         includeSuccessfulHookLogs: false,
-        printLogsToFile: 'OnFail',
+        printLogsToFile: 'onFail',
         outputRoot: config.projectRoot + '/test/cypress/logs/',
         specRoot: 'component/',
         outputTarget: {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -19,6 +19,16 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       addMatchImageSnapshotPlugin(on, config);
+      require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        printLogsToConsole: 'onFail',
+        includeSuccessfulHookLogs: false,
+        printLogsToFile: 'onFail',
+        outputRoot: config.projectRoot + '/test/cypress/logs/',
+        specRoot: 'e2e/',
+        outputTarget: {
+          'cypress-logs|txt': 'txt',
+        },
+      });
       on('task', {
         getAppConfig,
         fileExists,
@@ -35,6 +45,16 @@ module.exports = defineConfig({
   component: {
     setupNodeEvents(on, config) {
       addMatchImageSnapshotPlugin(on, config);
+      require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        printLogsToConsole: 'onFail',
+        includeSuccessfulHookLogs: true,
+        printLogsToFile: 'OnFail',
+        outputRoot: config.projectRoot + '/test/cypress/logs/',
+        specRoot: 'component/',
+        outputTarget: {
+          'cypress-logs|txt': 'txt',
+        },
+      });
       on('task', {
         getAppConfig,
       });

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "cypress-image-snapshot": "^4.0.1",
     "cypress-multi-reporters": "^2.0.0",
     "cypress-parallel": "^0.14.0",
+    "cypress-terminal-report": "^7.0.4",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-cypress": "^4.0.0",

--- a/test/cypress/support/component.js
+++ b/test/cypress/support/component.js
@@ -15,8 +15,10 @@
 
 import './commands';
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
 addMatchImageSnapshotCommand();
+installLogsCollector();
 
 // Change this if you have a different entrypoint for the main scss.
 import 'src/css/app.scss';

--- a/test/cypress/support/e2e.js
+++ b/test/cypress/support/e2e.js
@@ -16,5 +16,7 @@
 import './commands';
 
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
 addMatchImageSnapshotCommand();
+installLogsCollector();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,6 +2005,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 compatx@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/compatx/-/compatx-0.1.8.tgz#af6f61910ade6ce1073c0fdff23c786bcd75c026"
@@ -2207,6 +2212,17 @@ cypress-parallel@^0.14.0:
     lodash.camelcase "^4.3.0"
     mocha "~9.2.0"
     yargs "15.3.1"
+
+cypress-terminal-report@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-7.0.4.tgz#4ed3b6264df69d17dbd5f2dec351510ee8e1079f"
+  integrity sha512-atP8It2IwcgzJ3YsQcwYFbnuCC/KSGPEUaorJsJi3E9JE93IdFf21LuwuApOfbEMmqVu6mPtlxmxqutBFZNxhg==
+  dependencies:
+    chalk "^4.0.0"
+    compare-versions "^6.1.1"
+    fs-extra "^10.1.0"
+    process "^0.11.10"
+    superstruct "0.14.2"
 
 cypress@^13.2.0:
   version "13.16.0"
@@ -3327,7 +3343,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^10.0.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -6009,6 +6025,11 @@ strip-literal@^2.1.0:
   integrity sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==
   dependencies:
     js-tokens "^9.0.0"
+
+superstruct@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
+  integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
 
 supports-color@8.1.1, supports-color@^8.1.1:
   version "8.1.1"


### PR DESCRIPTION
Plugin for Cypress that adds better terminal output for easier debugging.

https://www.npmjs.com/package/cypress-terminal-report

Plugin is configured to log individual component/e2e tests files into individual test log files saved into root log test/cypress/logs/ directory.
