### PR TITLE
src/composables: add ability to load subsidiaries based on org ID via useApiGetSubsidiaries composable

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -86,6 +86,7 @@ urlApiRefresh = "auth/token/refresh/"
 urlApiRegister = "auth/registration/"
 urlApiRegisterCoordinator = "challenge/registration/coordinator/"
 urlApiResetPassword = "auth/password/reset/"
+urlApiSubsidiaries = "subsidiaries/"
 urlApiChallengeRegistrationUser = "challenge/registration/user/"
 urlApiCities = "cities/"
 

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -44,12 +44,11 @@ describe('<FormFieldCompanyAddress>', () => {
         i18n,
         organizationId,
       );
+      model.value = null;
       cy.mount(FormFieldCompanyAddress, {
         props: {
           ...vModelAdapter(model),
         },
-      }).then(() => {
-        model.value = null;
       });
       cy.viewport('macbook-16');
     });
@@ -151,12 +150,11 @@ describe('<FormFieldCompanyAddress>', () => {
         i18n,
         organizationId,
       );
+      model.value = null;
       cy.mount(FormFieldCompanyAddress, {
         props: {
           ...vModelAdapter(model),
         },
-      }).then(() => {
-        model.value = null;
       });
       cy.viewport('iphone-6');
     });

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -1,29 +1,20 @@
+import { ref } from 'vue';
 import { colors } from 'quasar';
 import FormFieldCompanyAddress from 'components/form/FormFieldCompanyAddress.vue';
 import { i18n } from '../../boot/i18n';
-import { useSelectedOrganization } from 'src/composables/useSelectedOrganization';
+import { vModelAdapter } from 'app/test/cypress/utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
+import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
 
+// variables
+const model = ref(null);
+const organizationId = 580;
+
 describe('<FormFieldCompanyAddress>', () => {
-  let options;
-
-  before(() => {
-    setActivePinia(createPinia());
-    const store = useRegisterChallengeStore();
-
-    cy.fixture('formOrganizationOptions').then((formOrganizationOptions) => {
-      const { addressOptions, organizationOptions } = useSelectedOrganization(
-        formOrganizationOptions,
-      );
-      store.setOrganizationId(organizationOptions.value[0].value);
-      options = addressOptions.value;
-    });
-  });
-
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
       ['messageNoResult', 'labelAddress'],
@@ -47,10 +38,18 @@ describe('<FormFieldCompanyAddress>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.interceptSubsidiariesGetApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        organizationId,
+      );
       cy.mount(FormFieldCompanyAddress, {
         props: {
-          options,
+          ...vModelAdapter(model),
         },
+      }).then(() => {
+        model.value = null;
       });
       cy.viewport('macbook-16');
     });
@@ -74,28 +73,48 @@ describe('<FormFieldCompanyAddress>', () => {
       cy.dataCy('button-add-address').should('be.visible');
     });
 
-    it('allows user to select option', () => {
-      cy.dataCy('form-company-address').find('.q-select').click();
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').should('have.length', options.length);
-        });
-    });
-
     it('validates address field correctly', () => {
       cy.dataCy('form-company-address').find('input').focus();
       cy.dataCy('form-company-address').find('input').blur();
-      cy.dataCy('form-company-address')
-        .find('.q-field__messages')
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('form.messageFieldRequired', {
-            fieldName: i18n.global.t('form.labelAddress'),
-          }),
+      cy.contains(
+        i18n.global.t('form.messageFieldRequired', {
+          fieldName: i18n.global.t('form.labelAddress'),
+        }),
+      ).should('be.visible');
+    });
+
+    it('allows user to select option', () => {
+      cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
+        cy.fixture('apiGetSubsidiariesResponseNext').then(
+          (subsidiariesResponseNext) => {
+            cy.wrap(useRegisterChallengeStore()).then((store) => {
+              // set organization ID in store
+              store.setOrganizationId(organizationId);
+              cy.wrap(store.getOrganizationId).should('eq', organizationId);
+              // wait for subsidiaries API
+              cy.waitForSubsidiariesApi(
+                subsidiariesResponse,
+                subsidiariesResponseNext,
+              );
+              cy.dataCy('form-company-address').find('.q-select').click();
+              // select option
+              cy.get('.q-menu')
+                .should('be.visible')
+                .within(() => {
+                  cy.get('.q-item').should(
+                    'have.length',
+                    subsidiariesResponse.results.length +
+                      subsidiariesResponseNext.results.length,
+                  );
+                  cy.get('.q-item').first().click();
+                });
+              cy.wrap(model)
+                .its('value')
+                .should('eq', subsidiariesResponse.results[0].id);
+            });
+          },
         );
+      });
     });
 
     it('renders dialog for adding a new address', () => {
@@ -126,10 +145,18 @@ describe('<FormFieldCompanyAddress>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.interceptSubsidiariesGetApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        organizationId,
+      );
       cy.mount(FormFieldCompanyAddress, {
         props: {
-          options,
+          ...vModelAdapter(model),
         },
+      }).then(() => {
+        model.value = null;
       });
       cy.viewport('iphone-6');
     });

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -25,7 +25,7 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, onMounted, ref, watch } from 'vue';
+import { computed, defineComponent, inject, ref, watch } from 'vue';
 
 // components
 import DialogDefault from 'src/components/global/DialogDefault.vue';
@@ -53,7 +53,7 @@ export default defineComponent({
   },
   props: {
     modelValue: {
-      type: Object as () => FormCompanyAddressFields | null,
+      type: Number as () => number | null,
       required: true,
     },
   },
@@ -62,15 +62,9 @@ export default defineComponent({
     const formRef = ref<typeof QForm | null>(null);
     const logger = inject('vuejs3-logger') as Logger | null;
 
-    const store = useRegisterChallengeStore();
-    const organizationId = computed<number | null>(() => {
-      return store.getOrganizationId ? store.getOrganizationId : null;
-    });
-
-    const address = computed<FormCompanyAddressFields | null>({
+    const address = computed<number | null>({
       get: () => props.modelValue,
-      set: (value: FormCompanyAddressFields | null) =>
-        emit('update:modelValue', value),
+      set: (value: number | null) => emit('update:modelValue', value),
     });
 
     const addressNew = ref<FormCompanyAddressFields>({
@@ -84,20 +78,18 @@ export default defineComponent({
 
     const { subsidiaries, isLoading, loadSubsidiaries } =
       useApiGetSubsidiaries(logger);
-    onMounted(() => {
-      if (organizationId.value) {
-        loadSubsidiaries(organizationId.value);
-      }
-    });
-    /**
-     * On organization ID change, reset address and load new subsidiaries
-     * for the new organization.
-     */
+
+    const store = useRegisterChallengeStore();
     watch(
-      () => organizationId.value,
-      () => {
+      () => store.getOrganizationId,
+      (newValue) => {
+        logger?.debug(`organizationId updated to <${newValue}>`);
         address.value = null;
+        if (newValue) {
+          loadSubsidiaries(newValue);
+        }
       },
+      { immediate: true },
     );
 
     const options = computed(() =>

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -9,8 +9,8 @@
  * Note: This component is commonly used in `RegisterChallengePage`.
  *
  * @props
- * - `modelValue` (object, required): The object representing address.
- *   It should be of type `FormAddressType`.
+ * - `modelValue` (number|null): the number representing address.
+ *
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
@@ -52,7 +52,8 @@ export default defineComponent({
   props: {
     modelValue: {
       type: Number as () => number | null,
-      required: true,
+      required: false,
+      default: null,
     },
   },
   emits: ['update:modelValue'],
@@ -81,7 +82,9 @@ export default defineComponent({
     watch(
       () => store.getOrganizationId,
       (newValue) => {
-        logger?.debug(`organizationId updated to <${newValue}>`);
+        logger?.debug(
+          `Resgister challenge stote organization ID updated to <${newValue}>`,
+        );
         address.value = null;
         if (newValue) {
           loadSubsidiaries(newValue);
@@ -111,9 +114,9 @@ export default defineComponent({
      * @returns {string} - Formatted string representation of the address or
      * empty string.
      */
-    function getAddressString(
+    const getAddressString = (
       address: FormCompanyAddressFields | undefined,
-    ): string {
+    ): string => {
       if (!address) return '';
 
       const parts = [
@@ -126,11 +129,11 @@ export default defineComponent({
       ].filter(Boolean);
 
       return parts.join(', ');
-    }
+    };
 
     /**
      * Provides dialog behaviour
-     * @returns
+     * @returns {isDialogOpen, onClose}
      * - `isDialogOpen` (boolean): Whether the dialog is open.
      * - `onClose` (function): Runs when the dialog is closed.
      */

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -25,6 +25,7 @@
  */
 
 // libraries
+import { QForm } from 'quasar';
 import { computed, defineComponent, inject, ref, watch } from 'vue';
 
 // components
@@ -39,10 +40,7 @@ import { useValidation } from 'src/composables/useValidation';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
-import type {
-  FormCompanyAddressFields,
-  FormOption,
-} from 'src/components/types/Form';
+import type { FormCompanyAddressFields } from 'src/components/types/Form';
 import type { Logger } from 'src/components/types/Logger';
 
 export default defineComponent({

--- a/src/components/form/FormFieldOptionGroup.vue
+++ b/src/components/form/FormFieldOptionGroup.vue
@@ -72,18 +72,18 @@ export default defineComponent({
       {
         label: i18n.global.t('form.participation.labelColleagues'),
         description: i18n.global.t('form.participation.textColleagues'),
-        value: 'colleagues',
+        value: OrganizationType.company,
         icon: 'favorite',
       },
       {
         label: i18n.global.t('form.participation.labelSchoolmates'),
         description: i18n.global.t('form.participation.textSchoolmates'),
-        value: 'schoolmates',
+        value: OrganizationType.school,
         icon: 'flight_takeoff',
       },
       {
         label: i18n.global.t('form.participation.labelFamilyShort'),
-        value: 'family',
+        value: OrganizationType.family,
         icon: 'flight_land',
       },
     ];

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -57,13 +57,13 @@ export default defineComponent({
         registerChallengeStore.getOrganizationType ?? OrganizationType.company,
     );
 
-    const { selectedAddress, organizationId, organizationOptions } =
+    const { organizationId, organizationOptions, subsidiaryId } =
       useSelectedOrganization(organizations);
 
     return {
-      selectedAddress,
       organizationId,
       organizationOptions,
+      subsidiaryId,
       OrganizationLevel,
       organizationType,
     };
@@ -82,7 +82,7 @@ export default defineComponent({
       :data-organization-type="organizationType"
     />
     <form-field-company-address
-      v-model="selectedAddress"
+      v-model="subsidiaryId"
       data-cy="form-company-address"
     />
   </div>

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -57,16 +57,11 @@ export default defineComponent({
         registerChallengeStore.getOrganizationType ?? OrganizationType.company,
     );
 
-    const {
-      selectedAddress,
-      addressOptions,
-      organizationId,
-      organizationOptions,
-    } = useSelectedOrganization(organizations);
+    const { selectedAddress, organizationId, organizationOptions } =
+      useSelectedOrganization(organizations);
 
     return {
       selectedAddress,
-      addressOptions,
       organizationId,
       organizationOptions,
       OrganizationLevel,
@@ -88,7 +83,6 @@ export default defineComponent({
     />
     <form-field-company-address
       v-model="selectedAddress"
-      :options="addressOptions"
       data-cy="form-company-address"
     />
   </div>

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -57,6 +57,7 @@ export interface ConfigGlobal {
   urlApiResetPassword: string;
   urlApiChallengeRegistrationUser: string;
   urlApiCities: string;
+  urlApiSubsidiaries: string;
   urlLoginRegisterBackgroundImage: string;
   urlRTWBBLogo: string;
   checkIsEmailVerifiedInterval: number;

--- a/src/composables/useApiGetSubsidiaries.ts
+++ b/src/composables/useApiGetSubsidiaries.ts
@@ -1,0 +1,104 @@
+// libraries
+import { ref } from 'vue';
+
+// composables
+import { useApi } from './useApi';
+
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
+// stores
+import { useLoginStore } from '../stores/login';
+
+// types
+import type { Logger } from '../components/types/Logger';
+import type { OrganizationSubsidiary } from '../components/types/Organization';
+
+// utils
+import { requestDefaultHeader, requestTokenHeader } from '../utils';
+
+interface GetSubsidiariesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: OrganizationSubsidiary[];
+}
+
+export const useApiGetSubsidiaries = (logger: Logger | null) => {
+  const subsidiaries = ref<OrganizationSubsidiary[]>([]);
+  const isLoading = ref<boolean>(false);
+  const loginStore = useLoginStore();
+  const { apiFetch } = useApi();
+
+  /**
+   * Load subsidiaries
+   * Fetches subsidiaries and saves them into options
+   */
+  const loadSubsidiaries = async (organizationId: number): Promise<void> => {
+    // reset options
+    subsidiaries.value = [];
+
+    // get subsidiaries
+    isLoading.value = true;
+
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+
+    // fetch subsidiaries
+    const { data } = await apiFetch<GetSubsidiariesResponse>({
+      endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/subsidiaries/`,
+      method: 'get',
+      translationKey: 'getSubsidiaries',
+      showSuccessMessage: false,
+      headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+      logger,
+    });
+
+    if (data?.results?.length) {
+      subsidiaries.value.push(...data.results);
+    }
+
+    // if data has multiple pages, fetch all pages
+    if (data?.next) {
+      await fetchNextPage(data.next);
+    }
+
+    isLoading.value = false;
+  };
+
+  /**
+   * Fetch next page of subsidiaries
+   */
+  const fetchNextPage = async (url: string): Promise<void> => {
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+
+    // fetch next page
+    const { data } = await apiFetch<GetSubsidiariesResponse>({
+      endpoint: url,
+      method: 'get',
+      translationKey: 'getSubsidiaries',
+      showSuccessMessage: false,
+      headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+      logger,
+    });
+
+    // store results
+    if (data?.results?.length) {
+      subsidiaries.value.push(...data.results);
+    }
+
+    // if data has multiple pages, fetch all pages
+    if (data?.next) {
+      await fetchNextPage(data.next);
+    }
+  };
+
+  return {
+    subsidiaries,
+    isLoading,
+    loadSubsidiaries,
+  };
+};

--- a/src/composables/useApiGetSubsidiaries.ts
+++ b/src/composables/useApiGetSubsidiaries.ts
@@ -1,5 +1,5 @@
 // libraries
-import { ref } from 'vue';
+import { ref, Ref } from 'vue';
 
 // composables
 import { useApi } from './useApi';
@@ -24,7 +24,21 @@ interface GetSubsidiariesResponse {
   results: OrganizationSubsidiary[];
 }
 
-export const useApiGetSubsidiaries = (logger: Logger | null) => {
+type UseApiGetSubsidiariesReturn = {
+  subsidiaries: Ref<OrganizationSubsidiary[]>;
+  isLoading: Ref<boolean>;
+  loadSubsidiaries: (organizationId: number) => Promise<void>;
+};
+
+/**
+ * Get subsidiaries composable
+ * Used to enable calling the API to get organization subsidiaries
+ * @param logger - Logger
+ * @returns {UseApiGetSubsidiariesReturn}
+ */
+export const useApiGetSubsidiaries = (
+  logger: Logger | null,
+): UseApiGetSubsidiariesReturn => {
   const subsidiaries = ref<OrganizationSubsidiary[]>([]);
   const isLoading = ref<boolean>(false);
   const loginStore = useLoginStore();
@@ -33,12 +47,20 @@ export const useApiGetSubsidiaries = (logger: Logger | null) => {
   /**
    * Load subsidiaries
    * Fetches subsidiaries and saves them into options
+   * @param {number} organizationId - Organization Id to get subsidiaries
+   * @returns {Promise<void>} - Promise
    */
   const loadSubsidiaries = async (organizationId: number): Promise<void> => {
     // reset options
+    logger?.debug(
+      `Reseting default options <${JSON.stringify(subsidiaries.value, null, 2)}>.`,
+    );
     subsidiaries.value = [];
-
+    logger?.debug(
+      `Default options set to <${JSON.stringify(subsidiaries.value, null, 2)}>.`,
+    );
     // get subsidiaries
+    logger?.info('Get subsidiaries from the API.');
     isLoading.value = true;
 
     // append access token into HTTP header
@@ -69,8 +91,11 @@ export const useApiGetSubsidiaries = (logger: Logger | null) => {
 
   /**
    * Fetch next page of subsidiaries
+   * @param {string} url - Get subsidiaries next page API URL
+   * @returns {Promise<void>} - Promise
    */
   const fetchNextPage = async (url: string): Promise<void> => {
+    logger?.debug(`Fetching next page of subsidiaries from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
     requestTokenHeader_.Authorization += loginStore.getAccessToken;

--- a/src/composables/useApiGetSubsidiaries.ts
+++ b/src/composables/useApiGetSubsidiaries.ts
@@ -47,7 +47,7 @@ export const useApiGetSubsidiaries = (logger: Logger | null) => {
 
     // fetch subsidiaries
     const { data } = await apiFetch<GetSubsidiariesResponse>({
-      endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/subsidiaries/`,
+      endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/${rideToWorkByBikeConfig.urlApiSubsidiaries}`,
       method: 'get',
       translationKey: 'getSubsidiaries',
       showSuccessMessage: false,

--- a/src/composables/useSelectedOrganization.ts
+++ b/src/composables/useSelectedOrganization.ts
@@ -7,7 +7,6 @@ import { useRegisterChallengeStore } from '../stores/registerChallenge';
 import type { Organization } from '../components/types/Organization';
 import type {
   FormCompanyAddressFields,
-  FormOption,
   FormSelectTableOption,
 } from 'src/components/types/Form';
 
@@ -64,61 +63,9 @@ export const useSelectedOrganization = (organizations: Organization[]) => {
     set: (value: number | null) => store.setSubsidiaryId(value),
   });
 
-  /**
-   * Computes the address options for the address select
-   * based on the selected organizationId.
-   * @returns {FormSelectTableOption[]} - The address options or empty array.
-   */
-  const addressOptions = computed<FormOption[]>(() => {
-    if (!organizationId.value) return [];
-
-    const selectedOrganization = organizations.find(
-      (organization) => organization.id === organizationId.value,
-    );
-    if (!selectedOrganization) return [];
-
-    const addressOptions: FormOption[] = [] as FormOption[];
-
-    // add subsidiaries addresses to the options
-    selectedOrganization.subsidiaries.forEach((subsidiary) => {
-      if (subsidiary.address) {
-        addressOptions.push({
-          label: getAddressString(subsidiary.address),
-          value: subsidiary.address,
-        });
-      }
-    });
-
-    return addressOptions;
-  });
-
-  /**
-   * Get a formatted address string from the provided address object.
-   * @param {FormCompanyAddressFields | undefined} address - The address object.
-   * @returns {string} - Formatted string representation of the address or
-   * empty string.
-   */
-  function getAddressString(
-    address: FormCompanyAddressFields | undefined,
-  ): string {
-    if (!address) return '';
-
-    const parts = [
-      address.street,
-      address.houseNumber,
-      address.city,
-      address.zip,
-      address.cityChallenge,
-      address.department,
-    ].filter(Boolean);
-
-    return parts.join(', ');
-  }
-
   return {
     selectedAddress,
     subsidiaryId,
-    addressOptions,
     organizationId,
     organizationOptions,
   };

--- a/src/composables/useSelectedOrganization.ts
+++ b/src/composables/useSelectedOrganization.ts
@@ -1,14 +1,11 @@
-import { computed, ref, watch } from 'vue';
+import { computed } from 'vue';
 
 // stores
 import { useRegisterChallengeStore } from '../stores/registerChallenge';
 
 // types
 import type { Organization } from '../components/types/Organization';
-import type {
-  FormCompanyAddressFields,
-  FormSelectTableOption,
-} from 'src/components/types/Form';
+import type { FormSelectTableOption } from 'src/components/types/Form';
 
 export const useSelectedOrganization = (organizations: Organization[]) => {
   // store
@@ -31,42 +28,14 @@ export const useSelectedOrganization = (organizations: Organization[]) => {
     }));
   });
 
-  /**
-   * Internal reference state for selected address.
-   * Used as model value in `FormSelectOrganization` component.
-   */
-  const selectedAddress = ref<FormCompanyAddressFields | null>(null);
-
-  /**
-   * Control selected subsidiaryId based on selected address.
-   */
-  watch(selectedAddress, (newVal: FormCompanyAddressFields | null) => {
-    const selectedOrganization = organizations.find(
-      (organization) => organization.id === organizationId.value,
-    );
-
-    if (newVal) {
-      const subsidiary = selectedOrganization?.subsidiaries.find(
-        (subsidiary) => subsidiary.address === newVal,
-      );
-      subsidiaryId.value = subsidiary?.id ?? null;
-    }
-  });
-
-  /**
-   * Computes the subsidiaryId based on selected address and
-   * current store value.
-   */
   const subsidiaryId = computed<number | null>({
-    get: (): number | null =>
-      store.getSubsidiaryId ? store.getSubsidiaryId : null,
+    get: (): number | null => store.getSubsidiaryId,
     set: (value: number | null) => store.setSubsidiaryId(value),
   });
 
   return {
-    selectedAddress,
-    subsidiaryId,
     organizationId,
     organizationOptions,
+    subsidiaryId,
   };
 };

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -45,6 +45,11 @@ apiMessageError = "Načítání měst selhalo."
 apiMessageErrorWithMessage = "Načítání měst selhalo. Chyba: {error}"
 apiMessageSuccess = "Města byla úspěšně načtena."
 
+[getSubsidiaries]
+apiMessageError = "Načítání poboček selhalo."
+apiMessageErrorWithMessage = "Načítání poboček selhalo. Chyba: {error}"
+apiMessageSuccess = "Pobočky byly úspěšně načteny."
+
 [global]
 all = "Všechny"
 and = "a"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -45,6 +45,11 @@ apiMessageError = "Fetching cities failed."
 apiMessageErrorWithMessage = "Fetching cities failed. Error: {error}"
 apiMessageSuccess = "Cities fetched successfully."
 
+[getSubsidiaries]
+apiMessageError = "Fetching subsidiaries failed."
+apiMessageErrorWithMessage = "Fetching subsidiaries failed. Error: {error}"
+apiMessageSuccess = "Subsidiaries fetched successfully."
+
 [global]
 all = "All"
 and = "and"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -45,6 +45,11 @@ apiMessageError = "Načítanie miest zlyhalo."
 apiMessageErrorWithMessage = "Načítanie miest zlyhalo. Chyba: {error}"
 apiMessageSuccess = "Mestá boli úspešne načítané."
 
+[getSubsidiaries]
+apiMessageError = "Načítanie pobočiek zlyhalo."
+apiMessageErrorWithMessage = "Načítanie pobočiek zlyhalo. Chyba: {error}"
+apiMessageSuccess = "Pobočky boli úspešne načítané."
+
 [global]
 all = "Všetky"
 and = "a"

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -83,6 +83,16 @@ describe('Register Challenge page', () => {
         cy.window().then((win) => {
           // alias i18n
           cy.wrap(win.i18n).as('i18n');
+          // setup API intercepts
+          cy.fixture('formOrganizationOptions').then(
+            (formOrganizationOptions) => {
+              cy.interceptSubsidiariesGetApi(
+                config,
+                win.i18n,
+                formOrganizationOptions[0].id,
+              );
+            },
+          );
         });
       });
     });

--- a/test/cypress/fixtures/apiGetSubsidiariesResponse.json
+++ b/test/cypress/fixtures/apiGetSubsidiariesResponse.json
@@ -1,0 +1,95 @@
+{
+  "count": 8,
+  "next": "https://test.dopracenakole.cz/rest/organizations/580/subsidiaries/?limit=20&offset=20",
+  "previous": null,
+  "results": [
+    {
+      "id": 1388,
+      "address": {
+        "street": "Joštova",
+        "street_number": "5",
+        "recipient": "ČSOB",
+        "psc": "60179",
+        "city": "60179"
+      },
+      "teams": []
+    },
+    {
+      "id": 1747,
+      "address": {
+        "street": "Palachovo náměstí",
+        "street_number": "2",
+        "recipient": "KBC SSC",
+        "psc": "62500",
+        "city": "Brno"
+      },
+      "teams": []
+    },
+    {
+      "id": 1875,
+      "address": {
+        "street": "Na Pankráci",
+        "street_number": "310/60",
+        "recipient": "ČSOB - Na Pankráci",
+        "psc": "14000",
+        "city": "Praha 4"
+      },
+      "teams": []
+    },
+    {
+      "id": 2219,
+      "address": {
+        "street": "Nám. T.G.Masaryka",
+        "street_number": "12",
+        "recipient": "ČSOB, a.s.",
+        "psc": "30555",
+        "city": "30555"
+      },
+      "teams": []
+    },
+    {
+      "id": 2234,
+      "address": {
+        "street": "Zbraslavské nám.",
+        "street_number": "461",
+        "recipient": "ČSOB a.s., Zbraslavské nám.",
+        "psc": "15600",
+        "city": "Praha 5"
+      },
+      "teams": []
+    },
+    {
+      "id": 2241,
+      "address": {
+        "street": "Ostrožná",
+        "street_number": "17",
+        "recipient": "pobočka Opava, Ostrožná 17",
+        "psc": "74601",
+        "city": "Opava"
+      },
+      "teams": []
+    },
+    {
+      "id": 2285,
+      "address": {
+        "street": "Čechova",
+        "street_number": "4",
+        "recipient": "ČSOB, a.s.",
+        "psc": "75002",
+        "city": "Přerov"
+      },
+      "teams": []
+    },
+    {
+      "id": 2301,
+      "address": {
+        "street": "Radlická",
+        "street_number": "333/150",
+        "recipient": "ústředí společnosti",
+        "psc": "15057",
+        "city": "Prha 5"
+      },
+      "teams": []
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetSubsidiariesResponse.json
+++ b/test/cypress/fixtures/apiGetSubsidiariesResponse.json
@@ -1,93 +1,226 @@
 {
-  "count": 8,
+  "count": 20,
   "next": "https://test.dopracenakole.cz/rest/organizations/580/subsidiaries/?limit=20&offset=20",
   "previous": null,
+
   "results": [
     {
-      "id": 1388,
+      "id": 1358,
       "address": {
-        "street": "Joštova",
-        "street_number": "5",
-        "recipient": "ČSOB",
-        "psc": "60179",
-        "city": "60179"
+        "street": "Krkonošská",
+        "street_number": "177",
+        "recipient": "pobočka Vrchlabí",
+        "psc": "54301",
+        "city": "Vrchlabí"
       },
       "teams": []
     },
     {
-      "id": 1747,
+      "id": 805,
       "address": {
-        "street": "Palachovo náměstí",
-        "street_number": "2",
-        "recipient": "KBC SSC",
-        "psc": "62500",
-        "city": "Brno"
+        "street": "Krkonošská",
+        "street_number": "177",
+        "recipient": "Vrchlabí",
+        "psc": "54301",
+        "city": "Vrchlabí"
       },
       "teams": []
     },
     {
-      "id": 1875,
+      "id": 888,
       "address": {
-        "street": "Na Pankráci",
-        "street_number": "310/60",
-        "recipient": "ČSOB - Na Pankráci",
-        "psc": "14000",
-        "city": "Praha 4"
+        "street": "1.Máje",
+        "street_number": "79/18",
+        "recipient": "ČSOB, a.s., Liberec - 1. Máje",
+        "psc": "46178",
+        "city": "Liberec"
       },
       "teams": []
     },
     {
-      "id": 2219,
+      "id": 889,
       "address": {
-        "street": "Nám. T.G.Masaryka",
-        "street_number": "12",
-        "recipient": "ČSOB, a.s.",
-        "psc": "30555",
-        "city": "30555"
+        "street": "Tř.T.G.Masaryka",
+        "street_number": "492",
+        "recipient": "Frýdek-Místek",
+        "psc": "73801",
+        "city": "Frýdek-Místek"
       },
       "teams": []
     },
     {
-      "id": 2234,
+      "id": 974,
       "address": {
-        "street": "Zbraslavské nám.",
-        "street_number": "461",
-        "recipient": "ČSOB a.s., Zbraslavské nám.",
-        "psc": "15600",
-        "city": "Praha 5"
-      },
-      "teams": []
-    },
-    {
-      "id": 2241,
-      "address": {
-        "street": "Ostrožná",
-        "street_number": "17",
-        "recipient": "pobočka Opava, Ostrožná 17",
+        "street": "Náměstí Osvoboditelů",
+        "street_number": "6",
+        "recipient": "Poštovní spořitelna Opava (Era), Finanční centrum",
         "psc": "74601",
         "city": "Opava"
       },
       "teams": []
     },
     {
-      "id": 2285,
+      "id": 1013,
       "address": {
-        "street": "Čechova",
-        "street_number": "4",
-        "recipient": "ČSOB, a.s.",
-        "psc": "75002",
-        "city": "Přerov"
+        "street": "Dolní náměstí",
+        "street_number": "27 - 28",
+        "recipient": "Olomouc Dolní náměstí",
+        "psc": "77900",
+        "city": "Olomouc"
       },
       "teams": []
     },
     {
-      "id": 2301,
+      "id": 1045,
       "address": {
-        "street": "Radlická",
-        "street_number": "333/150",
-        "recipient": "ústředí společnosti",
-        "psc": "15057",
-        "city": "Prha 5"
+        "street": "Hollarova",
+        "street_number": "5",
+        "recipient": "pobočka Ostrava-Hollarova",
+        "psc": "70200",
+        "city": "Ostrava"
+      },
+      "teams": []
+    },
+    {
+      "id": 973,
+      "address": {
+        "street": "Mírové náměstí",
+        "street_number": "1/1",
+        "recipient": "ČSOB-ÚL",
+        "psc": "40001",
+        "city": "Ústí nad Labem"
+      },
+      "teams": []
+    },
+    {
+      "id": 1000,
+      "address": {
+        "street": "Milady Horákové",
+        "street_number": "6",
+        "recipient": "Brno - Milady Horákové",
+        "psc": "60200",
+        "city": "Brno"
+      },
+      "teams": []
+    },
+    {
+      "id": 1109,
+      "address": {
+        "street": "Horní 47",
+        "street_number": "1471/47",
+        "recipient": "Ostrava Hrabůvka,Horní 47",
+        "psc": "70030",
+        "city": "Ostrava Hrabůvka"
+      },
+      "teams": []
+    },
+    {
+      "id": 1150,
+      "address": {
+        "street": "Dukelská brána",
+        "street_number": "5",
+        "recipient": "ČSOB, a. s., Dukelská brána 5, 796 01 Prostějov",
+        "psc": "79601",
+        "city": "Prostějov"
+      },
+      "teams": []
+    },
+    {
+      "id": 1199,
+      "address": {
+        "street": "Pivovarská",
+        "street_number": "113",
+        "recipient": "pobočka Mladá Boleslav - Pivovarská",
+        "psc": "29301",
+        "city": "Mladá Boleslav"
+      },
+      "teams": []
+    },
+    {
+      "id": 1547,
+      "address": {
+        "street": "Lannova",
+        "street_number": "11/3",
+        "recipient": "ČSOB, České Budějovice-Lannova",
+        "psc": "37001",
+        "city": "České Budějovice"
+      },
+      "teams": []
+    },
+    {
+      "id": 1604,
+      "address": {
+        "street": "tř. Míru",
+        "street_number": "63",
+        "recipient": "FIB Pardubice",
+        "psc": "53183",
+        "city": "Pardubice"
+      },
+      "teams": []
+    },
+    {
+      "id": 1616,
+      "address": {
+        "street": "Náměstí Osvoboditelů",
+        "street_number": "6",
+        "recipient": "ČSOB a.s. Era finanční centrum",
+        "psc": "74601",
+        "city": "Opava"
+      },
+      "teams": []
+    },
+    {
+      "id": 1642,
+      "address": {
+        "street": "T.G.Masaryka",
+        "street_number": "492",
+        "recipient": "pobočka Frýdek",
+        "psc": "73801",
+        "city": "Frýdek-Místek"
+      },
+      "teams": []
+    },
+    {
+      "id": 1605,
+      "address": {
+        "street": "Nerudova",
+        "street_number": "18/39",
+        "recipient": "ČSOB",
+        "psc": "50002",
+        "city": "Hradec Králové"
+      },
+      "teams": []
+    },
+    {
+      "id": 1639,
+      "address": {
+        "street": "Sušilova",
+        "street_number": "1528",
+        "recipient": "ČSOB",
+        "psc": "50003",
+        "city": "Hradec Králové"
+      },
+      "teams": []
+    },
+    {
+      "id": 1676,
+      "address": {
+        "street": "Kostelní",
+        "street_number": "85",
+        "recipient": "ČSOB, a.s., pobočka Žamberk",
+        "psc": "56401",
+        "city": "Žamberk"
+      },
+      "teams": []
+    },
+    {
+      "id": 1135,
+      "address": {
+        "street": "Komenkého",
+        "street_number": "802/17",
+        "recipient": "Jablonec nad Nisou",
+        "psc": "46629",
+        "city": "Jablonec nad Nisou"
       },
       "teams": []
     }

--- a/test/cypress/fixtures/apiGetSubsidiariesResponseNext.json
+++ b/test/cypress/fixtures/apiGetSubsidiariesResponseNext.json
@@ -1,225 +1,93 @@
 {
-  "count": 20,
+  "count": 8,
   "next": null,
   "previous": "https://test.dopracenakole.cz/rest/organizations/580/subsidiaries/?limit=20&offset=0",
   "results": [
     {
-      "id": 1358,
+      "id": 1388,
       "address": {
-        "street": "Krkonošská",
-        "street_number": "177",
-        "recipient": "pobočka Vrchlabí",
-        "psc": "54301",
-        "city": "Vrchlabí"
-      },
-      "teams": []
-    },
-    {
-      "id": 805,
-      "address": {
-        "street": "Krkonošská",
-        "street_number": "177",
-        "recipient": "Vrchlabí",
-        "psc": "54301",
-        "city": "Vrchlabí"
-      },
-      "teams": []
-    },
-    {
-      "id": 888,
-      "address": {
-        "street": "1.Máje",
-        "street_number": "79/18",
-        "recipient": "ČSOB, a.s., Liberec - 1. Máje",
-        "psc": "46178",
-        "city": "Liberec"
-      },
-      "teams": []
-    },
-    {
-      "id": 889,
-      "address": {
-        "street": "Tř.T.G.Masaryka",
-        "street_number": "492",
-        "recipient": "Frýdek-Místek",
-        "psc": "73801",
-        "city": "Frýdek-Místek"
-      },
-      "teams": []
-    },
-    {
-      "id": 974,
-      "address": {
-        "street": "Náměstí Osvoboditelů",
-        "street_number": "6",
-        "recipient": "Poštovní spořitelna Opava (Era), Finanční centrum",
-        "psc": "74601",
-        "city": "Opava"
-      },
-      "teams": []
-    },
-    {
-      "id": 1013,
-      "address": {
-        "street": "Dolní náměstí",
-        "street_number": "27 - 28",
-        "recipient": "Olomouc Dolní náměstí",
-        "psc": "77900",
-        "city": "Olomouc"
-      },
-      "teams": []
-    },
-    {
-      "id": 1045,
-      "address": {
-        "street": "Hollarova",
+        "street": "Joštova",
         "street_number": "5",
-        "recipient": "pobočka Ostrava-Hollarova",
-        "psc": "70200",
-        "city": "Ostrava"
+        "recipient": "ČSOB",
+        "psc": "60179",
+        "city": "60179"
       },
       "teams": []
     },
     {
-      "id": 973,
+      "id": 1747,
       "address": {
-        "street": "Mírové náměstí",
-        "street_number": "1/1",
-        "recipient": "ČSOB-ÚL",
-        "psc": "40001",
-        "city": "Ústí nad Labem"
-      },
-      "teams": []
-    },
-    {
-      "id": 1000,
-      "address": {
-        "street": "Milady Horákové",
-        "street_number": "6",
-        "recipient": "Brno - Milady Horákové",
-        "psc": "60200",
+        "street": "Palachovo náměstí",
+        "street_number": "2",
+        "recipient": "KBC SSC",
+        "psc": "62500",
         "city": "Brno"
       },
       "teams": []
     },
     {
-      "id": 1109,
+      "id": 1875,
       "address": {
-        "street": "Horní 47",
-        "street_number": "1471/47",
-        "recipient": "Ostrava Hrabůvka,Horní 47",
-        "psc": "70030",
-        "city": "Ostrava Hrabůvka"
+        "street": "Na Pankráci",
+        "street_number": "310/60",
+        "recipient": "ČSOB - Na Pankráci",
+        "psc": "14000",
+        "city": "Praha 4"
       },
       "teams": []
     },
     {
-      "id": 1150,
+      "id": 2219,
       "address": {
-        "street": "Dukelská brána",
-        "street_number": "5",
-        "recipient": "ČSOB, a. s., Dukelská brána 5, 796 01 Prostějov",
-        "psc": "79601",
-        "city": "Prostějov"
+        "street": "Nám. T.G.Masaryka",
+        "street_number": "12",
+        "recipient": "ČSOB, a.s.",
+        "psc": "30555",
+        "city": "30555"
       },
       "teams": []
     },
     {
-      "id": 1199,
+      "id": 2234,
       "address": {
-        "street": "Pivovarská",
-        "street_number": "113",
-        "recipient": "pobočka Mladá Boleslav - Pivovarská",
-        "psc": "29301",
-        "city": "Mladá Boleslav"
+        "street": "Zbraslavské nám.",
+        "street_number": "461",
+        "recipient": "ČSOB a.s., Zbraslavské nám.",
+        "psc": "15600",
+        "city": "Praha 5"
       },
       "teams": []
     },
     {
-      "id": 1547,
+      "id": 2241,
       "address": {
-        "street": "Lannova",
-        "street_number": "11/3",
-        "recipient": "ČSOB, České Budějovice-Lannova",
-        "psc": "37001",
-        "city": "České Budějovice"
-      },
-      "teams": []
-    },
-    {
-      "id": 1604,
-      "address": {
-        "street": "tř. Míru",
-        "street_number": "63",
-        "recipient": "FIB Pardubice",
-        "psc": "53183",
-        "city": "Pardubice"
-      },
-      "teams": []
-    },
-    {
-      "id": 1616,
-      "address": {
-        "street": "Náměstí Osvoboditelů",
-        "street_number": "6",
-        "recipient": "ČSOB a.s. Era finanční centrum",
+        "street": "Ostrožná",
+        "street_number": "17",
+        "recipient": "pobočka Opava, Ostrožná 17",
         "psc": "74601",
         "city": "Opava"
       },
       "teams": []
     },
     {
-      "id": 1642,
+      "id": 2285,
       "address": {
-        "street": "T.G.Masaryka",
-        "street_number": "492",
-        "recipient": "pobočka Frýdek",
-        "psc": "73801",
-        "city": "Frýdek-Místek"
+        "street": "Čechova",
+        "street_number": "4",
+        "recipient": "ČSOB, a.s.",
+        "psc": "75002",
+        "city": "Přerov"
       },
       "teams": []
     },
     {
-      "id": 1605,
+      "id": 2301,
       "address": {
-        "street": "Nerudova",
-        "street_number": "18/39",
-        "recipient": "ČSOB",
-        "psc": "50002",
-        "city": "Hradec Králové"
-      },
-      "teams": []
-    },
-    {
-      "id": 1639,
-      "address": {
-        "street": "Sušilova",
-        "street_number": "1528",
-        "recipient": "ČSOB",
-        "psc": "50003",
-        "city": "Hradec Králové"
-      },
-      "teams": []
-    },
-    {
-      "id": 1676,
-      "address": {
-        "street": "Kostelní",
-        "street_number": "85",
-        "recipient": "ČSOB, a.s., pobočka Žamberk",
-        "psc": "56401",
-        "city": "Žamberk"
-      },
-      "teams": []
-    },
-    {
-      "id": 1135,
-      "address": {
-        "street": "Komenkého",
-        "street_number": "802/17",
-        "recipient": "Jablonec nad Nisou",
-        "psc": "46629",
-        "city": "Jablonec nad Nisou"
+        "street": "Radlická",
+        "street_number": "333/150",
+        "recipient": "ústředí společnosti",
+        "psc": "15057",
+        "city": "Prha 5"
       },
       "teams": []
     }

--- a/test/cypress/fixtures/apiGetSubsidiariesResponseNext.json
+++ b/test/cypress/fixtures/apiGetSubsidiariesResponseNext.json
@@ -1,0 +1,227 @@
+{
+  "count": 20,
+  "next": null,
+  "previous": "https://test.dopracenakole.cz/rest/organizations/580/subsidiaries/?limit=20&offset=0",
+  "results": [
+    {
+      "id": 1358,
+      "address": {
+        "street": "Krkonošská",
+        "street_number": "177",
+        "recipient": "pobočka Vrchlabí",
+        "psc": "54301",
+        "city": "Vrchlabí"
+      },
+      "teams": []
+    },
+    {
+      "id": 805,
+      "address": {
+        "street": "Krkonošská",
+        "street_number": "177",
+        "recipient": "Vrchlabí",
+        "psc": "54301",
+        "city": "Vrchlabí"
+      },
+      "teams": []
+    },
+    {
+      "id": 888,
+      "address": {
+        "street": "1.Máje",
+        "street_number": "79/18",
+        "recipient": "ČSOB, a.s., Liberec - 1. Máje",
+        "psc": "46178",
+        "city": "Liberec"
+      },
+      "teams": []
+    },
+    {
+      "id": 889,
+      "address": {
+        "street": "Tř.T.G.Masaryka",
+        "street_number": "492",
+        "recipient": "Frýdek-Místek",
+        "psc": "73801",
+        "city": "Frýdek-Místek"
+      },
+      "teams": []
+    },
+    {
+      "id": 974,
+      "address": {
+        "street": "Náměstí Osvoboditelů",
+        "street_number": "6",
+        "recipient": "Poštovní spořitelna Opava (Era), Finanční centrum",
+        "psc": "74601",
+        "city": "Opava"
+      },
+      "teams": []
+    },
+    {
+      "id": 1013,
+      "address": {
+        "street": "Dolní náměstí",
+        "street_number": "27 - 28",
+        "recipient": "Olomouc Dolní náměstí",
+        "psc": "77900",
+        "city": "Olomouc"
+      },
+      "teams": []
+    },
+    {
+      "id": 1045,
+      "address": {
+        "street": "Hollarova",
+        "street_number": "5",
+        "recipient": "pobočka Ostrava-Hollarova",
+        "psc": "70200",
+        "city": "Ostrava"
+      },
+      "teams": []
+    },
+    {
+      "id": 973,
+      "address": {
+        "street": "Mírové náměstí",
+        "street_number": "1/1",
+        "recipient": "ČSOB-ÚL",
+        "psc": "40001",
+        "city": "Ústí nad Labem"
+      },
+      "teams": []
+    },
+    {
+      "id": 1000,
+      "address": {
+        "street": "Milady Horákové",
+        "street_number": "6",
+        "recipient": "Brno - Milady Horákové",
+        "psc": "60200",
+        "city": "Brno"
+      },
+      "teams": []
+    },
+    {
+      "id": 1109,
+      "address": {
+        "street": "Horní 47",
+        "street_number": "1471/47",
+        "recipient": "Ostrava Hrabůvka,Horní 47",
+        "psc": "70030",
+        "city": "Ostrava Hrabůvka"
+      },
+      "teams": []
+    },
+    {
+      "id": 1150,
+      "address": {
+        "street": "Dukelská brána",
+        "street_number": "5",
+        "recipient": "ČSOB, a. s., Dukelská brána 5, 796 01 Prostějov",
+        "psc": "79601",
+        "city": "Prostějov"
+      },
+      "teams": []
+    },
+    {
+      "id": 1199,
+      "address": {
+        "street": "Pivovarská",
+        "street_number": "113",
+        "recipient": "pobočka Mladá Boleslav - Pivovarská",
+        "psc": "29301",
+        "city": "Mladá Boleslav"
+      },
+      "teams": []
+    },
+    {
+      "id": 1547,
+      "address": {
+        "street": "Lannova",
+        "street_number": "11/3",
+        "recipient": "ČSOB, České Budějovice-Lannova",
+        "psc": "37001",
+        "city": "České Budějovice"
+      },
+      "teams": []
+    },
+    {
+      "id": 1604,
+      "address": {
+        "street": "tř. Míru",
+        "street_number": "63",
+        "recipient": "FIB Pardubice",
+        "psc": "53183",
+        "city": "Pardubice"
+      },
+      "teams": []
+    },
+    {
+      "id": 1616,
+      "address": {
+        "street": "Náměstí Osvoboditelů",
+        "street_number": "6",
+        "recipient": "ČSOB a.s. Era finanční centrum",
+        "psc": "74601",
+        "city": "Opava"
+      },
+      "teams": []
+    },
+    {
+      "id": 1642,
+      "address": {
+        "street": "T.G.Masaryka",
+        "street_number": "492",
+        "recipient": "pobočka Frýdek",
+        "psc": "73801",
+        "city": "Frýdek-Místek"
+      },
+      "teams": []
+    },
+    {
+      "id": 1605,
+      "address": {
+        "street": "Nerudova",
+        "street_number": "18/39",
+        "recipient": "ČSOB",
+        "psc": "50002",
+        "city": "Hradec Králové"
+      },
+      "teams": []
+    },
+    {
+      "id": 1639,
+      "address": {
+        "street": "Sušilova",
+        "street_number": "1528",
+        "recipient": "ČSOB",
+        "psc": "50003",
+        "city": "Hradec Králové"
+      },
+      "teams": []
+    },
+    {
+      "id": 1676,
+      "address": {
+        "street": "Kostelní",
+        "street_number": "85",
+        "recipient": "ČSOB, a.s., pobočka Žamberk",
+        "psc": "56401",
+        "city": "Žamberk"
+      },
+      "teams": []
+    },
+    {
+      "id": 1135,
+      "address": {
+        "street": "Komenkého",
+        "street_number": "802/17",
+        "recipient": "Jablonec nad Nisou",
+        "psc": "46629",
+        "city": "Jablonec nad Nisou"
+      },
+      "teams": []
+    }
+  ]
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -407,32 +407,36 @@ Cypress.Commands.add(
  */
 Cypress.Commands.add(
   'waitForSubsidiariesApi',
-  (subsidiariesResponse, subsidiariesResponseNext) => {
-    cy.wait(['@getSubsidiaries', '@getSubsidiariesNextPage']).spread(
-      (getSubsidiaries, getSubsidiariesNextPage) => {
-        expect(getSubsidiaries.request.headers.authorization).to.include(
-          bearerTokeAuth,
+  cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
+    cy.fixture('apiGetSubsidiariesResponseNext').then(
+      (subsidiariesResponseNext) => {
+        cy.wait(['@getSubsidiaries', '@getSubsidiariesNextPage']).spread(
+          (getSubsidiaries, getSubsidiariesNextPage) => {
+            expect(getSubsidiaries.request.headers.authorization).to.include(
+              bearerTokeAuth,
+            );
+            if (getSubsidiaries.response) {
+              expect(getSubsidiaries.response.statusCode).to.equal(
+                httpSuccessfullStatus,
+              );
+              expect(getSubsidiaries.response.body).to.deep.equal(
+                subsidiariesResponse,
+              );
+            }
+            expect(
+              getSubsidiariesNextPage.request.headers.authorization,
+            ).to.include(bearerTokeAuth);
+            if (getSubsidiariesNextPage.response) {
+              expect(getSubsidiariesNextPage.response.statusCode).to.equal(
+                httpSuccessfullStatus,
+              );
+              expect(getSubsidiariesNextPage.response.body).to.deep.equal(
+                subsidiariesResponseNext,
+              );
+            }
+          },
         );
-        if (getSubsidiaries.response) {
-          expect(getSubsidiaries.response.statusCode).to.equal(
-            httpSuccessfullStatus,
-          );
-          expect(getSubsidiaries.response.body).to.deep.equal(
-            subsidiariesResponse,
-          );
-        }
-        expect(
-          getSubsidiariesNextPage.request.headers.authorization,
-        ).to.include(bearerTokeAuth);
-        if (getSubsidiariesNextPage.response) {
-          expect(getSubsidiariesNextPage.response.statusCode).to.equal(
-            httpSuccessfullStatus,
-          );
-          expect(getSubsidiariesNextPage.response.body).to.deep.equal(
-            subsidiariesResponseNext,
-          );
-        }
       },
     );
-  },
+  }),
 );

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -370,14 +370,15 @@ Cypress.Commands.add('waitForCitiesApi', () => {
 Cypress.Commands.add(
   'interceptSubsidiariesGetApi',
   (config, i18n, organizationId) => {
-    const { apiBase, apiDefaultLang, urlApiOrganizations } = config;
+    const { apiBase, apiDefaultLang, urlApiOrganizations, urlApiSubsidiaries } =
+      config;
     const apiBaseUrl = getApiBaseUrlWithLang(
       null,
       apiBase,
       apiDefaultLang,
       i18n,
     );
-    const urlApiSubsidiariesLocalized = `${apiBaseUrl}${urlApiOrganizations}${organizationId}/subsidiaries/`;
+    const urlApiSubsidiariesLocalized = `${apiBaseUrl}${urlApiOrganizations}${organizationId}/${urlApiSubsidiaries}`;
 
     cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
       cy.fixture('apiGetSubsidiariesResponseNext').then(

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -37,7 +37,7 @@ import {
   userAgentHeader,
 } from './commonTests';
 import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_lang';
-import { bearerTokeAuth } from 'src/utils';
+import { bearerTokeAuth } from '../../../src/utils';
 
 // Fix for ResizeObserver loop issue in Firefox
 // see https://stackoverflow.com/questions/74947338/i-keep-getting-error-resizeobserver-loop-limit-exceeded-in-cypress
@@ -407,36 +407,32 @@ Cypress.Commands.add(
  */
 Cypress.Commands.add(
   'waitForSubsidiariesApi',
-  cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
-    cy.fixture('apiGetSubsidiariesResponseNext').then(
-      (subsidiariesResponseNext) => {
-        cy.wait(['@getSubsidiaries', '@getSubsidiariesNextPage']).spread(
-          (getSubsidiaries, getSubsidiariesNextPage) => {
-            expect(getSubsidiaries.request.headers.authorization).to.include(
-              bearerTokeAuth,
-            );
-            if (getSubsidiaries.response) {
-              expect(getSubsidiaries.response.statusCode).to.equal(
-                httpSuccessfullStatus,
-              );
-              expect(getSubsidiaries.response.body).to.deep.equal(
-                subsidiariesResponse,
-              );
-            }
-            expect(
-              getSubsidiariesNextPage.request.headers.authorization,
-            ).to.include(bearerTokeAuth);
-            if (getSubsidiariesNextPage.response) {
-              expect(getSubsidiariesNextPage.response.statusCode).to.equal(
-                httpSuccessfullStatus,
-              );
-              expect(getSubsidiariesNextPage.response.body).to.deep.equal(
-                subsidiariesResponseNext,
-              );
-            }
-          },
+  (subsidiariesResponse, subsidiariesResponseNext) => {
+    cy.wait(['@getSubsidiaries', '@getSubsidiariesNextPage']).spread(
+      (getSubsidiaries, getSubsidiariesNextPage) => {
+        expect(getSubsidiaries.request.headers.authorization).to.include(
+          bearerTokeAuth,
         );
+        if (getSubsidiaries.response) {
+          expect(getSubsidiaries.response.statusCode).to.equal(
+            httpSuccessfullStatus,
+          );
+          expect(getSubsidiaries.response.body).to.deep.equal(
+            subsidiariesResponse,
+          );
+        }
+        expect(
+          getSubsidiariesNextPage.request.headers.authorization,
+        ).to.include(bearerTokeAuth);
+        if (getSubsidiariesNextPage.response) {
+          expect(getSubsidiariesNextPage.response.statusCode).to.equal(
+            httpSuccessfullStatus,
+          );
+          expect(getSubsidiariesNextPage.response.body).to.deep.equal(
+            subsidiariesResponseNext,
+          );
+        }
       },
     );
-  }),
+  },
 );


### PR DESCRIPTION
Add ability to load subsidiaries based on organizationId via `useApiGetSubsidiaries` composable.

* Add API fetch behaviour in `useApiGetSubsidiaries`.
* Add fixtures and Cypress commands for testing.
* Update `FormFieldCompanyAddress.cy.js` component test to check for intercepted API methods.
* Update component `FormFieldCompanyAddress` - we no longer accept options. Instead, options are loaded based on accessing the `organizationId` field from `registerChallenge` store.
* Use correct values in `FormFieldOptionGroup` (OrganizationType enum)
* Simplify composable`useSelectedOrganization` - we can use `subsidiaryId` (computed from store) instead of `selectedAddress` 