### PR TITLE
src/components: update organizationType in store after subject selection in RegisterChallengePayment

### DIFF
--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -7,6 +7,7 @@ import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
 import { OrganizationType } from 'components/types/Organization';
 import { useRegisterChallengeStore } from 'stores/registerChallenge';
+import { getRadioOption } from 'test/cypress/utils';
 
 // selectors
 const selectorBannerPaymentMinimum = 'banner-payment-minimum';
@@ -492,10 +493,6 @@ function coreTests() {
         .should('equal', OrganizationType.none);
     });
   });
-}
-
-function getRadioOption(value) {
-  return `radio-option-${value}`;
 }
 
 function testDonation() {

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -460,33 +460,45 @@ function coreTests() {
       // access store via computed property to correctly track changes
       const computedStoreProperty = computed(() => store.getOrganizationType);
       // start in default state (individual)
-      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.individual))
+        .should('be.visible')
+        .click();
       // switch to company
-      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.company))
+        .should('be.visible')
+        .click();
       // check store value
       cy.wrap(computedStoreProperty)
         .its('value')
         .should('equal', OrganizationType.company);
       // switch to school
-      cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.school))
+        .should('be.visible')
+        .click();
       // check store value
       cy.wrap(computedStoreProperty)
         .its('value')
         .should('equal', OrganizationType.school);
       // switch to individual
-      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.individual))
+        .should('be.visible')
+        .click();
       // check store value
       cy.wrap(computedStoreProperty)
         .its('value')
         .should('equal', OrganizationType.none);
       // switch to company
-      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.company))
+        .should('be.visible')
+        .click();
       // check store value
       cy.wrap(computedStoreProperty)
         .its('value')
         .should('equal', OrganizationType.company);
       // switch to voucher
-      cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+      cy.dataCy(getRadioOption(PaymentSubject.voucher))
+        .should('be.visible')
+        .click();
       // check store value
       cy.wrap(computedStoreProperty)
         .its('value')

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -1,8 +1,12 @@
+import { createPinia, setActivePinia } from 'pinia';
 import { colors } from 'quasar';
+import { computed } from 'vue';
 import RegisterChallengePayment from 'components/register/RegisterChallengePayment.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
+import { OrganizationType } from 'components/types/Organization';
+import { useRegisterChallengeStore } from 'stores/registerChallenge';
 
 // selectors
 const selectorBannerPaymentMinimum = 'banner-payment-minimum';
@@ -79,6 +83,7 @@ describe('<RegisterChallengePayment>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
+      setActivePinia(createPinia());
       cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
         cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
           cy.wrap(voucherFull).as('voucherFull');
@@ -96,6 +101,7 @@ describe('<RegisterChallengePayment>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      setActivePinia(createPinia());
       cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
         cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
           cy.wrap(voucherFull).as('voucherFull');
@@ -446,6 +452,45 @@ function coreTests() {
 
     // user still has option to add donation
     testDonation();
+  });
+
+  it('if selected company or school, saves organization type value in store', () => {
+    cy.wrap(useRegisterChallengeStore()).then((store) => {
+      // access store via computed property to correctly track changes
+      const computedStoreProperty = computed(() => store.getOrganizationType);
+      // start in default state (individual)
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      // switch to company
+      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+      // check store value
+      cy.wrap(computedStoreProperty)
+        .its('value')
+        .should('equal', OrganizationType.company);
+      // switch to school
+      cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
+      // check store value
+      cy.wrap(computedStoreProperty)
+        .its('value')
+        .should('equal', OrganizationType.school);
+      // switch to individual
+      cy.dataCy(getRadioOption(optionIndividual)).should('be.visible').click();
+      // check store value
+      cy.wrap(computedStoreProperty)
+        .its('value')
+        .should('equal', OrganizationType.none);
+      // switch to company
+      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+      // check store value
+      cy.wrap(computedStoreProperty)
+        .its('value')
+        .should('equal', OrganizationType.company);
+      // switch to voucher
+      cy.dataCy(getRadioOption(optionVoucher)).should('be.visible').click();
+      // check store value
+      cy.wrap(computedStoreProperty)
+        .its('value')
+        .should('equal', OrganizationType.none);
+    });
   });
 }
 

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -7,7 +7,7 @@ import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
 import { OrganizationType } from 'components/types/Organization';
 import { useRegisterChallengeStore } from 'stores/registerChallenge';
-import { getRadioOption } from 'test/cypress/utils';
+import { getRadioOption } from '../../../test/cypress/utils';
 
 // selectors
 const selectorBannerPaymentMinimum = 'banner-payment-minimum';

--- a/src/components/form/FormFieldRadioRequired.vue
+++ b/src/components/form/FormFieldRadioRequired.vue
@@ -9,8 +9,8 @@
  * Used in `FormRegister`, `FormLogin`, `RegisterChallengePayment`.
  *
  * @props
- * - `modelValue` (string, required): The object representing user input.
- *   It should be of type `string`.
+ * - `modelValue` (string|null): The object representing user input.
+ *   It should be of type `string` or `null`.
  * - `options` (object, required): The object representing the options.
  *   Should have props:
  *   - label (string)
@@ -40,7 +40,7 @@ export default defineComponent({
   props: {
     modelValue: {
       type: String as () => string | null,
-      required: true,
+      default: null,
     },
     options: {
       type: Array as () => FormOption[],

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -189,6 +189,9 @@ export default defineComponent({
         `Organization type <${registerChallengeStore.getOrganizationType}>`,
       );
     });
+    const organizationType = computed<OrganizationType>(() => {
+      return registerChallengeStore.getOrganizationType;
+    });
 
     const isVoucherValid = computed((): boolean => {
       return !!activeVoucher.value?.code;
@@ -424,6 +427,7 @@ export default defineComponent({
       isRegistrationCoordinator,
       optionsPaymentAmountComputed,
       optionsPaymentSubject,
+      organizationType,
       paymentAmountMax,
       paymentAmountMin,
       primaryLightColor,
@@ -513,7 +517,7 @@ export default defineComponent({
       <!-- Input: Company -->
       <form-field-company
         v-model="selectedCompany"
-        :organizationType="selectedPaymentSubject"
+        :organization-type="organizationType"
         class="text-grey-10"
         data-cy="form-field-company"
       />

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -176,18 +176,20 @@ export default defineComponent({
       logger?.debug(
         `Selected payment subject changed from <${oldVal}> to <${newVal}>`,
       );
-      if (newVal === PaymentSubject.company) {
-        logger?.debug(`Set organization type to <${OrganizationType.company}>`);
-        registerChallengeStore.setOrganizationType(OrganizationType.company);
-      } else if (newVal === PaymentSubject.school) {
-        logger?.debug(`Set organization type to <${OrganizationType.school}>`);
-        registerChallengeStore.setOrganizationType(OrganizationType.school);
-      } else {
-        logger?.debug(`Set organization type to <${OrganizationType.none}>`);
-        registerChallengeStore.setOrganizationType(OrganizationType.none);
+      switch (newVal) {
+        case PaymentSubject.company:
+          registerChallengeStore.setOrganizationType(newVal);
+          break;
+        case PaymentSubject.school:
+          registerChallengeStore.setOrganizationType(newVal);
+          break;
+        default:
+          registerChallengeStore.setOrganizationType(OrganizationType.none);
+          break;
       }
       logger?.debug(
-        `Organization type <${registerChallengeStore.getOrganizationType}>`,
+        'Set store organization type to' +
+          ` <${registerChallengeStore.getOrganizationType}>.`,
       );
     });
     const organizationType = computed<OrganizationType>(() => {

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -185,7 +185,6 @@ export default defineComponent({
           break;
         default:
           registerChallengeStore.setOrganizationType(OrganizationType.none);
-          break;
       }
       logger?.debug(
         'Set store organization type to' +

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -45,6 +45,7 @@ import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 // enums
 import { Currency } from '../../composables/useFormatPrice';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
+import { OrganizationType } from '../types/Organization';
 
 // stores
 import { useRegisterChallengeStore } from '../../stores/registerChallenge';

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -46,6 +46,9 @@ import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { Currency } from '../../composables/useFormatPrice';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
 
+// stores
+import { useRegisterChallengeStore } from '../../stores/registerChallenge';
+
 // types
 import type { FormOption, FormPaymentVoucher } from '../types/Form';
 import type { Logger } from '../types/Logger';
@@ -165,6 +168,26 @@ export default defineComponent({
       phone: '',
       responsibility: false,
       terms: false,
+    });
+
+    const registerChallengeStore = useRegisterChallengeStore();
+    watch(selectedPaymentSubject, (newVal, oldVal) => {
+      logger?.debug(
+        `Selected payment subject changed from <${oldVal}> to <${newVal}>`,
+      );
+      if (newVal === PaymentSubject.company) {
+        logger?.debug(`Set organization type to <${OrganizationType.company}>`);
+        registerChallengeStore.setOrganizationType(OrganizationType.company);
+      } else if (newVal === PaymentSubject.school) {
+        logger?.debug(`Set organization type to <${OrganizationType.school}>`);
+        registerChallengeStore.setOrganizationType(OrganizationType.school);
+      } else {
+        logger?.debug(`Set organization type to <${OrganizationType.none}>`);
+        registerChallengeStore.setOrganizationType(OrganizationType.none);
+      }
+      logger?.debug(
+        `Organization type <${registerChallengeStore.getOrganizationType}>`,
+      );
     });
 
     const isVoucherValid = computed((): boolean => {

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -6,6 +6,7 @@ export enum OrganizationType {
   company = 'company',
   school = 'school',
   family = 'family',
+  none = '',
 }
 
 export enum OrganizationLevel {

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -28,7 +28,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     $log: null as Logger | null,
     personalDetails: emptyFormPersonalDetails,
     payment: null, // TODO: add data type options
-    organizationType: '' as OrganizationType,
+    organizationType: OrganizationType.none,
     organizationId: null as number | null,
     subsidiaryId: null as number | null,
     teamId: null as number | null,

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -8,10 +8,6 @@ import { routesConf } from '../../../src/router/routes_conf';
 import { OrganizationType } from '../../../src/components/types/Organization';
 import { getRadioOption } from 'test/cypress/utils';
 
-// variables
-const optionCompany = 'company';
-const optionSchool = 'school';
-
 const doneIcon = new URL(
   '../../../src/assets/svg/check.svg',
   cy.config().baseUrl,
@@ -259,7 +255,9 @@ describe('Register Challenge page', () => {
       cy.get('@i18n').then((i18n) => {
         passToStep2();
         // in payment step, select "paid by company"
-        cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+        cy.dataCy(getRadioOption(OrganizationType.company))
+          .should('be.visible')
+          .click();
         // select paying company (required)
         cy.fixture('formFieldCompany').then((formFieldCompany) => {
           cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
@@ -297,7 +295,9 @@ describe('Register Challenge page', () => {
       cy.get('@i18n').then((i18n) => {
         passToStep2();
         // in payment step, select "paid by school"
-        cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
+        cy.dataCy(getRadioOption(OrganizationType.school))
+          .should('be.visible')
+          .click();
         // select paying school (required)
         cy.fixture('formFieldCompany').then((formFieldCompany) => {
           cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -256,69 +256,79 @@ describe('Register Challenge page', () => {
     });
 
     it('pre-selects company in step 3 based on payment subject', () => {
-      passToStep2();
-      // in payment step, select "paid by company"
-      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
-      // select paying company (required)
-      cy.fixture('formFieldCompany').then((formFieldCompany) => {
-        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          cy.dataCy('form-field-company').find('.q-field__append').click();
-          // select option
-          cy.get('.q-item__label')
-            .should('be.visible')
-            .and((opts) => {
-              expect(
-                opts.length,
-                formFieldCompany.results.length +
-                  formFieldCompanyNext.results.length,
-              );
-            })
-            .first()
-            .click();
-          cy.get('.q-menu').should('not.exist');
+      cy.get('@i18n').then((i18n) => {
+        passToStep2();
+        // in payment step, select "paid by company"
+        cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+        // select paying company (required)
+        cy.fixture('formFieldCompany').then((formFieldCompany) => {
+          cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+            waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+            cy.dataCy('form-field-company').find('.q-field__append').click();
+            // select option
+            cy.get('.q-item__label')
+              .should('be.visible')
+              .and((opts) => {
+                expect(
+                  opts.length,
+                  formFieldCompany.results.length +
+                    formFieldCompanyNext.results.length,
+                );
+              })
+              .first()
+              .click();
+            cy.get('.q-menu').should('not.exist');
+          });
         });
+        // go to next step "organization type"
+        cy.dataCy('step-2-continue').should('be.visible').click();
+        // option "company" is selected
+        cy.dataCy('form-field-option-group')
+          .find('.q-radio__inner.q-radio__inner--truthy')
+          .siblings('.q-radio__label')
+          .should(
+            'contain',
+            i18n.global.t('form.participation.labelColleagues'),
+          );
       });
-      // go to next step "organization type"
-      cy.dataCy('step-2-continue').should('be.visible').click();
-      // option "company" is selected
-      cy.dataCy('form-field-option-group')
-        .find('.q-radio__inner')
-        .first()
-        .should('have.class', 'q-radio__inner--truthy');
     });
 
     it('pre-selects school in step 3 based on payment subject', () => {
-      passToStep2();
-      // in payment step, select "paid by school"
-      cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
-      // select paying school (required)
-      cy.fixture('formFieldCompany').then((formFieldCompany) => {
-        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-          cy.dataCy('form-field-company').find('.q-field__append').click();
-          // select option
-          cy.get('.q-item__label')
-            .should('be.visible')
-            .and((opts) => {
-              expect(
-                opts.length,
-                formFieldCompany.results.length +
-                  formFieldCompanyNext.results.length,
-              );
-            })
-            .first()
-            .click();
-          cy.get('.q-menu').should('not.exist');
+      cy.get('@i18n').then((i18n) => {
+        passToStep2();
+        // in payment step, select "paid by school"
+        cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
+        // select paying school (required)
+        cy.fixture('formFieldCompany').then((formFieldCompany) => {
+          cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+            waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+            cy.dataCy('form-field-company').find('.q-field__append').click();
+            // select option
+            cy.get('.q-item__label')
+              .should('be.visible')
+              .and((opts) => {
+                expect(
+                  opts.length,
+                  formFieldCompany.results.length +
+                    formFieldCompanyNext.results.length,
+                );
+              })
+              .first()
+              .click();
+            cy.get('.q-menu').should('not.exist');
+          });
         });
+        // go to next step "organization type"
+        cy.dataCy('step-2-continue').should('be.visible').click();
+        // option "school" is selected
+        cy.dataCy('form-field-option-group')
+          .find('.q-radio__inner.q-radio__inner--truthy')
+          .siblings('.q-radio__label')
+          .should(
+            'contain',
+            i18n.global.t('form.participation.labelSchoolmates'),
+          );
       });
-      // go to next step "organization type"
-      cy.dataCy('step-2-continue').should('be.visible').click();
-      // option "school" is selected
-      cy.dataCy('form-field-option-group')
-        .find('.q-radio__inner')
-        .eq(1)
-        .should('have.class', 'q-radio__inner--truthy');
     });
 
     it('validates fourth step (organization and address)', () => {

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -257,9 +257,9 @@ describe('Register Challenge page', () => {
 
     it('pre-selects company in step 3 based on payment subject', () => {
       passToStep2();
-      // switch to company
+      // in payment step, select "paid by company"
       cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
-      // select company
+      // select paying company (required)
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
@@ -279,9 +279,9 @@ describe('Register Challenge page', () => {
           cy.get('.q-menu').should('not.exist');
         });
       });
-      // go to next step
+      // go to next step "organization type"
       cy.dataCy('step-2-continue').should('be.visible').click();
-      // option company is selected
+      // option "company" is selected
       cy.dataCy('form-field-option-group')
         .find('.q-radio__inner')
         .first()
@@ -290,9 +290,9 @@ describe('Register Challenge page', () => {
 
     it('pre-selects school in step 3 based on payment subject', () => {
       passToStep2();
-      // switch to school
+      // in payment step, select "paid by school"
       cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
-      // select school
+      // select paying school (required)
       cy.fixture('formFieldCompany').then((formFieldCompany) => {
         cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
           waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
@@ -312,9 +312,9 @@ describe('Register Challenge page', () => {
           cy.get('.q-menu').should('not.exist');
         });
       });
-      // go to next step
+      // go to next step "organization type"
       cy.dataCy('step-2-continue').should('be.visible').click();
-      // option company is selected
+      // option "school" is selected
       cy.dataCy('form-field-option-group')
         .find('.q-radio__inner')
         .eq(1)

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1,8 +1,16 @@
 import {
+  interceptOrganizationsApi,
   testLanguageSwitcher,
   testBackgroundImage,
+  waitForOrganizationsApi,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
+import { OrganizationType } from '../../../src/components/types/Organization';
+import { getRadioOption } from 'test/cypress/utils';
+
+// variables
+const optionCompany = 'company';
+const optionSchool = 'school';
 
 const doneIcon = new URL(
   '../../../src/assets/svg/check.svg',
@@ -95,6 +103,16 @@ describe('Register Challenge page', () => {
                 config,
                 win.i18n,
                 formOrganizationOptions[0].subsidiaries[0].id,
+              );
+              interceptOrganizationsApi(
+                config,
+                win.i18n,
+                OrganizationType.company,
+              );
+              interceptOrganizationsApi(
+                config,
+                win.i18n,
+                OrganizationType.school,
               );
             },
           );
@@ -235,6 +253,72 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-3-continue').should('be.visible').click();
       // on step 4
       cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
+    });
+
+    it('pre-selects company in step 3 based on payment subject', () => {
+      passToStep2();
+      // switch to company
+      cy.dataCy(getRadioOption(optionCompany)).should('be.visible').click();
+      // select company
+      cy.fixture('formFieldCompany').then((formFieldCompany) => {
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.dataCy('form-field-company').find('.q-field__append').click();
+          // select option
+          cy.get('.q-item__label')
+            .should('be.visible')
+            .and((opts) => {
+              expect(
+                opts.length,
+                formFieldCompany.results.length +
+                  formFieldCompanyNext.results.length,
+              );
+            })
+            .first()
+            .click();
+          cy.get('.q-menu').should('not.exist');
+        });
+      });
+      // go to next step
+      cy.dataCy('step-2-continue').should('be.visible').click();
+      // option company is selected
+      cy.dataCy('form-field-option-group')
+        .find('.q-radio__inner')
+        .first()
+        .should('have.class', 'q-radio__inner--truthy');
+    });
+
+    it('pre-selects school in step 3 based on payment subject', () => {
+      passToStep2();
+      // switch to school
+      cy.dataCy(getRadioOption(optionSchool)).should('be.visible').click();
+      // select school
+      cy.fixture('formFieldCompany').then((formFieldCompany) => {
+        cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+          waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+          cy.dataCy('form-field-company').find('.q-field__append').click();
+          // select option
+          cy.get('.q-item__label')
+            .should('be.visible')
+            .and((opts) => {
+              expect(
+                opts.length,
+                formFieldCompany.results.length +
+                  formFieldCompanyNext.results.length,
+              );
+            })
+            .first()
+            .click();
+          cy.get('.q-menu').should('not.exist');
+        });
+      });
+      // go to next step
+      cy.dataCy('step-2-continue').should('be.visible').click();
+      // option company is selected
+      cy.dataCy('form-field-option-group')
+        .find('.q-radio__inner')
+        .eq(1)
+        .should('have.class', 'q-radio__inner--truthy');
     });
 
     it('validates fourth step (organization and address)', () => {

--- a/test/cypress/utils/index.ts
+++ b/test/cypress/utils/index.ts
@@ -36,4 +36,20 @@ function vModelAdapter<T>(modelRef: Ref<T>, modelName = 'modelValue') {
   };
 }
 
-export { hexToRgb, transparentColor, vModelAdapter, whiteColor };
+/**
+ * Returns the selector for a radio option.
+ * Used in RegisterChallengePayment.cy.js and register_challenge.spec.cy.js.
+ * @param value - The value of the radio option.
+ * @returns The selector for the radio option.
+ */
+function getRadioOption(value: string) {
+  return `radio-option-${value}`;
+}
+
+export {
+  getRadioOption,
+  hexToRgb,
+  transparentColor,
+  vModelAdapter,
+  whiteColor,
+};

--- a/test/cypress/utils/index.ts
+++ b/test/cypress/utils/index.ts
@@ -38,13 +38,10 @@ function vModelAdapter<T>(modelRef: Ref<T>, modelName = 'modelValue') {
 
 /**
  * Returns the selector for a radio option.
- * Used in RegisterChallengePayment.cy.js and register_challenge.spec.cy.js.
- * @param value - The value of the radio option.
- * @returns The selector for the radio option.
+ * @param {String} val - The value of the radio option.
+ * @returns {String} - The string selector for the radio option.
  */
-function getRadioOption(value: string) {
-  return `radio-option-${value}`;
-}
+const getRadioOption = (val: string): string => `radio-option-${val}`;
 
 export {
   getRadioOption,


### PR DESCRIPTION
Update `organizationType` prop in `registerChallenge` store after subject selection in `RegisterChallengePayment`.

* Define new enum value `none` to be able to reset `organizationType` value.
* Refactor `getRadioOption` function to share it between E2E and component tests.
* Add tests.

---

Related changes in upcoming PRs:
- Save paymentSubject to store
- Limit `organization` and `organizationType` options if `paymentSubject` is `company` or `school`