### PR TITLE
src/components: update FormFieldSelectTable labels via useSelectTable composable

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -29,16 +29,22 @@ describe('<FormFieldSelectTable>', () => {
     cy.testLanguageStringsInContext(
       [
         'buttonAddCompany',
+        'buttonAddFamily',
+        'buttonAddSchool',
         'hintCityChallenge',
         'hintDepartment',
         'labelCityChallenge',
         'labelCompany',
         'labelDepartment',
+        'labelFamily',
+        'labelSchool',
         'textCompanyPermission',
         'textCoordinator',
         'textSubsidiaryAddress',
         'textUserExperience',
         'titleAddCompany',
+        'titleAddFamily',
+        'titleAddSchool',
         'titleSubsidiaryAddress',
       ],
       'form.company',
@@ -67,7 +73,7 @@ describe('<FormFieldSelectTable>', () => {
     );
   });
 
-  context('company desktop', () => {
+  context('organization company', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -194,7 +200,7 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('company selected', () => {
+  context('organization company selected', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -215,7 +221,79 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('team desktop', () => {
+  context('organization school', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldSelectTable, {
+        props: {
+          options: options.value,
+          organizationLevel: OrganizationLevel.organization,
+          organizationType: OrganizationType.school,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('shows correct labels', () => {
+      // label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.labelSchool'));
+      // button add new
+      cy.dataCy('form-select-table-button')
+        .should('be.visible')
+        .and('contain', i18n.global.t('register.challenge.buttonAddCompany'));
+      cy.dataCy('form-select-table-button').click();
+      // title dialog
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.titleAddSchool'));
+      // scroll to bottom
+      cy.dataCy('dialog-body').scrollTo('bottom', { ensureScrollable: false });
+      // button dialog
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.buttonAddSchool'));
+    });
+  });
+
+  context('organization family', () => {
+    beforeEach(() => {
+      cy.mount(FormFieldSelectTable, {
+        props: {
+          options: options.value,
+          organizationLevel: OrganizationLevel.organization,
+          organizationType: OrganizationType.family,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('shows correct labels', () => {
+      // label
+      cy.dataCy('form-select-table-query')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.labelFamily'));
+      // button add new
+      cy.dataCy('form-select-table-button')
+        .should('be.visible')
+        .and('contain', i18n.global.t('register.challenge.buttonAddCompany'));
+      cy.dataCy('form-select-table-button').click();
+      // title dialog
+      cy.dataCy('dialog-add-option')
+        .find('h3')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.titleAddFamily'));
+      // scroll to bottom
+      cy.dataCy('dialog-body').scrollTo('bottom', { ensureScrollable: false });
+      // button dialog
+      cy.dataCy('dialog-button-submit')
+        .should('be.visible')
+        .and('contain', i18n.global.t('form.company.buttonAddFamily'));
+    });
+  });
+
+  context('team', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {
@@ -317,7 +395,7 @@ describe('<FormFieldSelectTable>', () => {
     });
   });
 
-  context('subsidiary desktop', () => {
+  context('subsidiary', () => {
     beforeEach(() => {
       cy.mount(FormFieldSelectTable, {
         props: {

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -16,7 +16,7 @@
  *   representing the options.
  * - `organizationLevel` (OrganizationLevel, required): The organization
  *   level - table is used for organization or team selection.
- * - `organizationType` (OrganizationType, required,
+ * - `organizationType` (OrganizationType,
  *   default: OrganizationType.organization): The organization type.
  *
  * @events
@@ -88,7 +88,6 @@ export default defineComponent({
     },
     organizationType: {
       type: String as () => OrganizationType,
-      required: true,
       default: OrganizationType.company,
     },
   },

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -16,7 +16,7 @@
  *   representing the options.
  * - `organizationLevel` (OrganizationLevel, required): The organization
  *   level - table is used for organization or team selection.
- * - `organizationType` (OrganizationType,
+ * - `organizationType` (OrganizationType, required,
  *   default: OrganizationType.organization): The organization type.
  *
  * @events
@@ -50,6 +50,7 @@ import FormAddCompany from '../form/FormAddCompany.vue';
 import FormAddTeam from '../form/FormAddTeam.vue';
 
 // composables
+import { useOrganizations } from '../../composables/useOrganizations';
 import { useSelectTable } from '../../composables/useSelectTable';
 import { useValidation } from '../../composables/useValidation';
 
@@ -87,6 +88,7 @@ export default defineComponent({
     },
     organizationType: {
       type: String as () => OrganizationType,
+      required: true,
       default: OrganizationType.company,
     },
   },
@@ -172,8 +174,42 @@ export default defineComponent({
       }
     };
 
-    const { label, labelButton, labelButtonDialog, titleDialog } =
-      useSelectTable(props.organizationLevel);
+    const { getOrganizationLabels } = useOrganizations();
+    const { getSelectTableLabels } = useSelectTable();
+
+    const label = computed(() => {
+      // if level is organization, show label for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).labelName;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).label;
+    });
+
+    const buttonAddNew = computed(() => {
+      return getSelectTableLabels(props.organizationLevel).buttonAddNew;
+    });
+
+    const buttonDialog = computed(() => {
+      // if level is organization, show button label for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).buttonDialog;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).buttonDialog;
+    });
+
+    const titleDialog = computed(() => {
+      // if level is organization, show title for correct type
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        if (props.organizationType) {
+          return getOrganizationLabels(props.organizationType).titleDialog;
+        }
+      }
+      return getSelectTableLabels(props.organizationLevel).titleDialog;
+    });
 
     return {
       borderRadius,
@@ -184,8 +220,8 @@ export default defineComponent({
       inputValue,
       isDialogOpen,
       label,
-      labelButton,
-      labelButtonDialog,
+      buttonAddNew,
+      buttonDialog,
       query,
       teamNew,
       titleDialog,
@@ -304,7 +340,7 @@ export default defineComponent({
           >
             <!-- Label -->
             <span class="inline-block q-pl-xs">
-              {{ labelButton }}
+              {{ buttonAddNew }}
             </span>
           </q-btn>
         </q-card-section>
@@ -348,7 +384,7 @@ export default defineComponent({
                   data-cy="dialog-button-submit"
                   @click="onSubmit"
                 >
-                  {{ labelButtonDialog }}
+                  {{ buttonDialog }}
                 </q-btn>
               </div>
             </div>

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -62,3 +62,10 @@ export type FormPaymentVoucher = {
   name: string;
   amount: number;
 };
+
+export type FormSelectTableLabels = {
+  label: string;
+  buttonAddNew: string;
+  buttonDialog: string;
+  titleDialog: string;
+};

--- a/src/composables/useSelectTable.ts
+++ b/src/composables/useSelectTable.ts
@@ -1,61 +1,54 @@
-// libraries
-import { computed } from 'vue';
-
 // composables
 import { i18n } from '../boot/i18n';
 
 // enums
 import { OrganizationLevel } from '../components/types/Organization';
 
-export const useSelectTable = (organizationLevel: OrganizationLevel) => {
-  const label = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.labelTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.labelSubsidiary');
-      default:
-        return i18n.global.t('form.company.labelCompany');
-    }
-  });
+// types
+export type SelectTableLabels = {
+  label: string;
+  buttonAddNew: string;
+  buttonDialog: string;
+  titleDialog: string;
+};
 
-  const labelButton = computed(() => {
+export const useSelectTable = () => {
+  const getSelectTableLabels = (
+    organizationLevel: OrganizationLevel,
+  ): SelectTableLabels => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
-        return i18n.global.t('form.team.buttonAddTeam');
+        return {
+          label: i18n.global.t('form.team.labelTeam'),
+          buttonAddNew: i18n.global.t('form.team.buttonAddTeam'),
+          buttonDialog: i18n.global.t('form.team.buttonAddTeam'),
+          titleDialog: i18n.global.t('form.team.titleAddTeam'),
+        };
       case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
+        return {
+          label: i18n.global.t('form.subsidiary.labelSubsidiary'),
+          buttonAddNew: i18n.global.t('form.subsidiary.buttonAddSubsidiary'),
+          buttonDialog: i18n.global.t('form.subsidiary.buttonAddSubsidiary'),
+          titleDialog: i18n.global.t('form.subsidiary.titleAddSubsidiary'),
+        };
+      case OrganizationLevel.organization:
+        return {
+          label: i18n.global.t('form.company.labelCompany'),
+          buttonAddNew: i18n.global.t('register.challenge.buttonAddCompany'),
+          buttonDialog: i18n.global.t('form.company.buttonAddCompany'),
+          titleDialog: i18n.global.t('form.company.titleAddCompany'),
+        };
       default:
-        return i18n.global.t('register.challenge.buttonAddCompany');
+        return {
+          label: '',
+          buttonAddNew: '',
+          buttonDialog: '',
+          titleDialog: '',
+        };
     }
-  });
-
-  const labelButtonDialog = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.buttonAddTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.buttonAddSubsidiary');
-      default:
-        return i18n.global.t('form.company.buttonAddCompany');
-    }
-  });
-
-  const titleDialog = computed(() => {
-    switch (organizationLevel) {
-      case OrganizationLevel.team:
-        return i18n.global.t('form.team.titleAddTeam');
-      case OrganizationLevel.subsidiary:
-        return i18n.global.t('form.subsidiary.titleAddSubsidiary');
-      default:
-        return i18n.global.t('form.company.titleAddCompany');
-    }
-  });
+  };
 
   return {
-    label,
-    labelButton,
-    labelButtonDialog,
-    titleDialog,
+    getSelectTableLabels,
   };
 };

--- a/src/composables/useSelectTable.ts
+++ b/src/composables/useSelectTable.ts
@@ -1,21 +1,15 @@
 // composables
 import { i18n } from '../boot/i18n';
 
+import { FormSelectTableLabels } from '../components/types/Form';
+
 // enums
 import { OrganizationLevel } from '../components/types/Organization';
-
-// types
-export type SelectTableLabels = {
-  label: string;
-  buttonAddNew: string;
-  buttonDialog: string;
-  titleDialog: string;
-};
 
 export const useSelectTable = () => {
   const getSelectTableLabels = (
     organizationLevel: OrganizationLevel,
-  ): SelectTableLabels => {
+  ): FormSelectTableLabels => {
     switch (organizationLevel) {
       case OrganizationLevel.team:
         return {


### PR DESCRIPTION
Update `FormFieldSelectTable` labels using the `useSelectTable` composable:

* Update `useSelectTable` composable to use the same structure as `useOrganizations`.
* Use composable in `FormFieldSelectTable` component.
* Update tests

--- 

In another PR, update dynamically the step 4 title based on organization type.