### PR TITLE
src/composables: add composable useApiPostSubsidiary for sending create subsidiary request

### DIFF
--- a/src/adapters/subsidiaryAdapter.ts
+++ b/src/adapters/subsidiaryAdapter.ts
@@ -1,0 +1,41 @@
+// types
+import type { FormCompanyAddressFields } from '../components/types/Form';
+import type {
+  SubsidiaryPostApiPayload,
+  SubsidiaryPostApiResponse,
+} from '../components/types/ApiSubsidiary';
+
+/**
+ * Adapter for converting between API and form subsidiary data formats
+ */
+export const subsidiaryAdapter = {
+  /**
+   * Convert form data to API payload format
+   */
+  toApiPayload(formData: FormCompanyAddressFields): SubsidiaryPostApiPayload {
+    return {
+      address: {
+        street: formData.street,
+        street_number: formData.houseNumber,
+        recipient: formData.department,
+        city: formData.city,
+        psc: formData.zip,
+      },
+      city_id: formData.cityChallenge,
+    };
+  },
+
+  /**
+   * Convert API response to form data format
+   */
+  toFormData(apiData: SubsidiaryPostApiResponse): FormCompanyAddressFields {
+    return {
+      street: apiData.address.street,
+      houseNumber: apiData.address.street_number,
+      city: apiData.address.city,
+      zip: String(apiData.address.psc),
+      cityChallenge: apiData.city_id,
+      department: apiData.address.recipient,
+    };
+  },
+};

--- a/src/components/types/ApiSubsidiary.ts
+++ b/src/components/types/ApiSubsidiary.ts
@@ -1,0 +1,23 @@
+/**
+ * API types for subsidiary-related operations
+ */
+
+export interface SubsidiaryPostApiAddress {
+  street: string;
+  street_number: string;
+  recipient: string;
+  city: string;
+  psc: string | number;
+}
+
+export interface SubsidiaryPostApiPayload {
+  address: SubsidiaryPostApiAddress;
+  city_id: number | null;
+}
+
+export interface SubsidiaryPostApiResponse {
+  id: number;
+  city_id: number | null;
+  active: boolean;
+  address: SubsidiaryPostApiAddress;
+}

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -61,44 +61,30 @@ export const useApiPostSubsidiary = (
     logger?.debug(
       `Created subsidiary payload <${JSON.stringify(subsidiaryPayload, null, 2)}>.`,
     );
+    logger?.info('Create new subsidiary.');
     isLoading.value = true;
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
     requestTokenHeader_.Authorization += loginStore.getAccessToken;
 
-    try {
-      // post subsidiary
-      const { data } = await apiFetch<SubsidiaryPostApiResponse>({
-        endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/${rideToWorkByBikeConfig.urlApiSubsidiaries}`,
-        method: 'post',
-        translationKey: 'createSubsidiary',
-        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
-        payload: subsidiaryPayload,
-        logger,
-      });
+    // post subsidiary
+    const { data } = await apiFetch<SubsidiaryPostApiResponse>({
+      endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/${rideToWorkByBikeConfig.urlApiSubsidiaries}`,
+      method: 'post',
+      translationKey: 'createSubsidiary',
+      headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+      payload: subsidiaryPayload,
+      logger,
+    });
 
-      isLoading.value = false;
-
-      if (data) {
-        logger?.debug(
-          `Parsing response subsidiary data <${JSON.stringify(data, null, 2)}>.`,
-        );
-        const subsidiaryDataParsed = subsidiaryAdapter.toFormData(data);
-        logger?.debug(
-          `Parsed subsidiary data <${JSON.stringify(subsidiaryDataParsed, null, 2)}>.`,
-        );
-
-        return subsidiaryDataParsed;
-      } else {
-        logger?.debug('No data returned from subsidiary creation API.');
-        return null;
-      }
-    } catch (error) {
-      logger?.error(`Error creating subsidiary: ${error}`);
-      isLoading.value = false;
-      return null;
-    }
+    isLoading.value = false;
+    const formData = data ? subsidiaryAdapter.toFormData(data) : data;
+    logger?.debug(
+      'Convert newly created and returned subsidiary API data to form data' +
+        ` <${JSON.stringify(formData, null, 2)}>.`,
+    );
+    return formData;
   };
 
   return {

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -1,0 +1,90 @@
+// libraries
+import { ref, Ref } from 'vue';
+
+// composables
+import { useApi } from './useApi';
+
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
+// stores
+import { useLoginStore } from '../stores/login';
+
+// types
+import type { Logger } from '../components/types/Logger';
+import type { FormCompanyAddressFields } from '../components/types/Form';
+
+// utils
+import { requestDefaultHeader, requestTokenHeader } from '../utils';
+
+interface PostSubsidiaryResponse {
+  id: number;
+  address: FormCompanyAddressFields;
+}
+
+type UseApiPostSubsidiaryReturn = {
+  isLoading: Ref<boolean>;
+  createSubsidiary: (
+    organizationId: number,
+    subsidiaryData: FormCompanyAddressFields,
+  ) => Promise<PostSubsidiaryResponse | null>;
+};
+
+/**
+ * Post subsidiary composable
+ * Used to enable calling the API to create organization subsidiary
+ * @param logger - Logger
+ * @returns {UseApiPostSubsidiaryReturn}
+ */
+export const useApiPostSubsidiary = (
+  logger: Logger | null,
+): UseApiPostSubsidiaryReturn => {
+  const isLoading = ref<boolean>(false);
+  const loginStore = useLoginStore();
+  const { apiFetch } = useApi();
+
+  /**
+   * Create subsidiary
+   * Creates a new subsidiary under specified organization
+   * @param {number} organizationId - Organization Id to create subsidiary under
+   * @param {FormCompanyAddressFields} subsidiaryData - Subsidiary data to create
+   * @returns {Promise<PostSubsidiaryResponse | null>} - Promise
+   */
+  const createSubsidiary = async (
+    organizationId: number,
+    subsidiaryData: FormCompanyAddressFields,
+  ): Promise<PostSubsidiaryResponse | null> => {
+    logger?.debug(
+      `Creating subsidiary with data <${JSON.stringify(subsidiaryData, null, 2)}>.`,
+    );
+    isLoading.value = true;
+
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+
+    try {
+      // post subsidiary
+      const { data } = await apiFetch<PostSubsidiaryResponse>({
+        endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationId}/${rideToWorkByBikeConfig.urlApiSubsidiaries}`,
+        method: 'post',
+        translationKey: 'createSubsidiary',
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+        payload: subsidiaryData,
+        logger,
+      });
+
+      isLoading.value = false;
+      return data;
+    } catch (error) {
+      logger?.error(`Error creating subsidiary: ${error}`);
+      isLoading.value = false;
+      return null;
+    }
+  };
+
+  return {
+    isLoading,
+    createSubsidiary,
+  };
+};

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -11,6 +11,7 @@ import { rideToWorkByBikeConfig } from '../boot/global_vars';
 import { useLoginStore } from '../stores/login';
 
 // types
+import type { FormCompanyAddressFields } from '../components/types/Form';
 import type { Logger } from '../components/types/Logger';
 
 // utils
@@ -18,7 +19,7 @@ import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
 interface PostSubsidiaryPayload {
   address: PostSubsidiaryAddressFields;
-  city_id: number;
+  city_id: number | null;
 }
 
 interface PostSubsidiaryAddressFields {
@@ -31,7 +32,7 @@ interface PostSubsidiaryAddressFields {
 
 interface PostSubsidiaryResponse {
   id: number;
-  city_id: number;
+  city_id: number | null;
   active: boolean;
   address: PostSubsidiaryAddressFields;
 }
@@ -66,10 +67,24 @@ export const useApiPostSubsidiary = (
    */
   const createSubsidiary = async (
     organizationId: number,
-    subsidiaryData: PostSubsidiaryPayload,
+    subsidiaryData: FormCompanyAddressFields,
   ): Promise<PostSubsidiaryResponse | null> => {
+    // parse subsidiary data and create a paylaod for API
     logger?.debug(
-      `Creating subsidiary with data <${JSON.stringify(subsidiaryData, null, 2)}>.`,
+      `Creating subsidiary payload from data <${JSON.stringify(subsidiaryData, null, 2)}>.`,
+    );
+    const subsidiaryPayload: PostSubsidiaryPayload = {
+      address: {
+        street: subsidiaryData.street,
+        street_number: subsidiaryData.houseNumber,
+        recipient: subsidiaryData.department,
+        city: subsidiaryData.city,
+        psc: subsidiaryData.zip,
+      },
+      city_id: subsidiaryData.cityChallenge,
+    };
+    logger?.debug(
+      `Created subsidiary payload <${JSON.stringify(subsidiaryPayload, null, 2)}>.`,
     );
     isLoading.value = true;
 
@@ -84,7 +99,7 @@ export const useApiPostSubsidiary = (
         method: 'post',
         translationKey: 'createSubsidiary',
         headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
-        payload: subsidiaryData,
+        payload: subsidiaryPayload,
         logger,
       });
 

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -41,8 +41,8 @@ interface UseApiPostSubsidiaryReturn {
   isLoading: Ref<boolean>;
   createSubsidiary: (
     organizationId: number,
-    subsidiaryData: PostSubsidiaryPayload,
-  ) => Promise<PostSubsidiaryResponse | null>;
+    subsidiaryData: FormCompanyAddressFields,
+  ) => Promise<FormCompanyAddressFields | null>;
 }
 
 /**
@@ -68,7 +68,7 @@ export const useApiPostSubsidiary = (
   const createSubsidiary = async (
     organizationId: number,
     subsidiaryData: FormCompanyAddressFields,
-  ): Promise<PostSubsidiaryResponse | null> => {
+  ): Promise<FormCompanyAddressFields | null> => {
     // parse subsidiary data and create a paylaod for API
     logger?.debug(
       `Creating subsidiary payload from data <${JSON.stringify(subsidiaryData, null, 2)}>.`,
@@ -104,7 +104,29 @@ export const useApiPostSubsidiary = (
       });
 
       isLoading.value = false;
-      return data;
+
+      if (data) {
+        logger?.debug(
+          `Parsing response subsidiary data <${JSON.stringify(data, null, 2)}>.`,
+        );
+        // parse subsidiary data to return
+        const subsidiaryDataParsed: FormCompanyAddressFields = {
+          street: data.address.street,
+          houseNumber: data.address.street_number,
+          city: data.address.city,
+          zip: data.address.psc ? String(data.address.psc) : '',
+          cityChallenge: data.city_id,
+          department: data.address.recipient,
+        };
+        logger?.debug(
+          `Parsed subsidiary data <${JSON.stringify(subsidiaryDataParsed, null, 2)}>.`,
+        );
+
+        return subsidiaryDataParsed;
+      } else {
+        logger?.debug('No data returned from subsidiary creation API.');
+        return null;
+      }
     } catch (error) {
       logger?.error(`Error creating subsidiary: ${error}`);
       isLoading.value = false;

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -12,23 +12,37 @@ import { useLoginStore } from '../stores/login';
 
 // types
 import type { Logger } from '../components/types/Logger';
-import type { FormCompanyAddressFields } from '../components/types/Form';
 
 // utils
 import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
-interface PostSubsidiaryResponse {
-  id: number;
-  address: FormCompanyAddressFields;
+interface PostSubsidiaryPayload {
+  address: PostSubsidiaryAddressFields;
+  city_id: number;
 }
 
-type UseApiPostSubsidiaryReturn = {
+interface PostSubsidiaryAddressFields {
+  street: string;
+  street_number: string;
+  recipient: string;
+  city: string;
+  psc: string | number;
+}
+
+interface PostSubsidiaryResponse {
+  id: number;
+  city_id: number;
+  active: boolean;
+  address: PostSubsidiaryAddressFields;
+}
+
+interface UseApiPostSubsidiaryReturn {
   isLoading: Ref<boolean>;
   createSubsidiary: (
     organizationId: number,
-    subsidiaryData: FormCompanyAddressFields,
+    subsidiaryData: PostSubsidiaryPayload,
   ) => Promise<PostSubsidiaryResponse | null>;
-};
+}
 
 /**
  * Post subsidiary composable
@@ -47,12 +61,12 @@ export const useApiPostSubsidiary = (
    * Create subsidiary
    * Creates a new subsidiary under specified organization
    * @param {number} organizationId - Organization Id to create subsidiary under
-   * @param {FormCompanyAddressFields} subsidiaryData - Subsidiary data to create
+   * @param {PostSubsidiaryPayload} subsidiaryData - Subsidiary data to create
    * @returns {Promise<PostSubsidiaryResponse | null>} - Promise
    */
   const createSubsidiary = async (
     organizationId: number,
-    subsidiaryData: FormCompanyAddressFields,
+    subsidiaryData: PostSubsidiaryPayload,
   ): Promise<PostSubsidiaryResponse | null> => {
     logger?.debug(
       `Creating subsidiary with data <${JSON.stringify(subsidiaryData, null, 2)}>.`,

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -31,6 +31,11 @@ apiMessageError = "Vytvoření týmu selhalo."
 apiMessageErrorWithMessage = "Vytvoření týmu selhalo. Chyba: {error}"
 apiMessageSuccess = "Tým byl úspěšně vytvořen."
 
+[createSubsidiary]
+apiMessageError = "Vytvoření pobočky selhalo."
+apiMessageErrorWithMessage = "Vytvoření pobočky selhalo. Chyba: {error}"
+apiMessageSuccess = "Pobočka byla úspěšně vytvořena."
+
 [drawerMenu]
 buttonParticipation = "Účast"
 buttonCityAdministration = "Správa města"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -31,6 +31,11 @@ apiMessageError = "Team creation failed."
 apiMessageErrorWithMessage = "Team creation failed. Error: {error}"
 apiMessageSuccess = "Team was successfully created."
 
+[createSubsidiary]
+apiMessageError = "Subsidiary creation failed."
+apiMessageErrorWithMessage = "Subsidiary creation failed. Error: {error}"
+apiMessageSuccess = "Subsidiary was successfully created."
+
 [drawerMenu]
 buttonParticipation = "Participation"
 buttonCityAdministration = "City administration"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -31,6 +31,11 @@ apiMessageError = "Vytvorenie tímu zlyhalo."
 apiMessageErrorWithMessage = "Vytvorenie tímu zlyhalo. Chyba: {error}"
 apiMessageSuccess = "Tím bol úspešne vytvorený."
 
+[createSubsidiary]
+apiMessageError = "Vytvorenie pobočky zlyhalo."
+apiMessageErrorWithMessage = "Vytvorenie pobočky zlyhalo. Chyba: {error}"
+apiMessageSuccess = "Pobočka bola úspešne vytvorená."
+
 [drawerMenu]
 buttonParticipation = "Účasť"
 buttonCityAdministration = "Správa mesta"

--- a/test/cypress/fixtures/apiPostSubsidiaryRequest.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryRequest.json
@@ -1,8 +1,10 @@
 {
-  "street": "Test Street",
-  "houseNumber": "123",
-  "city": "Test City",
-  "zip": "12345",
-  "cityChallenge": 1,
-  "department": "Test Department"
+  "address": {
+    "street": "Subsidiary Street",
+    "street_number": "1",
+    "recipient": "Subsidiary Recipient",
+    "city": "Subsidiary City",
+    "psc": "12345"
+  },
+  "city_id": 4
 }

--- a/test/cypress/fixtures/apiPostSubsidiaryRequest.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryRequest.json
@@ -1,0 +1,8 @@
+{
+  "street": "Test Street",
+  "houseNumber": "123",
+  "city": "Test City",
+  "zip": "12345",
+  "cityChallenge": 1,
+  "department": "Test Department"
+}

--- a/test/cypress/fixtures/apiPostSubsidiaryResponse.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryResponse.json
@@ -1,12 +1,15 @@
 {
-  "id": 54321,
+  "id": 5351,
+  "city_id": 4,
+  "active": true,
+  "box_addressee_name": null,
+  "box_addressee_telephone": null,
+  "box_addressee_email": null,
   "address": {
-    "street": "Test Street",
-    "houseNumber": "123",
-    "city": "Test City",
-    "zip": "12345",
-    "cityChallenge": 1,
-    "department": "Test Department"
-  },
-  "teams": []
+    "street": "Test Subsidiary Street 4",
+    "street_number": "004",
+    "recipient": "Recipient 4",
+    "psc": 50004,
+    "city": "City 4"
+  }
 }

--- a/test/cypress/fixtures/apiPostSubsidiaryResponse.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryResponse.json
@@ -1,0 +1,12 @@
+{
+  "id": 54321,
+  "address": {
+    "street": "Test Street",
+    "houseNumber": "123",
+    "city": "Test City",
+    "zip": "12345",
+    "cityChallenge": 1,
+    "department": "Test Department"
+  },
+  "teams": []
+}

--- a/test/cypress/fixtures/apiPostSubsidiaryResponse.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryResponse.json
@@ -2,9 +2,6 @@
   "id": 5351,
   "city_id": 4,
   "active": true,
-  "box_addressee_name": null,
-  "box_addressee_telephone": null,
-  "box_addressee_email": null,
   "address": {
     "street": "Test Subsidiary Street 4",
     "street_number": "004",

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -496,7 +496,6 @@ Cypress.Commands.add(
       i18n,
     );
     const urlApiThisCampaignLocalized = `${apiBaseUrl}${urlApiThisCampaign}`;
-
     cy.fixture('apiGetThisCampaign').then((thisCampaignResponse) => {
       cy.intercept('GET', urlApiThisCampaignLocalized, {
         statusCode: responseStatusCode
@@ -1103,6 +1102,53 @@ Cypress.Commands.add('waitForTeamPostApi', () => {
         if (response) {
           expect(response.statusCode).to.equal(httpSuccessfullStatus);
           expect(response.body).to.deep.equal(teamResponse);
+        }
+      });
+    });
+  });
+});
+
+/*
+* Intercept subsidiary POST API call
+* Provides `@postSubsidiary` alias
+* @param {object} config - App global config
+* @param {object} i18n - i18n instance
+* @param {number} organizationId - Organization ID
+*/
+Cypress.Commands.add(
+  'interceptSubsidiaryPostApi',
+  (config, i18n, organizationId) => {
+    const { apiBase, apiDefaultLang, urlApiOrganizations, urlApiSubsidiaries } =
+      config;
+    const apiBaseUrl = getApiBaseUrlWithLang(
+      null,
+      apiBase,
+      apiDefaultLang,
+      i18n,
+    );
+    const urlApiSubsidiaryLocalized = `${apiBaseUrl}${urlApiOrganizations}${organizationId}/${urlApiSubsidiaries}`;
+    cy.fixture('apiPostSubsidiaryResponse').then((subsidiaryResponse) => {
+      cy.intercept('POST', urlApiSubsidiaryLocalized, {
+        statusCode: httpSuccessfullStatus,
+        body: subsidiaryResponse,
+      }).as('postSubsidiary');
+    });
+  }
+);
+
+/*
+ * Wait for intercept subsidiary POST API call and compare request/response object
+ * Wait for `@postSubsidiary` intercept
+ */
+Cypress.Commands.add('waitForSubsidiaryPostApi', () => {
+  cy.fixture('apiPostSubsidiaryRequest').then((subsidiaryRequest) => {
+    cy.fixture('apiPostSubsidiaryResponse').then((subsidiaryResponse) => {
+      cy.wait('@postSubsidiary').then(({ request, response }) => {
+        expect(request.headers.authorization).to.include(bearerTokeAuth);
+        expect(request.body).to.deep.equal(subsidiaryRequest);
+        if (response) {
+          expect(response.statusCode).to.equal(httpSuccessfullStatus);
+          expect(response.body).to.deep.equal(subsidiaryResponse);
         }
       });
     });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -496,6 +496,7 @@ Cypress.Commands.add(
       i18n,
     );
     const urlApiThisCampaignLocalized = `${apiBaseUrl}${urlApiThisCampaign}`;
+
     cy.fixture('apiGetThisCampaign').then((thisCampaignResponse) => {
       cy.intercept('GET', urlApiThisCampaignLocalized, {
         statusCode: responseStatusCode
@@ -1109,12 +1110,12 @@ Cypress.Commands.add('waitForTeamPostApi', () => {
 });
 
 /*
-* Intercept subsidiary POST API call
-* Provides `@postSubsidiary` alias
-* @param {object} config - App global config
-* @param {object} i18n - i18n instance
-* @param {number} organizationId - Organization ID
-*/
+ * Intercept subsidiary POST API call
+ * Provides `@postSubsidiary` alias
+ * @param {object} config - App global config
+ * @param {object} i18n - i18n instance
+ * @param {number} organizationId - Organization ID
+ */
 Cypress.Commands.add(
   'interceptSubsidiaryPostApi',
   (config, i18n, organizationId) => {
@@ -1133,7 +1134,7 @@ Cypress.Commands.add(
         body: subsidiaryResponse,
       }).as('postSubsidiary');
     });
-  }
+  },
 );
 
 /*

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1113,7 +1113,7 @@ Cypress.Commands.add('waitForTeamPostApi', () => {
  * Intercept subsidiary POST API call
  * Provides `@postSubsidiary` alias
  * @param {object} config - App global config
- * @param {object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {number} organizationId - Organization ID
  */
 Cypress.Commands.add(


### PR DESCRIPTION
Add composable useApiPostSubsidiary for sending create subsidiary request

* Add composable
* Add translation string
* Add test commands

⚠️ Composable contains code to parse local form state object (type `FormCompanyAddressFields`) to payload structure required by API. Same in reverse is done on the output of the function.
TODO: Confirm that parsing is a correct approach.