### PR TITLE
src/composables: provide feed variant for baseUrl in useApi composable

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -74,7 +74,8 @@ entryFeePaymentOptions = "500,700"
 # API CONFIGURATION
 
 apiBase = "https://test.dopracenakole.cz/rest/"
-apiBaseFeed = "https://dopracenakole.cz/feed/"
+apiBaseRtwbbFeed = "https://dopracenakole.cz/feed/"
+
 apiVersion = "1.0"
 apiDefaultLang = "cs"
 

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -74,6 +74,7 @@ entryFeePaymentOptions = "500,700"
 # API CONFIGURATION
 
 apiBase = "https://test.dopracenakole.cz/rest/"
+apiBaseFeed = "https://dopracenakole.cz/feed/"
 apiVersion = "1.0"
 apiDefaultLang = "cs"
 

--- a/src/components/enums/Api.ts
+++ b/src/components/enums/Api.ts
@@ -1,0 +1,4 @@
+export enum ApiBaseUrl {
+  rest = 'rest',
+  feed = 'feed',
+}

--- a/src/components/enums/Api.ts
+++ b/src/components/enums/Api.ts
@@ -1,4 +1,4 @@
 export enum ApiBaseUrl {
-  rest = 'rest',
-  feed = 'feed',
+  rtwbbBackendApi = 'rtwbbBackendApi',
+  rtwbbFeedApi = 'rtwbFeedApi',
 }

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -43,6 +43,7 @@ export interface ConfigGlobal {
   entryFeePaymentOptions: string;
   notifyMessagePosition: string;
   apiBase: string;
+  apiBaseFeed: string;
   apiVersion: string;
   apiDefaultLang: string;
   urlApiHasUserVerifiedEmail: string;

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -43,7 +43,7 @@ export interface ConfigGlobal {
   entryFeePaymentOptions: string;
   notifyMessagePosition: string;
   apiBase: string;
-  apiBaseFeed: string;
+  apiBaseRtwbbFeed: string;
   apiVersion: string;
   apiDefaultLang: string;
   urlApiHasUserVerifiedEmail: string;

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { Notify } from 'quasar';
 import { api, axios } from '../boot/axios';
 import { i18n } from '../boot/i18n';
+import { ApiBaseUrl } from '../components/enums/Api';
 import { getApiBaseUrlWithLang } from '../utils/get_api_base_url_with_lang';
 
 // utils
@@ -61,25 +62,25 @@ const hasReponseDataNonFieldsErrorsKey = ({
 
 /*
  * Select Axios base API URL based on the variant
- * @param {BaseUrl} variant - Base URL variant
+ * @param {ApiBaseUrl} variant - Base URL variant
  * @param {(Logger|null)} logger - Logger instance
  * @returns {string} - Axios base API URL
  */
 const getAxiosBaseApiUrl = (
-  variant: BaseUrl,
+  variant: ApiBaseUrl,
   logger: Logger | null,
 ): string => {
   logger?.debug(`Get Axios base API URL with variant <${variant}>.`);
   switch (variant) {
-    case BaseUrl.rest:
+    case ApiBaseUrl.rest:
       logger?.debug(`Use endpoint <${apiBase}>.`);
       return `${apiBase}`;
-    case BaseUrl.feed:
+    case ApiBaseUrl.feed:
       logger?.debug(`Use endpoint <${apiBaseFeed}>.`);
       return `${apiBaseFeed}`;
     default:
       logger?.debug(
-        `Defaulting to <${BaseUrl.rest}> variant in getAxiosBaseApiUrl().`,
+        `Defaulting to <${ApiBaseUrl.rest}> variant in getAxiosBaseApiUrl().`,
       );
       return `${apiBase}`;
   }
@@ -106,12 +107,7 @@ const injectAxioBaseApiUrlWithLang = (
   );
 };
 
-export enum BaseUrl {
-  rest = 'rest',
-  feed = 'feed',
-}
-
-export const useApi = (variant: BaseUrl = BaseUrl.rest) => {
+export const useApi = (variant: ApiBaseUrl = ApiBaseUrl.rest) => {
   const apiFetch = async <T>({
     endpoint,
     payload,

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -11,7 +11,7 @@ import { requestDefaultHeader } from '../utils';
 
 // config
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
-const { apiDefaultLang, apiBase, apiBaseFeed } = rideToWorkByBikeConfig;
+const { apiDefaultLang, apiBase, apiBaseRtwbbFeed } = rideToWorkByBikeConfig;
 
 // types
 import type { AxiosRequestHeaders, Method } from 'axios';
@@ -61,27 +61,25 @@ const hasReponseDataNonFieldsErrorsKey = ({
 };
 
 /*
- * Select Axios base API URL based on the variant
- * @param {ApiBaseUrl} variant - Base URL variant
+ * Select Axios base API URL endpoint
+ * @param {ApiBaseUrl} baseUrlEndpointType - Base URL endpoint type
  * @param {(Logger|null)} logger - Logger instance
  * @returns {string} - Axios base API URL
  */
 const getAxiosBaseApiUrl = (
-  variant: ApiBaseUrl,
+  baseUrlEndpointType: ApiBaseUrl,
   logger: Logger | null,
 ): string => {
-  logger?.debug(`Get Axios base API URL with variant <${variant}>.`);
-  switch (variant) {
-    case ApiBaseUrl.rest:
-      logger?.debug(`Use endpoint <${apiBase}>.`);
+  logger?.debug(`Base API URL endopint type is <${baseUrlEndpointType}>.`);
+  switch (baseUrlEndpointType) {
+    case ApiBaseUrl.rtwbbBackendApi:
+      logger?.debug(`Use base API URL <${apiBase}> endpoint.`);
       return `${apiBase}`;
-    case ApiBaseUrl.feed:
-      logger?.debug(`Use endpoint <${apiBaseFeed}>.`);
-      return `${apiBaseFeed}`;
+    case ApiBaseUrl.rtwbbFeedApi:
+      logger?.debug(`Use base API URL <${apiBaseRtwbbFeed}> endpoint.`);
+      return `${apiBaseRtwbbFeed}`;
     default:
-      logger?.debug(
-        `Defaulting to <${ApiBaseUrl.rest}> variant in getAxiosBaseApiUrl().`,
-      );
+      logger?.debug(`Use default base API URL <${apiBase}> endpoint.`);
       return `${apiBase}`;
   }
 };
@@ -105,9 +103,12 @@ const injectAxioBaseApiUrlWithLang = (
     apiDefaultLang,
     i18n,
   );
+  logger?.debug(`Injected base API URL <${api.defaults.baseURL}>.`);
 };
 
-export const useApi = (variant: ApiBaseUrl = ApiBaseUrl.rest) => {
+export const useApi = (
+  baseUrlEndpointType: ApiBaseUrl = ApiBaseUrl.rtwbbBackendApi,
+) => {
   const apiFetch = async <T>({
     endpoint,
     payload,
@@ -135,9 +136,9 @@ export const useApi = (variant: ApiBaseUrl = ApiBaseUrl.rest) => {
       logger?.debug(
         `<api()> function headers parameter argument <${JSON.stringify(headers)}>.`,
       );
+      // Get Axios base API URL endpoint
+      const baseUrl = getAxiosBaseApiUrl(baseUrlEndpointType, logger);
       // Inject Axios base API URL with lang (internationalization)
-      const baseUrl = getAxiosBaseApiUrl(variant, logger);
-      logger?.debug(`Base API URL <${baseUrl}>.`);
       injectAxioBaseApiUrlWithLang(baseUrl, logger);
       const startTime = performance.now();
       const data: apiData = {


### PR DESCRIPTION
Provide feed variant for baseUrl in useApi composable.
Allows to specify `feed` variant to call RTWBB WordPress API.
Defaults to `rest` variant for backwards compatibility.