### PR TITLE
src/components: fix incorrect label in FormFieldOptionGroup component

### DIFF
--- a/src/components/__tests__/FormFieldOptionGroup.cy.js
+++ b/src/components/__tests__/FormFieldOptionGroup.cy.js
@@ -12,7 +12,17 @@ const colorPrimary = `rgb(${rgbPrimary.r}, ${rgbPrimary.g}, ${rgbPrimary.b})`;
 
 describe('<FormFieldOptionGroup>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'index.component', i18n);
+    cy.testLanguageStringsInContext(
+      [
+        'labelColleagues',
+        'textColleagues',
+        'labelSchoolmates',
+        'textSchoolmates',
+        'labelFamily',
+      ],
+      'form.participation',
+      i18n,
+    );
   });
 
   context('desktop', () => {

--- a/src/components/form/FormFieldOptionGroup.vue
+++ b/src/components/form/FormFieldOptionGroup.vue
@@ -82,7 +82,7 @@ export default defineComponent({
         icon: 'flight_takeoff',
       },
       {
-        label: i18n.global.t('form.participation.labelFamilyShort'),
+        label: i18n.global.t('form.participation.labelFamily'),
         value: OrganizationType.family,
         icon: 'flight_land',
       },


### PR DESCRIPTION
Fix incorrect label key in `FormFieldOptionGroup` component.
Test translation strings for `FormFieldOptionGroup` in component tests.