### PR TITLE
src/components: enable loading city options from API in FormAddSubsidiary

### DIFF
--- a/src/components/__tests__/FormAddCompany.cy.js
+++ b/src/components/__tests__/FormAddCompany.cy.js
@@ -6,6 +6,7 @@ import { OrganizationType } from '../types/Organization';
 import { emptyFormCompanyFields } from '../global/FormFieldCompany.vue';
 import { deepObjectWithSimplePropsCopy } from '../../utils';
 import { FormAddCompanyVariantProp } from '../enums/Form';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // selectors
 const classSelectorDropdownItem = '.q-item';
@@ -53,6 +54,7 @@ describe('<FormAddCompany>', () => {
 
   context('variant: simple', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormAddCompany, {
         props: {
           ...vModelAdapter(model),
@@ -96,6 +98,7 @@ describe('<FormAddCompany>', () => {
 
   context('variant: default', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormAddCompany, {
         props: {
           ...vModelAdapter(model),
@@ -156,6 +159,11 @@ describe('<FormAddCompany>', () => {
           companyAddress.address[0].department,
         );
         cy.dataCy(selectorFormDepartment).blur();
+        // override cityChallenge with fixture data to get correct ID
+        cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
+          companyAddress.address[0].cityChallenge =
+            citiesResponse.results[0].id;
+        });
         // verify model updates
         cy.wrap(model).its('value').should('deep.equal', companyAddress);
       });

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -44,6 +44,7 @@ describe('<FormFieldCompanyAddress>', () => {
         i18n,
         organizationId,
       );
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       model.value = null;
       cy.mount(FormFieldCompanyAddress, {
         props: {
@@ -150,6 +151,7 @@ describe('<FormFieldCompanyAddress>', () => {
         i18n,
         organizationId,
       );
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       model.value = null;
       cy.mount(FormFieldCompanyAddress, {
         props: {

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -75,6 +75,7 @@ describe('<FormFieldSelectTable>', () => {
 
   context('organization company', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options.value,
@@ -202,6 +203,7 @@ describe('<FormFieldSelectTable>', () => {
 
   context('organization company selected', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options.value,
@@ -223,6 +225,7 @@ describe('<FormFieldSelectTable>', () => {
 
   context('organization school', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options.value,
@@ -259,6 +262,7 @@ describe('<FormFieldSelectTable>', () => {
 
   context('organization family', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options.value,

--- a/src/components/form/FormAddSubsidiary.vue
+++ b/src/components/form/FormAddSubsidiary.vue
@@ -24,19 +24,18 @@
  */
 
 // libraries
-import { computed, defineComponent, nextTick } from 'vue';
+import { computed, defineComponent, inject, nextTick, onMounted } from 'vue';
 
 // components
 import FormFieldTextRequired from '../global/FormFieldTextRequired.vue';
 
 // composables
 import { useValidation } from 'src/composables/useValidation';
-
-// fixtures
-import cityChallengeResponse from '../../../test/cypress/fixtures/cityChallengeResponse.json';
+import { useApiGetCities } from '../../composables/useApiGetCities';
 
 // types
-import type { FormCompanyAddressFields, FormOption } from '../types/Form';
+import type { FormCompanyAddressFields } from '../types/Form';
+import type { Logger } from '../types/Logger';
 
 // enums
 import { FormSubsidiaryAddressFields } from '../enums/Form';
@@ -65,18 +64,20 @@ export default defineComponent({
       },
     });
 
-    const optionsCityChallenge: FormOption[] =
-      cityChallengeResponse.results.map((city) => ({
-        label: city.name,
-        value: city.id,
-      }));
+    const logger = inject('vuejs3-logger') as Logger | null;
+    const { isLoading, options, loadCities } = useApiGetCities(logger);
+
+    onMounted(() => {
+      loadCities();
+    });
 
     const { isFilled } = useValidation();
 
     return {
       subsidiary,
       isFilled,
-      optionsCityChallenge,
+      isLoading,
+      options,
       FormSubsidiaryAddressFields,
     };
   },
@@ -143,7 +144,8 @@ export default defineComponent({
         ]"
         id="form-city-challenge"
         :hint="$t('form.company.hintCityChallenge')"
-        :options="optionsCityChallenge"
+        :options="options"
+        :loading="isLoading"
         class="q-mt-sm"
         data-cy="form-add-subsidiary-city-challenge"
         :name="FormSubsidiaryAddressFields.cityChallenge"

--- a/src/components/form/FormFieldSelectCity.vue
+++ b/src/components/form/FormFieldSelectCity.vue
@@ -24,7 +24,6 @@ import { computed, defineComponent, inject, onMounted } from 'vue';
 import { useApiGetCities } from '../../composables/useApiGetCities';
 
 // types
-import { FormOption } from '../../components/types/Form';
 import { Logger } from '../../components/types/Logger';
 
 export default defineComponent({
@@ -44,23 +43,16 @@ export default defineComponent({
     });
 
     const logger = inject('vuejs3-logger') as Logger | null;
-    const { cities, isLoading, loadCities } = useApiGetCities(logger);
+    const { isLoading, options, loadCities } = useApiGetCities(logger);
 
     onMounted(() => {
       loadCities();
     });
 
-    const optionsCity = computed<FormOption[]>(() =>
-      cities.value.map((city) => ({
-        label: city.name,
-        value: city.id,
-      })),
-    );
-
     return {
       city,
       isLoading,
-      optionsCity,
+      options,
     };
   },
 });
@@ -82,7 +74,7 @@ export default defineComponent({
       map-options
       v-model="city"
       :loading="isLoading"
-      :options="optionsCity"
+      :options="options"
       :style="{ 'min-width': '160px' }"
       class="col-auto"
       id="form-select-city"

--- a/src/composables/useApiGetCities.ts
+++ b/src/composables/useApiGetCities.ts
@@ -1,5 +1,5 @@
 // libraries
-import { ref, Ref } from 'vue';
+import { computed, ref } from 'vue';
 
 // composables
 import { useApi } from './useApi';
@@ -11,7 +11,9 @@ import { rideToWorkByBikeConfig } from '../boot/global_vars';
 import { useLoginStore } from '../stores/login';
 
 // types
+import type { ComputedRef, Ref } from 'vue';
 import type { City, GetCitiesResponse } from '../components/types/City';
+import type { FormOption } from '../components/types/Form';
 import type { Logger } from '../components/types/Logger';
 
 // utils
@@ -20,6 +22,7 @@ import { requestDefaultHeader, requestTokenHeader } from '../utils';
 type useApiGetCitiesReturn = {
   cities: Ref<City[]>;
   isLoading: Ref<boolean>;
+  options: ComputedRef<FormOption[]>;
   loadCities: () => Promise<void>;
 };
 
@@ -114,9 +117,17 @@ export const useApiGetCities = (
     }
   };
 
+  const options = computed<FormOption[]>(() =>
+    cities.value.map((city) => ({
+      label: city.name,
+      value: city.id,
+    })),
+  );
+
   return {
     cities,
     isLoading,
+    options,
     loadCities,
   };
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,13 +40,12 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
-  const enabled = false;
+
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    (!window.Cypress ||
-      window.Cypress.spec.name === 'register.spec.cy.js' ||
-      window.Cypress.spec.name === 'router_rules.cy.js') &&
-    enabled
+    !window.Cypress ||
+    window.Cypress.spec.name === 'register.spec.cy.js' ||
+    window.Cypress.spec.name === 'router_rules.cy.js'
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,12 +40,13 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
-
+  const enabled = false;
   // turn off auth check if in Cypress tests (except for register tests)
   if (
-    !window.Cypress ||
-    window.Cypress.spec.name === 'register.spec.cy.js' ||
-    window.Cypress.spec.name === 'router_rules.cy.js'
+    (!window.Cypress ||
+      window.Cypress.spec.name === 'register.spec.cy.js' ||
+      window.Cypress.spec.name === 'router_rules.cy.js') &&
+    enabled
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;


### PR DESCRIPTION
Enable loading city options from API in `FormAddSubsidiary` component.

* Use existing composable `useApiGetCities.ts`.
* Add test commands (intercept, waitForApi and model comparison) to `FormAddSubsidiary.cy.js`.
* Add API intercepts to wrapping component `FormFieldCompanyAddress.cy.js` test to prevent error messages and setup for tests when adding a new subsidiary.
* Refactor code that computes `options` array from city API results (from `FormFieldSelectCity.vue`) - expose computed property from `useApiGetCities.ts` composable, so that `options` can be used directly in the component.