### PR TITLE
src/components: fix payment options display in RegisterChallengePayment

### DIFF
--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -358,6 +358,9 @@ function coreTests() {
     cy.dataCy(getRadioOption(PaymentSubject.company))
       .should('be.visible')
       .click();
+    // amount options are hidden
+    cy.dataCy(selectorPaymentAmount).should('not.exist');
+    // company select is shown
     cy.dataCy(selectorCompany).should('be.visible');
     cy.dataCy(selectorCompanyLabel)
       .should('be.visible')
@@ -436,9 +439,12 @@ function coreTests() {
     cy.dataCy(getRadioOption(PaymentSubject.school))
       .should('be.visible')
       .click();
+    // amount options are hidden
+    cy.dataCy(selectorPaymentAmount).should('not.exist');
+    // company select is shown
     cy.dataCy(selectorCompany).should('be.visible');
 
-    // if coordinator user still has option to add donation
+    // user still has option to add donation
     testDonation();
   });
 }

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -67,11 +67,11 @@ export default defineComponent({
     const defaultPaymentAmountMax = parseInt(
       rideToWorkByBikeConfig.entryFeePaymentMax,
     );
-    logger?.debug(`Default max. payement amount <${defaultPaymentAmountMax}>.`);
+    logger?.debug(`Default max. payment amount <${defaultPaymentAmountMax}>.`);
     const defaultPaymentAmountMin = parseInt(
       rideToWorkByBikeConfig.entryFeePaymentMin,
     );
-    logger?.debug(`Default min. payement amount <${defaultPaymentAmountMin}>.`);
+    logger?.debug(`Default min. payment amount <${defaultPaymentAmountMin}>.`);
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
     const { getPaletteColor, lighten } = colors;
     const primaryColor = getPaletteColor('primary');
@@ -213,7 +213,7 @@ export default defineComponent({
         isVoucherFreeEntry.value
       ) {
         logger?.debug(
-          `Selected payement subject <${selectedPaymentSubject.value}>,` +
+          `Selected payment subject <${selectedPaymentSubject.value}>,` +
             ` is voucher free entry <${isVoucherFreeEntry.value}>.`,
         );
         opts = [];
@@ -223,7 +223,7 @@ export default defineComponent({
         activeVoucher.value?.amount
       ) {
         logger?.debug(
-          `Selected payement subject <${selectedPaymentSubject.value}>,` +
+          `Selected payment subject <${selectedPaymentSubject.value}>,` +
             ` is voucher valid <${isVoucherValid.value}>,` +
             ` active voucher amount <${activeVoucher.value?.amount}>.`,
         );
@@ -251,7 +251,7 @@ export default defineComponent({
         opts = [];
       } else if (selectedPaymentSubject.value === PaymentSubject.individual) {
         logger?.debug(
-          `Selected payement subject <${selectedPaymentSubject.value}>.`,
+          `Selected payment subject <${selectedPaymentSubject.value}>.`,
         );
         opts = [
           // min option

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -48,6 +48,7 @@ import { PaymentAmount, PaymentSubject } from '../enums/Payment';
 
 // types
 import type { FormOption, FormPaymentVoucher } from '../types/Form';
+import type { Logger } from '../types/Logger';
 
 export default defineComponent({
   name: 'RegisterChallengePayment',
@@ -154,7 +155,9 @@ export default defineComponent({
     const paymentAmountMax = ref<number>(defaultPaymentAmountMax);
     const paymentAmountMin = ref<number>(defaultPaymentAmountMin);
     //  Model for 'Entry fee payment' radio button element
-    const selectedPaymentSubject = ref<string>(PaymentSubject.individual);
+    const selectedPaymentSubject = ref<PaymentSubject>(
+      PaymentSubject.individual,
+    );
     const selectedCompany = ref<string>('');
     const isRegistrationCoordinator = ref<boolean>(false);
     const formRegisterCoordinator = reactive({
@@ -204,7 +207,7 @@ export default defineComponent({
           ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
           ' radio button element.',
       );
-      let opts = [];
+      let opts: FormOption[] = [];
       if (
         selectedPaymentSubject.value === PaymentSubject.voucher &&
         isVoucherFreeEntry.value
@@ -240,7 +243,13 @@ export default defineComponent({
             value: PaymentAmount.custom,
           },
         ];
-      } else if (selectedPaymentSubject.value !== PaymentSubject.voucher) {
+      } else if (
+        selectedPaymentSubject.value === PaymentSubject.company ||
+        selectedPaymentSubject.value === PaymentSubject.school ||
+        selectedPaymentSubject.value === PaymentSubject.voucher
+      ) {
+        opts = [];
+      } else if (selectedPaymentSubject.value === PaymentSubject.individual) {
         logger?.debug(
           `Selected payement subject <${selectedPaymentSubject.value}>.`,
         );

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -244,10 +244,12 @@ export default defineComponent({
           },
         ];
       } else if (
-        selectedPaymentSubject.value === PaymentSubject.company ||
-        selectedPaymentSubject.value === PaymentSubject.school ||
-        selectedPaymentSubject.value === PaymentSubject.voucher
+        [PaymentSubject.company, PaymentSubject.school, Payment.voucher]
+          .includes[selectedPaymentSubject.value]
       ) {
+        logger?.debug(
+          `Selected payment subject <${selectedPaymentSubject.value}>.`,
+        );
         opts = [];
       } else if (selectedPaymentSubject.value === PaymentSubject.individual) {
         logger?.debug(

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -244,8 +244,11 @@ export default defineComponent({
           },
         ];
       } else if (
-        [PaymentSubject.company, PaymentSubject.school, Payment.voucher]
-          .includes[selectedPaymentSubject.value]
+        [
+          PaymentSubject.company,
+          PaymentSubject.school,
+          PaymentSubject.voucher,
+        ].includes(selectedPaymentSubject.value)
       ) {
         logger?.debug(
           `Selected payment subject <${selectedPaymentSubject.value}>.`,


### PR DESCRIPTION
Fix bug where UI was showing payment options when on `company` or `school` payment.
Adds condition for `selectedPaymentSubject` value (after handling scenarios with valid discount vouchers) which clears the payment options array.
Add tests that confirm that options are hidden.

Additionally, fix a few TypeScript warnings and typos.