### PR TITLE
test/cypress: update register_challenge E2E test to avoid failing on dropdown select

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -255,12 +255,24 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-5').find('.q-stepper__step-content').should('not.exist');
       // select address
       cy.dataCy('form-company-address-input').click();
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').first().click();
-        });
+      // select subsidiary from dropdown
+      cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
+        cy.fixture('apiGetSubsidiariesResponseNext').then(
+          (subsidiariesResponseNext) => {
+            cy.get('.q-item__label')
+              .should('be.visible')
+              .and((opts) => {
+                expect(
+                  opts.length,
+                  subsidiariesResponse.results.length +
+                    subsidiariesResponseNext.results.length,
+                );
+              })
+              .first()
+              .click();
+          },
+        );
+      });
       // click
       cy.dataCy('step-4-continue').should('be.visible').click();
       // on step 5


### PR DESCRIPTION
Issue:
Test fails when checking for "step 5" - this cannot be accessed because of validation error on Address select field.

Solution:
Extend test to check for visibility of items before selecting an option.

![Screenshot 2024-12-10 at 17 06 59](https://github.com/user-attachments/assets/77b43b7b-a444-469f-aebc-f09b05b5ee44)
