### PR TITLE
src/composables: add useApiPostTeam() func to create/post the new team

### DIFF
--- a/src/components/types/ApiTeam.ts
+++ b/src/components/types/ApiTeam.ts
@@ -2,11 +2,10 @@
  * API types for team-related operations
  */
 
-export interface TeamPostApiPayload {
-  name: string;
-}
-
 export interface TeamPostApiResponse {
-  id: number;
-  name: string;
+  data: {
+    id: number;
+    name: string;
+  } | null;
+  success: boolean;
 }

--- a/src/components/types/ApiTeam.ts
+++ b/src/components/types/ApiTeam.ts
@@ -1,0 +1,19 @@
+/**
+ * API types for team-related operations
+ */
+
+export interface TeamPostApiPayload {
+  name: string;
+}
+
+export interface TeamPostApiResponse {
+  id: number;
+  name: string;
+}
+
+export interface TeamGetApiResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: TeamPostApiResponse[];
+}

--- a/src/components/types/ApiTeam.ts
+++ b/src/components/types/ApiTeam.ts
@@ -10,10 +10,3 @@ export interface TeamPostApiResponse {
   id: number;
   name: string;
 }
-
-export interface TeamGetApiResponse {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: TeamPostApiResponse[];
-}

--- a/src/composables/useApiPostTeam.ts
+++ b/src/composables/useApiPostTeam.ts
@@ -12,10 +12,7 @@ import { useLoginStore } from '../stores/login';
 
 // types
 import type { Logger } from '../components/types/Logger';
-import type {
-  TeamPostApiPayload,
-  TeamPostApiResponse,
-} from '../components/types/ApiTeam';
+import type { TeamPostApiResponse } from '../components/types/ApiTeam';
 
 // utils
 import { requestDefaultHeader, requestTokenHeader } from '../utils';
@@ -42,7 +39,7 @@ export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
   /**
    * Create team
    * Creates a new team under specified subsidiary
-   * @param {number} subsidiaryId - Subsidiary Id to create team under
+   * @param {number} subsidiaryId - Team subsidiary ID
    * @param {string} teamName - Team name to create
    * @returns {Promise<TeamPostApiResponse | null>} - Promise
    */
@@ -50,11 +47,9 @@ export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
     subsidiaryId: number,
     teamName: string,
   ): Promise<TeamPostApiResponse | null> => {
-    // create payload
-    logger?.debug(`Creating team payload with name <${teamName}>.`);
-    const teamPayload: TeamPostApiPayload = { name: teamName };
     logger?.debug(
-      `Created team payload <${JSON.stringify(teamPayload, null, 2)}>.`,
+      `Create new team with name <${teamName}>` +
+        ` under subsidiary with ID <${subsidiaryId}>.`,
     );
     isLoading.value = true;
 
@@ -62,31 +57,18 @@ export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
     const requestTokenHeader_ = { ...requestTokenHeader };
     requestTokenHeader_.Authorization += loginStore.getAccessToken;
 
-    try {
-      // post team
-      const { data } = await apiFetch<TeamPostApiResponse>({
-        endpoint: `${rideToWorkByBikeConfig.urlApiSubsidiaries}${subsidiaryId}/${rideToWorkByBikeConfig.urlApiTeams}`,
-        method: 'post',
-        translationKey: 'createTeam',
-        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
-        payload: teamPayload,
-        logger,
-      });
+    // post team
+    const { data } = await apiFetch<TeamPostApiResponse>({
+      endpoint: `${rideToWorkByBikeConfig.urlApiSubsidiaries}${subsidiaryId}/${rideToWorkByBikeConfig.urlApiTeams}`,
+      method: 'post',
+      translationKey: 'createTeam',
+      headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+      payload: { name: teamName },
+      logger,
+    });
 
-      isLoading.value = false;
-
-      if (data) {
-        logger?.debug(`Created team <${JSON.stringify(data, null, 2)}>.`);
-        return data;
-      } else {
-        logger?.debug('No data returned from team creation API.');
-        return null;
-      }
-    } catch (error) {
-      logger?.error(`Error creating team: ${error}`);
-      isLoading.value = false;
-      return null;
-    }
+    isLoading.value = false;
+    return data;
   };
 
   return {

--- a/src/composables/useApiPostTeam.ts
+++ b/src/composables/useApiPostTeam.ts
@@ -39,8 +39,8 @@ export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
   /**
    * Create team
    * Creates a new team under specified subsidiary
-   * @param {number} subsidiaryId - Team subsidiary ID
-   * @param {string} teamName - Team name to create
+   * @param {Number} subsidiaryId - Team subsidiary ID
+   * @param {String} teamName - Team name to create
    * @returns {Promise<TeamPostApiResponse | null>} - Promise
    */
   const createTeam = async (

--- a/src/composables/useApiPostTeam.ts
+++ b/src/composables/useApiPostTeam.ts
@@ -1,0 +1,96 @@
+// libraries
+import { ref, Ref } from 'vue';
+
+// composables
+import { useApi } from './useApi';
+
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
+// stores
+import { useLoginStore } from '../stores/login';
+
+// types
+import type { Logger } from '../components/types/Logger';
+import type {
+  TeamPostApiPayload,
+  TeamPostApiResponse,
+} from '../components/types/ApiTeam';
+
+// utils
+import { requestDefaultHeader, requestTokenHeader } from '../utils';
+
+interface UseApiPostTeamReturn {
+  isLoading: Ref<boolean>;
+  createTeam: (
+    subsidiaryId: number,
+    teamName: string,
+  ) => Promise<TeamPostApiResponse | null>;
+}
+
+/**
+ * Post team composable
+ * Used to enable calling the API to create subsidiary team
+ * @param logger - Logger
+ * @returns {UseApiPostTeamReturn}
+ */
+export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
+  const isLoading = ref<boolean>(false);
+  const loginStore = useLoginStore();
+  const { apiFetch } = useApi();
+
+  /**
+   * Create team
+   * Creates a new team under specified subsidiary
+   * @param {number} subsidiaryId - Subsidiary Id to create team under
+   * @param {string} teamName - Team name to create
+   * @returns {Promise<TeamPostApiResponse | null>} - Promise
+   */
+  const createTeam = async (
+    subsidiaryId: number,
+    teamName: string,
+  ): Promise<TeamPostApiResponse | null> => {
+    // create payload
+    logger?.debug(`Creating team payload with name <${teamName}>.`);
+    const teamPayload: TeamPostApiPayload = { name: teamName };
+    logger?.debug(
+      `Created team payload <${JSON.stringify(teamPayload, null, 2)}>.`,
+    );
+    isLoading.value = true;
+
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+
+    try {
+      // post team
+      const { data } = await apiFetch<TeamPostApiResponse>({
+        endpoint: `${rideToWorkByBikeConfig.urlApiSubsidiaries}${subsidiaryId}/${rideToWorkByBikeConfig.urlApiTeams}`,
+        method: 'post',
+        translationKey: 'createTeam',
+        headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+        payload: teamPayload,
+        logger,
+      });
+
+      isLoading.value = false;
+
+      if (data) {
+        logger?.debug(`Created team <${JSON.stringify(data, null, 2)}>.`);
+        return data;
+      } else {
+        logger?.debug('No data returned from team creation API.');
+        return null;
+      }
+    } catch (error) {
+      logger?.error(`Error creating team: ${error}`);
+      isLoading.value = false;
+      return null;
+    }
+  };
+
+  return {
+    isLoading,
+    createTeam,
+  };
+};

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -26,6 +26,11 @@ apiMessageError = "Ověření emailu se nezdařilo."
 apiMessageErrorWithMessage = "Ověření emailu se nezdařilo. Chyba: {error}"
 apiMessageSuccess = "Email byl úspěšně ověřen."
 
+[createTeam]
+apiMessageError = "Vytvoření týmu selhalo."
+apiMessageErrorWithMessage = "Vytvoření týmu selhalo. Chyba: {error}"
+apiMessageSuccess = "Tým byl úspěšně vytvořen."
+
 [drawerMenu]
 buttonParticipation = "Účast"
 buttonCityAdministration = "Správa města"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -26,6 +26,11 @@ apiMessageError = "Email verification failed."
 apiMessageErrorWithMessage = "Email verification failed. Error: {error}"
 apiMessageSuccess = "Email was successfully verified."
 
+[createTeam]
+apiMessageError = "Team creation failed."
+apiMessageErrorWithMessage = "Team creation failed. Error: {error}"
+apiMessageSuccess = "Team was successfully created."
+
 [drawerMenu]
 buttonParticipation = "Participation"
 buttonCityAdministration = "City administration"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -26,6 +26,11 @@ apiMessageError = "Overenie e-mailu zlyhalo."
 apiMessageErrorWithMessage = "Overenie e-mailu zlyhalo. Chyba: {error}"
 apiMessageSuccess = "E-mail bol úspešne overený."
 
+[createTeam]
+apiMessageError = "Vytvorenie tímu zlyhalo."
+apiMessageErrorWithMessage = "Vytvorenie tímu zlyhalo. Chyba: {error}"
+apiMessageSuccess = "Tím bol úspešne vytvorený."
+
 [drawerMenu]
 buttonParticipation = "Účasť"
 buttonCityAdministration = "Správa mesta"

--- a/test/cypress/fixtures/apiPostTeamRequest.json
+++ b/test/cypress/fixtures/apiPostTeamRequest.json
@@ -1,0 +1,3 @@
+{
+  "name": "Test Team"
+}

--- a/test/cypress/fixtures/apiPostTeamResponse.json
+++ b/test/cypress/fixtures/apiPostTeamResponse.json
@@ -1,0 +1,4 @@
+{
+  "id": 123,
+  "name": "Test Team"
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -392,9 +392,9 @@ Cypress.Commands.add('interceptTeamsGetApi', (config, i18n, subsidiaryId) => {
 /**
  * Intercept subsidiaries GET API calls
  * Provides `@getSubsidiaries` and `@getSubsidiariesNextPage` aliases
- * @param {object} config - App global config
- * @param {object|string} i18n - i18n instance or locale lang string e.g. en
- * @param {number} organizationId - Organization ID
+ * @param {Object} config - App global config
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
+ * @param {Number} organizationId - Organization ID
  */
 Cypress.Commands.add(
   'interceptSubsidiariesGetApi',
@@ -471,7 +471,7 @@ Cypress.Commands.add(
  * Intercept this campaign GET API call
  * Provides `@thisCampaignRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} responseBody - Override default response body
  * @param {Number} responseStatusCode - Override default response HTTP status code
  */
@@ -522,7 +522,7 @@ Cypress.Commands.add('waitForThisCampaignApi', () => {
  * Intercept this register POST API call
  * Provides `@registerRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} responseBody - Override default response body
  * @param {Number} responseStatusCode - Override default response HTTP status code
  */
@@ -559,7 +559,7 @@ Cypress.Commands.add(
  * Provides `@registerRequest`,
  *          `@refreshAuthTokenRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} registerResponseBody - Override default response body
  * @param {Number} registerResponseStatusCode - Override default response HTTP status code
  * @param {Object} refreshAuthTokenResponseBody - Override default response body for
@@ -598,7 +598,7 @@ Cypress.Commands.add(
  * Intercept this verify email GET API call
  * Provides `@verifyEmailRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} responseBody - Override default response body
  * @param {Number} responseStatusCode - Override default response HTTP status code
  */
@@ -633,7 +633,7 @@ Cypress.Commands.add(
  * Provides `@registerRequest`,
  *          `@verifyEmailRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} registerResponseBody - Override default response body for
  *                                        register intercept
  * @param {Object} registerResponseStatusCode - Override default response HTTP status code
@@ -688,7 +688,7 @@ Cypress.Commands.add(
  *          `@verifyEmailRequest`,
  *          `@thisCampaignRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} registerResponseBody - Override default response body for
  *                                        register intercept
  * @param {Object} registerResponseStatusCode - Override default response HTTP status code
@@ -790,7 +790,7 @@ Cypress.Commands.add(
  * Intercept refresh auth token POST API call
  * Provides `@refreshTokenRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} responseBody - Override default response body
  * @param {Number} responseStatusCode - Override default response HTTP status code
  */
@@ -823,7 +823,7 @@ Cypress.Commands.add(
  * Intercept this login POST API call
  * Provides `@loginRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} responseBody - Override default response body
  * @param {Number} responseStatusCode - Override default response HTTP status code
  */
@@ -860,7 +860,7 @@ Cypress.Commands.add(
  * Provides `@loginRequest`,
  *          `@refreshAuthTokenRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} loginResponseBody - Override default response body for
  *                                     register intercept
  * @param {Object} loginResponseStatusCode - Override default response HTTP status code
@@ -905,7 +905,7 @@ Cypress.Commands.add(
  *          `@refreshAuthTokenRequest`,
  *          `@verifyEmailRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} loginResponseBody - Override default response body for
  *                                     login intercept
  * @param {Object} loginResponseStatusCode - Override default response HTTP status code
@@ -958,7 +958,7 @@ Cypress.Commands.add(
  *          `@verifyEmailRequest`,
  *          `@thisCampaignRequest` alias
  * @param {Object} config - App global config
- * @param {Object} i18n - i18n instance
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
  * @param {Object} loginResponseBody - Override default response body for
  *                                     login intercept
  * @param {Object} loginResponseStatusCode - Override default response HTTP status code
@@ -1063,9 +1063,9 @@ Cypress.Commands.add('waitForTeamsGetApi', () => {
 /**
  * Intercept team POST API call
  * Provides `@postTeam` alias
- * @param {object} config - App global config
- * @param {object} i18n - i18n instance
- * @param {number} subsidiaryId - Subsidiary ID
+ * @param {Object} config - App global config
+ * @param {Object|String} i18n - i18n instance or locale lang string e.g. en
+ * @param {Number} subsidiaryId - Subsidiary ID
  */
 Cypress.Commands.add('interceptTeamPostApi', (config, i18n, subsidiaryId) => {
   const { apiBase, apiDefaultLang, urlApiSubsidiaries, urlApiTeams } = config;


### PR DESCRIPTION
Add create a team API request with `useApiPostTeam` composable.

- Created `useApiPostTeam` composable for team creation
- Added API types in `ApiTeam.ts`
- Added test fixtures and Cypress commands for API testing
- Payload structure: `{ name: string }`
- Response structure: `{ id: number, name: string }`