### PR TITLE
src/components: use API request composable for creating a team in FormSelectTeam component

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -10,10 +10,10 @@ import {
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 const { contactEmail } = rideToWorkByBikeConfig;
-const subsidiaryIdDefault = 1972;
 
 describe('<FormFieldSelectTable>', () => {
   let options;
+  let subsidiaryId;
 
   before(() => {
     setActivePinia(createPinia());
@@ -31,6 +31,10 @@ describe('<FormFieldSelectTable>', () => {
           options = organizations.map(mapOrganizationToOption);
         },
       );
+    });
+    // set common subsidiaryId from fixture
+    cy.fixture('formOrganizationOptions').then((formOrganizationOptions) => {
+      subsidiaryId = formOrganizationOptions[0].subsidiaries[0].id;
     });
   });
 
@@ -316,11 +320,7 @@ describe('<FormFieldSelectTable>', () => {
   context('team', () => {
     beforeEach(() => {
       cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
-      cy.interceptTeamPostApi(
-        rideToWorkByBikeConfig,
-        i18n,
-        subsidiaryIdDefault,
-      );
+      cy.interceptTeamPostApi(rideToWorkByBikeConfig, i18n, subsidiaryId);
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options,
@@ -387,10 +387,10 @@ describe('<FormFieldSelectTable>', () => {
         .and('contain', i18n.global.t('form.messageOptionRequired'));
     });
 
-    it.only('renders dialog when for adding a new team', () => {
+    it('renders dialog when for adding a new team', () => {
       cy.fixture('apiPostTeamRequest').then((teamRequest) => {
         cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setSubsidiaryId(subsidiaryIdDefault);
+          store.setSubsidiaryId(subsidiaryId);
 
           cy.dataCy('button-add-option').click();
           cy.dataCy('dialog-add-option').should('be.visible');

--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -7,9 +7,10 @@ import {
   OrganizationLevel,
   OrganizationType,
 } from 'src/components/types/Organization';
-// import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
+import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 const { contactEmail } = rideToWorkByBikeConfig;
+const subsidiaryIdDefault = 1972;
 
 describe('<FormFieldSelectTable>', () => {
   let options;
@@ -314,6 +315,12 @@ describe('<FormFieldSelectTable>', () => {
 
   context('team', () => {
     beforeEach(() => {
+      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
+      cy.interceptTeamPostApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        subsidiaryIdDefault,
+      );
       cy.mount(FormFieldSelectTable, {
         props: {
           options: options,
@@ -380,38 +387,60 @@ describe('<FormFieldSelectTable>', () => {
         .and('contain', i18n.global.t('form.messageOptionRequired'));
     });
 
-    it('renders dialog when for adding a new team', () => {
-      cy.dataCy('button-add-option').click();
-      cy.dataCy('dialog-add-option').should('be.visible');
-      cy.dataCy('dialog-add-option')
-        .find('h3')
-        .should('be.visible')
-        .and('have.css', 'font-size', '20px')
-        .and('have.css', 'font-weight', '500')
-        .and('contain', i18n.global.t('form.team.titleAddTeam'));
-      // scroll to bottom
-      cy.dataCy('dialog-body').scrollTo('bottom', {
-        ensureScrollable: false,
+    it.only('renders dialog when for adding a new team', () => {
+      cy.fixture('apiPostTeamRequest').then((teamRequest) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setSubsidiaryId(subsidiaryIdDefault);
+
+          cy.dataCy('button-add-option').click();
+          cy.dataCy('dialog-add-option').should('be.visible');
+          cy.dataCy('dialog-add-option')
+            .find('h3')
+            .should('be.visible')
+            .and('have.css', 'font-size', '20px')
+            .and('have.css', 'font-weight', '500')
+            .and('contain', i18n.global.t('form.team.titleAddTeam'));
+          // scroll to bottom
+          cy.dataCy('dialog-body').scrollTo('bottom', {
+            ensureScrollable: false,
+          });
+          // action buttons are visible
+          cy.dataCy('dialog-button-cancel')
+            .should('be.visible')
+            .and('have.text', i18n.global.t('navigation.discard'));
+          cy.dataCy('dialog-button-submit')
+            .should('be.visible')
+            .and('have.text', i18n.global.t('form.team.buttonAddTeam'));
+          // submit empty
+          cy.dataCy('dialog-button-submit').click();
+          cy.dataCy('dialog-add-option').should('be.visible');
+          // scroll to top
+          cy.dataCy('dialog-body').scrollTo('top', {
+            ensureScrollable: false,
+          });
+          // fill in form
+          cy.dataCy('form-add-team-name').find('input').type(teamRequest.name);
+          // submit
+          cy.dataCy('dialog-button-submit').click();
+          // wait for POST API call
+          cy.waitForTeamPostApi();
+          // check if dialog is closed
+          cy.dataCy('dialog-add-option').should('not.exist');
+          // check if event is emitted
+          cy.fixture('apiPostTeamResponse').then((teamResponse) => {
+            // test emitted event
+            cy.wrap(Cypress.vueWrapper.emitted('create:option')).should(
+              'have.length',
+              1,
+            );
+            // test emitted payload
+            cy.wrap(Cypress.vueWrapper.emitted('create:option')[0][0]).should(
+              'deep.equal',
+              teamResponse,
+            );
+          });
+        });
       });
-      // action buttons are visible
-      cy.dataCy('dialog-button-cancel')
-        .should('be.visible')
-        .and('have.text', i18n.global.t('navigation.discard'));
-      cy.dataCy('dialog-button-submit')
-        .should('be.visible')
-        .and('have.text', i18n.global.t('form.team.buttonAddTeam'));
-      // submit empty
-      cy.dataCy('dialog-button-submit').click();
-      cy.dataCy('dialog-add-option').should('be.visible');
-      // scroll to top
-      cy.dataCy('dialog-body').scrollTo('top', {
-        ensureScrollable: false,
-      });
-      // fill in form
-      cy.dataCy('form-add-team-name').find('input').type('Team AutoMat');
-      // submit
-      cy.dataCy('dialog-button-submit').click();
-      cy.dataCy('dialog-add-option').should('not.exist');
     });
   });
 

--- a/src/components/__tests__/FormSelectTeam.cy.js
+++ b/src/components/__tests__/FormSelectTeam.cy.js
@@ -12,6 +12,7 @@ const selectorFormSelectTeam = 'form-select-team';
 const selectorFormSelectTableTeam = 'form-select-table-team';
 const selectorFormSelectTeamInfo = 'form-select-team-info';
 const selectorTableOptionGroup = 'form-select-table-option';
+
 describe('<FormSelectTeam>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
@@ -119,11 +120,26 @@ function coreTests() {
           cy.waitForTeamPostApi();
           // verify dialog closed
           cy.dataCy('dialog-add-option').should('not.exist');
-          // wait for teams reload
-          cy.waitForTeamsGetApi();
-          // verify api calls count
-          cy.get('@getTeams.all').its('length').should('eq', 2);
-          cy.get('@getTeamsNextPage.all').its('length').should('eq', 2);
+          // get teams fixture data to compare with updated list
+          cy.fixture('apiGetTeamsResponse').then((teamsResponse) => {
+            cy.fixture('apiGetTeamsResponseNext').then((teamsResponseNext) => {
+              // verify new team appears in the list
+              cy.dataCy('form-select-table-team')
+                .find('.q-radio__label')
+                .should(
+                  'have.length',
+                  teamsResponse.results.length +
+                    teamsResponseNext.results.length +
+                    1,
+                )
+                .and('contain', teamRequest.name);
+              // new team is selected
+              cy.dataCy('form-select-table-team')
+                .find('.q-radio__inner.q-radio__inner--truthy')
+                .siblings('.q-radio__label')
+                .should('contain', teamRequest.name);
+            });
+          });
         });
       });
     });

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -215,10 +215,9 @@ export default defineComponent({
           // close dialog
           isDialogOpen.value = false;
           logger?.info('Close add team modal dialog.');
-          // set team to new team
-          logger?.debug(`Setting team to ID <${data.id}>.`);
           // store data in v-model (emits to parent component)
           inputValue.value = data.id;
+          logger?.debug(`Team ID set to <${inputValue.value}>.`);
         }
       }
     };

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -194,6 +194,7 @@ export default defineComponent({
      * Submit dialog form based on organization level
      * If `company`, create a new company
      * If `team`, create a new team
+     * @returns {Promise<void>}
      */
     const submitDialogForm = async (): Promise<void> => {
       if (props.organizationLevel === OrganizationLevel.organization) {

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -217,6 +217,7 @@ export default defineComponent({
           logger?.info('Close add team modal dialog.');
           // set team to new team
           logger?.debug(`Setting team to ID <${data.id}>.`);
+          // store data in v-model (emits to parent component)
           inputValue.value = data.id;
         }
       }

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -23,6 +23,7 @@
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
+ * - `create:option`: Emitted when a new option is created.
  *
  * @components
  * - `DialogDefault`: Used to render a dialog window with form as content.
@@ -40,7 +41,7 @@
  */
 
 // libraries
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent, inject, ref } from 'vue';
 import { QForm } from 'quasar';
 
 // config
@@ -55,11 +56,16 @@ import FormAddTeam from '../form/FormAddTeam.vue';
 import { useOrganizations } from '../../composables/useOrganizations';
 import { useSelectTable } from '../../composables/useSelectTable';
 import { useValidation } from '../../composables/useValidation';
+import { useApiPostTeam } from '../../composables/useApiPostTeam';
 
 // enums
 import { OrganizationType, OrganizationLevel } from '../types/Organization';
 
+// stores
+import { useRegisterChallengeStore } from '../../stores/registerChallenge';
+
 // types
+import type { Logger } from '../types/Logger';
 import {
   FormCompanyFields,
   FormOption,
@@ -97,8 +103,10 @@ export default defineComponent({
       default: null,
     },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'create:option'],
   setup(props, { emit }) {
+    const logger = inject('vuejs3-logger') as Logger | null;
+
     // user input for filtering
     const query = ref<string>('');
     const formRef = ref<typeof QForm | null>(null);
@@ -169,12 +177,46 @@ export default defineComponent({
         const isFormValid: boolean = await formRef.value.validate();
 
         if (isFormValid) {
-          // TODO: Submit through API
+          await submitDialogForm();
           isDialogOpen.value = false;
         } else {
           formRef.value.$el.scrollIntoView({
             behavior: 'smooth',
           });
+        }
+      }
+    };
+
+    const { createTeam } = useApiPostTeam(logger);
+    const registerChallengeStore = useRegisterChallengeStore();
+
+    /**
+     * Submit dialog form based on organization level
+     * If `company`, create a new company
+     * If `team`, create a new team
+     */
+    const submitDialogForm = async (): Promise<void> => {
+      if (props.organizationLevel === OrganizationLevel.organization) {
+        // TODO: Create a new company
+      } else if (props.organizationLevel === OrganizationLevel.team) {
+        logger?.info('Create team.');
+        const subsidiaryId = registerChallengeStore.getSubsidiaryId;
+        if (subsidiaryId === null) {
+          logger?.debug('No subsidiary ID found in store.');
+          return;
+        }
+        const data = await createTeam(subsidiaryId, teamNew.value.name);
+        if (data?.id) {
+          logger?.debug(`Team created with ID <${data.id}>.`);
+          logger?.debug(`Team created with name <${data.name}>.`);
+          // emit `create:option` event
+          emit('create:option', data);
+          // close dialog
+          isDialogOpen.value = false;
+          logger?.info('Close add team modal dialog.');
+          // set team to new team
+          logger?.debug(`Setting team to ID <${data.id}>.`);
+          inputValue.value = data.id;
         }
       }
     };

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -203,13 +203,14 @@ export default defineComponent({
         logger?.info('Create team.');
         const subsidiaryId = registerChallengeStore.getSubsidiaryId;
         if (subsidiaryId === null) {
-          logger?.debug('No subsidiary ID found in store.');
+          logger?.info('No subsidiary ID found in the store.');
           return;
         }
         const data = await createTeam(subsidiaryId, teamNew.value.name);
         if (data?.id) {
-          logger?.debug(`Team created with ID <${data.id}>.`);
-          logger?.debug(`Team created with name <${data.name}>.`);
+          logger?.debug(
+            `New Team was created with ID <${data.id}> and name <${data.name}>.`,
+          );
           // emit `create:option` event
           emit('create:option', data);
           // close dialog
@@ -217,7 +218,7 @@ export default defineComponent({
           logger?.info('Close add team modal dialog.');
           // store data in v-model (emits to parent component)
           inputValue.value = data.id;
-          logger?.debug(`Team ID set to <${inputValue.value}>.`);
+          logger?.debug(`New team model ID set to <${inputValue.value}>.`);
         }
       }
     };

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -32,6 +32,8 @@ import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
 import type { Logger } from '../types/Logger';
+import type { OrganizationTeam } from '../types/Organization';
+import type { TeamPostApiResponse } from '../types/ApiTeam';
 
 export default defineComponent({
   name: 'FormSelectTeam',
@@ -52,7 +54,7 @@ export default defineComponent({
       },
     });
 
-    const { options, isLoading, loadTeams } = useApiGetTeams(logger);
+    const { options, isLoading, teams, loadTeams } = useApiGetTeams(logger);
     // load teams when subsidiary ID changes
     watch(
       () => registerChallengeStore.getSubsidiaryId,
@@ -70,16 +72,19 @@ export default defineComponent({
 
     /**
      * Handle option created event
-     * When option is created in the child component, refetch options.
-     * This correctly updates the options list as opposed to pushing
-     * the new option into the list manually.
+     * When option is created in the child component, push the result into
+     * the `teams` array (options are computed from `teams` array).
+     * @param {TeamPostApiResponse} data - Team data
      * @returns {void}
      */
-    const onOptionCreated = (): void => {
-      const currentSubsidiaryId = registerChallengeStore.getSubsidiaryId;
-      if (currentSubsidiaryId) {
-        loadTeams(currentSubsidiaryId);
-      }
+    const onOptionCreated = (data: TeamPostApiResponse): void => {
+      const newTeam: OrganizationTeam = {
+        id: data.id,
+        name: data.name,
+        subsidiary: registerChallengeStore.getSubsidiaryId as number,
+        members: [],
+      };
+      teams.value.push(newTeam);
     };
 
     return {

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -16,7 +16,7 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, watch } from 'vue';
+import { computed, defineComponent, inject, watch, ref } from 'vue';
 
 // components
 import FormFieldSelectTable from './FormFieldSelectTable.vue';
@@ -55,6 +55,7 @@ export default defineComponent({
     });
 
     const { options, isLoading, teams, loadTeams } = useApiGetTeams(logger);
+    const opts = ref([]);
     // load teams when subsidiary ID changes
     watch(
       () => registerChallengeStore.getSubsidiaryId,
@@ -64,7 +65,10 @@ export default defineComponent({
         );
         if (newValue) {
           logger?.info('Loading teams.');
-          loadTeams(newValue);
+          // Lazy loading
+          loadTeams(newValue).then(() => {
+            opts.value = options;
+          });
         }
       },
       { immediate: true },
@@ -89,7 +93,7 @@ export default defineComponent({
 
     return {
       isLoading,
-      options,
+      opts,
       team,
       OrganizationLevel,
       onOptionCreated,
@@ -108,7 +112,7 @@ export default defineComponent({
     <form-field-select-table
       v-model="team"
       :organization-level="OrganizationLevel.team"
-      :options="options"
+      :options="opts.value"
       :loading="isLoading"
       @create:option="onOptionCreated"
       data-cy="form-select-table-team"

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -429,68 +429,42 @@ describe('Register Challenge page', () => {
       passToStep5();
       checkActiveIcon(5);
 
-      cy.get('@config').then((config) => {
-        cy.get('@i18n').then((i18n) => {
-          // use formOrganizationOptions to get subsidiary id
-          cy.fixture('formOrganizationOptions').then(
-            (formOrganizationOptions) => {
-              // get team post request/response data fixture
-              cy.fixture('apiPostTeamRequest').then((teamRequest) => {
-                cy.fixture('apiPostTeamResponse').then((teamResponse) => {
-                  // create new team
-                  cy.dataCy('form-select-table-team').within(() => {
-                    cy.dataCy('button-add-option').click();
-                  });
-                  cy.dataCy('dialog-add-option').should('be.visible');
-                  cy.dataCy('form-add-team-name')
-                    .find('input')
-                    .type(teamRequest.name);
-                  // prepare new teams fixture with added team
-                  cy.fixture('apiGetTeamsResponse').then((teamsResponse) => {
-                    cy.fixture('apiGetTeamsResponseNext').then(
-                      (teamsResponseNext) => {
-                        const updatedTeamsResponse = {
-                          ...teamsResponse,
-                          results: [...teamsResponse.results, teamResponse],
-                        };
-                        // override teams GET intercept with updated data
-                        cy.interceptTeamsGetApi(
-                          config,
-                          i18n,
-                          formOrganizationOptions[0].subsidiaries[0].id,
-                          updatedTeamsResponse,
-                          teamsResponseNext,
-                        );
-                        // submit form
-                        cy.dataCy('dialog-button-submit').click();
-                        // wait for POST and subsequent GET
-                        cy.wait('@postTeam');
-                        cy.wait('@getTeams');
-                        cy.wait('@getTeamsNextPage');
-                        // verify dialog closed
-                        cy.dataCy('dialog-add-option').should('not.exist');
-                        // verify new team appears in the list
-                        cy.dataCy('form-select-table-team')
-                          .find('.q-radio__label')
-                          .should(
-                            'have.length',
-                            teamsResponse.results.length +
-                              teamsResponseNext.results.length +
-                              1,
-                          )
-                          .and('contain', teamResponse.name);
-                        // new team is selected
-                        cy.dataCy('form-select-table-team')
-                          .find('.q-radio__inner.q-radio__inner--truthy')
-                          .siblings('.q-radio__label')
-                          .should('contain', teamResponse.name);
-                      },
-                    );
-                  });
-                });
-              });
-            },
-          );
+      // use formOrganizationOptions to get subsidiary id
+      // get team post request/response data fixture
+      cy.fixture('apiPostTeamRequest').then((teamRequest) => {
+        cy.fixture('apiPostTeamResponse').then((teamResponse) => {
+          // create new team
+          cy.dataCy('form-select-table-team').within(() => {
+            cy.dataCy('button-add-option').click();
+          });
+          cy.dataCy('dialog-add-option').should('be.visible');
+          cy.dataCy('form-add-team-name').find('input').type(teamRequest.name);
+          // get teams fixture data to compare with updated list
+          cy.fixture('apiGetTeamsResponse').then((teamsResponse) => {
+            cy.fixture('apiGetTeamsResponseNext').then((teamsResponseNext) => {
+              // submit form
+              cy.dataCy('dialog-button-submit').click();
+              // wait for POST and subsequent GET
+              cy.waitForTeamPostApi();
+              // verify dialog closed
+              cy.dataCy('dialog-add-option').should('not.exist');
+              // verify new team appears in the list
+              cy.dataCy('form-select-table-team')
+                .find('.q-radio__label')
+                .should(
+                  'have.length',
+                  teamsResponse.results.length +
+                    teamsResponseNext.results.length +
+                    1,
+                )
+                .and('contain', teamResponse.name);
+              // new team is selected
+              cy.dataCy('form-select-table-team')
+                .find('.q-radio__inner.q-radio__inner--truthy')
+                .siblings('.q-radio__label')
+                .should('contain', teamResponse.name);
+            });
+          });
         });
       });
     });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -366,28 +366,38 @@ Cypress.Commands.add('waitForCitiesApi', () => {
  * @param {object} config - App global config
  * @param {object|string} i18n - i18n instance or locale lang string e.g. en
  * @param {number} subsidiaryId - Subsidiary ID
+ * @param {object} teamsResponse - Optional override for teams response data
+ * @param {object} teamsResponseNext - Optional override for teams next page response data
  */
-Cypress.Commands.add('interceptTeamsGetApi', (config, i18n, subsidiaryId) => {
-  const { apiBase, apiDefaultLang, urlApiSubsidiaries, urlApiTeams } = config;
-  const apiBaseUrl = getApiBaseUrlWithLang(null, apiBase, apiDefaultLang, i18n);
-  const urlApiTeamsLocalized = `${apiBaseUrl}${urlApiSubsidiaries}${subsidiaryId}/${urlApiTeams}`;
+Cypress.Commands.add(
+  'interceptTeamsGetApi',
+  (config, i18n, subsidiaryId, teamsResponse, teamsResponseNext) => {
+    const { apiBase, apiDefaultLang, urlApiSubsidiaries, urlApiTeams } = config;
+    const apiBaseUrl = getApiBaseUrlWithLang(
+      null,
+      apiBase,
+      apiDefaultLang,
+      i18n,
+    );
+    const urlApiTeamsLocalized = `${apiBaseUrl}${urlApiSubsidiaries}${subsidiaryId}/${urlApiTeams}`;
 
-  cy.fixture('apiGetTeamsResponse').then((teamsResponse) => {
-    cy.fixture('apiGetTeamsResponseNext').then((teamsResponseNext) => {
-      // intercept initial teams API call
-      cy.intercept('GET', urlApiTeamsLocalized, {
-        statusCode: httpSuccessfullStatus,
-        body: teamsResponse,
-      }).as('getTeams');
+    cy.fixture('apiGetTeamsResponse').then((defaultTeamsResponse) => {
+      cy.fixture('apiGetTeamsResponseNext').then((defaultTeamsResponseNext) => {
+        // intercept initial teams API call
+        cy.intercept('GET', urlApiTeamsLocalized, {
+          statusCode: httpSuccessfullStatus,
+          body: teamsResponse || defaultTeamsResponse,
+        }).as('getTeams');
 
-      // intercept next page API call
-      cy.intercept('GET', teamsResponse.next, {
-        statusCode: httpSuccessfullStatus,
-        body: teamsResponseNext,
-      }).as('getTeamsNextPage');
+        // intercept next page API call
+        cy.intercept('GET', defaultTeamsResponse.next, {
+          statusCode: httpSuccessfullStatus,
+          body: teamsResponseNext || defaultTeamsResponseNext,
+        }).as('getTeamsNextPage');
+      });
     });
-  });
-});
+  },
+);
 
 /**
  * Intercept subsidiaries GET API calls


### PR DESCRIPTION
Use API request composable for creating a team in `FormSelectTeam` component.

## FormFieldSelectTable
* Add `useApiPostTeam` composable to create a team.
* Add a `create:option` event to notify parent component about the data update.

## FormSelectTeam
* Get `subsidiaryId` from `registerChallenge` store.
* Connect `team` property to `registerChallenge` store.
* Add a reload on option change.

## Tests
* Refactor teams GET API intercept command to support custom response data.
* Add test for `create:option` event emission in `FormFieldSelectTable`.
* Add test for data reload after team creation in `FormSelectTeam`
* Add E2E test for team creation with updated fixture data.