### PR TITLE
src/components: refactor API call for creating organization in FormFieldCompany to a separate composable

### DIFF
--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -102,9 +102,12 @@ export default defineComponent({
   setup(props, { emit }) {
     const logger = inject('vuejs3-logger') as Logger | null;
     const optionsFiltered = ref<FormSelectOption[]>([]);
-    const { options, isLoading, loadOrganizations } =
-      useApiGetOrganizations(logger);
-    const { createOrganization, isLoading: isCreatingOrganization } =
+    const {
+      options,
+      isLoading: isLoadingGetOrganization,
+      loadOrganizations,
+    } = useApiGetOrganizations(logger);
+    const { createOrganization, isLoading: isLoadinPostOrganization } =
       useApiPostOrganization(logger);
     logger?.debug(
       `Initial organization ID model value is <${props.modelValue}>.`,
@@ -266,7 +269,9 @@ export default defineComponent({
       formRef,
       isDialogOpen,
       isFilled,
-      isLoading,
+      isOrganization,
+      isLoadingGetOrganization,
+      isLoadinPostOrganization,
       optionsFiltered,
       messageNoResult,
       options,
@@ -275,7 +280,6 @@ export default defineComponent({
       onSubmit,
       organizationFieldValidationTransStrings,
       OrganizationType,
-      isCreatingOrganization,
     };
   },
 });
@@ -307,7 +311,7 @@ export default defineComponent({
           :lazy-rules="true"
           :model-value="company"
           :options="optionsFiltered"
-          :loading="isLoading"
+          :loading="isLoadingGetOrganization"
           class="q-mt-sm"
           id="form-company"
           name="company"

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -272,7 +272,6 @@ export default defineComponent({
       formRef,
       isDialogOpen,
       isFilled,
-      isOrganization,
       isLoadingGetOrganization,
       isLoadinPostOrganization,
       optionsFiltered,

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -197,8 +197,8 @@ export default defineComponent({
             // close dialog
             isDialogOpen.value = false;
             logger?.info('Close add company modal dialog.');
-            // set company to new organization
-            logger?.debug(`Setting organization to ID <${data.id}>.`);
+            // Set organizations option to created organization
+            logger?.debug(`Setting organizations options to ID <${data.id}>.`);
             const newCompanyOption: { label: string; value: number } = {
               label: data.name,
               value: data.id,
@@ -206,8 +206,11 @@ export default defineComponent({
             optionsFiltered.value.push(newCompanyOption);
             company.value = newCompanyOption.value;
             logger?.debug(
-              `Append newly created organization <${JSON.stringify(newCompanyOption, null, 2)}>` +
-                ' into select organizations widget options.',
+              `Append newly created organization <${JSON.stringify(
+                newCompanyOption,
+                null,
+                2,
+              )}>` + ' into select organizations widget options.',
             );
             // Append newly created organization option into all organization select widget options
             options.value.push(newCompanyOption);

--- a/src/components/types/apiOrganization.ts
+++ b/src/components/types/apiOrganization.ts
@@ -1,0 +1,10 @@
+export interface PostOrganizationPayload {
+  name: string;
+  vatId: string;
+  organization_type: string;
+}
+
+export interface PostOrganizationResponse {
+  id: number;
+  name: string;
+}

--- a/src/composables/useApiPostOrganization.ts
+++ b/src/composables/useApiPostOrganization.ts
@@ -1,0 +1,92 @@
+// libraries
+import { ref, Ref } from 'vue';
+
+// composables
+import { useApi } from './useApi';
+
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
+// stores
+import { useLoginStore } from '../stores/login';
+
+// types
+import type { Logger } from '../components/types/Logger';
+import type {
+  PostOrganizationPayload,
+  PostOrganizationResponse,
+} from '../components/types/apiOrganization';
+
+// utils
+import { requestDefaultHeader, requestTokenHeader } from '../utils';
+
+interface UseApiPostOrganizationReturn {
+  isLoading: Ref<boolean>;
+  createOrganization: (
+    name: string,
+    vatId: string,
+    organizationType: string,
+  ) => Promise<PostOrganizationResponse | null>;
+}
+
+/**
+ * Post organization composable
+ * Used to enable calling the API to create organization
+ * @param logger - Logger
+ * @returns {UseApiPostOrganizationReturn}
+ */
+export const useApiPostOrganization = (
+  logger: Logger | null,
+): UseApiPostOrganizationReturn => {
+  const isLoading = ref<boolean>(false);
+  const loginStore = useLoginStore();
+  const { apiFetch } = useApi();
+
+  /**
+   * Create organization
+   * Creates a new organization
+   * @param {string} name - Organization name
+   * @param {string} vatId - Organization VAT ID
+   * @param {string} organizationType - Organization type
+   * @returns {Promise<PostOrganizationResponse | null>} - Promise
+   */
+  const createOrganization = async (
+    name: string,
+    vatId: string,
+    organizationType: string,
+  ): Promise<PostOrganizationResponse | null> => {
+    logger?.debug(
+      `Create new organization with name <${name}> and VAT ID <${vatId}>.`,
+    );
+    isLoading.value = true;
+
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+
+    // data
+    const payload: PostOrganizationPayload = {
+      name,
+      vatId,
+      organization_type: organizationType,
+    };
+
+    // post organization
+    const { data } = await apiFetch<PostOrganizationResponse>({
+      endpoint: rideToWorkByBikeConfig.urlApiOrganizations,
+      method: 'post',
+      translationKey: 'createOrganization',
+      headers: Object.assign(requestDefaultHeader(), requestTokenHeader_),
+      payload,
+      logger,
+    });
+
+    isLoading.value = false;
+    return data;
+  };
+
+  return {
+    isLoading,
+    createOrganization,
+  };
+};


### PR DESCRIPTION
Refactor API call for creating organization in FormFieldCompany to a separate composable. This is so that it can be reused on register challenge page.

Additionally, call `loadOrganizations` function inside the `onMounted` hook instead of directly in the `setup` method.