### PR TITLE
src/components: show selected option for FormFieldSelectTable in a sticky bar on top of the list

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -229,17 +229,18 @@ describe('<FormFieldSelectTable>', () => {
           options: options,
           organizationLevel: OrganizationLevel.organization,
           organizationType: OrganizationType.company,
-          modelValue: options[0].value,
+          modelValue: options[12].value,
         },
       });
       cy.viewport('macbook-16');
     });
 
-    it('shows selected option', () => {
+    it('shows selected option (sticky on top)', () => {
       cy.dataCy('form-select-table-options')
-        .find('.q-radio__inner')
-        .first()
-        .should('have.class', 'text-primary');
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', options[12].label)
+        .and('be.visible');
     });
   });
 

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -345,9 +345,7 @@ export default defineComponent({
           <q-virtual-scroll
             style="max-height: 250px"
             :items="filteredOptions"
-            :virtual-scroll-item-size="56"
             :virtual-scroll-sticky-size-start="56"
-            :virtual-scroll-sticky-size-end="32"
             separator
           >
             <template v-slot:before>

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -42,7 +42,7 @@
 
 // libraries
 import { computed, defineComponent, inject, ref } from 'vue';
-import { QForm, QVirtualScroll } from 'quasar';
+import { QForm } from 'quasar';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -109,7 +109,6 @@ export default defineComponent({
 
     // user input for filtering
     const query = ref<string>('');
-    const virtualScrollRef = ref<typeof QVirtualScroll | null>(null);
     const formRef = ref<typeof QForm | null>(null);
     const companyNew = ref<FormCompanyFields>({
       name: '',
@@ -284,7 +283,6 @@ export default defineComponent({
       query,
       teamNew,
       titleDialog,
-      virtualScrollRef,
       isFilled,
       onClose,
       onSubmit,
@@ -345,7 +343,6 @@ export default defineComponent({
         <!-- Options list -->
         <q-card-section class="q-pa-xs" data-cy="form-select-table-options">
           <q-virtual-scroll
-            ref="virtualScrollRef"
             style="max-height: 250px"
             :items="filteredOptions"
             :virtual-scroll-item-size="56"
@@ -354,7 +351,11 @@ export default defineComponent({
             separator
           >
             <template v-slot:before>
-              <q-item class="sticky" v-if="inputValue" tag="label">
+              <q-item
+                class="sticky"
+                v-if="inputValue && getOptionLabel(inputValue)"
+                tag="label"
+              >
                 <q-item-section avatar>
                   <!-- Show selected option -->
                   <q-radio

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -365,12 +365,6 @@ export default defineComponent({
                     data-cy="form-select-table-option"
                   />
                 </q-item-section>
-                <!-- Additional description
-                <q-item-section>
-                  <q-item-label>Label</q-item-label>
-                  <q-item-label caption>Description</q-item-label>
-                </q-item-section>
-                -->
               </q-item>
             </template>
             <template v-slot:default="{ item }">

--- a/test/cypress/fixtures/formFieldCompany.json
+++ b/test/cypress/fixtures/formFieldCompany.json
@@ -1,5 +1,5 @@
 {
-  "count": 10,
+  "count": 20,
   "next": "https://test.dopracenakole.cz/rest/organizations/company/?limit=10&offset=10",
   "previous": null,
   "results": [

--- a/test/cypress/fixtures/formFieldCompanyNext.json
+++ b/test/cypress/fixtures/formFieldCompanyNext.json
@@ -1,7 +1,7 @@
 {
-  "count": 10,
+  "count": 20,
   "next": null,
-  "previous": null,
+  "previous": "https://test.dopracenakole.cz/rest/organizations/company/?limit=10&offset=0",
   "results": [
     {
       "id": 3619,


### PR DESCRIPTION
Issue:
It is easy to lose track of selected value in `FormFieldSelectTable` component.

Solution:
Show selected option in a sticky bar on top of the virtual scroll list.
Update test to check for situation when selected value is outside the scroll area viewport.

Additionally, correct fixture parameters for test organizations response.