### PR TITLE
src/components: update default price behaviour in RegisterChallengePayment

### DIFF
--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -223,6 +223,84 @@ function coreTests() {
     );
   });
 
+  it('handles default price when switching between individual and discount voucher', () => {
+    cy.get('@voucherHalf').then((voucher) => {
+      // ensure we are on step individual
+      cy.dataCy(getRadioOption(PaymentSubject.individual))
+        .should('be.visible')
+        .click();
+      // check amount
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', defaultPaymentAmountMin);
+      // switch to voucher
+      cy.dataCy(getRadioOption(PaymentSubject.voucher))
+        .should('be.visible')
+        .click();
+      // amount options are hidden
+      cy.dataCy(selectorPaymentAmount).should('not.exist');
+      // input voucher
+      cy.dataCy(selectorVoucherInput).type(voucher.code);
+      cy.dataCy(selectorVoucherSubmit).click();
+      // option with discounted amount is available
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', voucher.amount);
+      // switch to individual
+      cy.dataCy(getRadioOption(PaymentSubject.individual))
+        .should('be.visible')
+        .click();
+      // amount is reset to default value
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', defaultPaymentAmountMin);
+      // switch to voucher
+      cy.dataCy(getRadioOption(PaymentSubject.voucher))
+        .should('be.visible')
+        .click();
+      // amount is reset to voucher value
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', voucher.amount);
+      // select payment amount available for both payment subjects
+      cy.dataCy(getRadioOption(testNumberValue)).should('be.visible').click();
+      // amount is set to shared test value
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', testNumberValue);
+      // switch to individual
+      cy.dataCy(getRadioOption(PaymentSubject.individual))
+        .should('be.visible')
+        .click();
+      // amount stays the same
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', testNumberValue);
+      // switch to voucher
+      cy.dataCy(getRadioOption(PaymentSubject.voucher))
+        .should('be.visible')
+        .click();
+      // amount stays the same
+      cy.dataCy(selectorPaymentAmount)
+        .should('be.visible')
+        .find('.q-radio__inner.q-radio__inner--truthy')
+        .siblings('.q-radio__label')
+        .should('contain', testNumberValue);
+    });
+  });
+
   it('if selected voucher - allows to apply voucher (HALF)', () => {
     cy.get('@voucherHalf').then((voucher) => {
       // option default amount is active

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -5,9 +5,10 @@ import RegisterChallengePayment from 'components/register/RegisterChallengePayme
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { PaymentAmount, PaymentSubject } from '../enums/Payment';
-import { OrganizationType } from 'components/types/Organization';
 import { useRegisterChallengeStore } from 'stores/registerChallenge';
 import { getRadioOption } from '../../../test/cypress/utils';
+import { interceptOrganizationsApi } from '../../../test/cypress/support/commonTests';
+import { OrganizationType } from '../types/Organization';
 
 // selectors
 const selectorBannerPaymentMinimum = 'banner-payment-minimum';
@@ -85,6 +86,16 @@ describe('<RegisterChallengePayment>', () => {
   context('desktop', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
+      interceptOrganizationsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        OrganizationType.company,
+      );
+      interceptOrganizationsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        OrganizationType.school,
+      );
       cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
         cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
           cy.wrap(voucherFull).as('voucherFull');
@@ -103,6 +114,16 @@ describe('<RegisterChallengePayment>', () => {
   context('mobile', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
+      interceptOrganizationsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        OrganizationType.company,
+      );
+      interceptOrganizationsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        OrganizationType.school,
+      );
       cy.fixture('registerPaymentVoucherFull').then((voucherFull) => {
         cy.fixture('registerPaymentVoucherHalf').then((voucherHalf) => {
           cy.wrap(voucherFull).as('voucherFull');

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -315,13 +315,47 @@ export default defineComponent({
           ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
           ' radio button element.',
       );
+      // new options include currently selected amount
+      const newOptionsIncludeSelectedAmount = optsVals.includes(
+        selectedPaymentAmount.value,
+      );
+      // selected amount is custom
+      const isSelectedAmountCustom =
+        selectedPaymentAmount.value === PaymentAmount.custom;
+      // reset custom amount to first option to update slider min value
+      if (isSelectedAmountCustom && options.length > 0) {
+        logger?.debug(
+          `Selected amount <${selectedPaymentAmountCustom.value}> is custom,` +
+            ` reset to first option <${options[0].value}>.`,
+        );
+        selectedPaymentAmount.value = String(options[0].value);
+      }
+      // new options include selected amount
+      else if (newOptionsIncludeSelectedAmount) {
+        logger?.debug(
+          `Selected amount <${selectedPaymentAmount.value}> passed into new options.`,
+        );
+      }
+      // new options do not include selected amount
+      else if (options.length > 0) {
+        logger?.debug(
+          `New options do not include selected amount <${selectedPaymentAmount.value}>` +
+            ` set new selected amount to <${options[0].value}>.`,
+        );
+        selectedPaymentAmount.value = String(options[0].value);
+      }
+      // no options, clear selected amount value
+      else if (options.length === 0) {
+        logger?.debug(
+          "No options for payment amount, setting selected amount to <''>",
+        );
+        selectedPaymentAmount.value = '';
+      }
       logger?.debug(
-        `Default payment amount option changed from <${selectedPaymentAmount.value}>` +
-          ` to <${defaultPaymentOption.value}> for` +
+        `New selected amount <${selectedPaymentAmount.value}> for` +
           ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
           ' radio button element.',
       );
-      selectedPaymentAmount.value = defaultPaymentOption.value;
     });
 
     /**

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -315,44 +315,49 @@ export default defineComponent({
           ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
           ' radio button element.',
       );
-      // new options include currently selected amount
-      const newOptionsIncludeSelectedAmount = optsVals.includes(
+      // New payment options include currently selected amount
+      const newPaymentOptionsIncludeSelectedAmount = optsVals.includes(
         selectedPaymentAmount.value,
       );
-      // selected amount is custom
+      // Selected payment amount is custom
       const isSelectedAmountCustom =
         selectedPaymentAmount.value === PaymentAmount.custom;
-      // reset custom amount to first option to update slider min value
-      if (isSelectedAmountCustom && options.length > 0) {
+
+      // Reset custom payment amount to first option to update slider min value
+      if (isSelectedAmountCustom && optsVals.length > 0) {
         logger?.debug(
-          `Selected amount <${selectedPaymentAmountCustom.value}> is custom,` +
-            ` reset to first option <${options[0].value}>.`,
+          `Selected payment amount is <${selectedPaymentAmountCustom.value}>,` +
+            ` reset it to the first option <${optsVals[0]}>.`,
         );
-        selectedPaymentAmount.value = String(options[0].value);
+        selectedPaymentAmount.value = String(optsVals[0]);
       }
-      // new options include selected amount
-      else if (newOptionsIncludeSelectedAmount) {
+      // New payment options include selected amount
+      else if (newPaymentOptionsIncludeSelectedAmount) {
         logger?.debug(
-          `Selected amount <${selectedPaymentAmount.value}> passed into new options.`,
+          'New payment options include selected payment amount' +
+            ` <${selectedPaymentAmount.value}>, selected payment` +
+            ` amount is the same <${selectedPaymentAmount.value}>.`,
         );
       }
-      // new options do not include selected amount
-      else if (options.length > 0) {
+      // New payment options do not include selected amount
+      else if (!newPaymentOptionsIncludeSelectedAmount) {
+        selectedPaymentAmount.value = String(optsVals[0]);
         logger?.debug(
-          `New options do not include selected amount <${selectedPaymentAmount.value}>` +
-            ` set new selected amount to <${options[0].value}>.`,
+          'New payment options do not include selected payment amount' +
+            ` <${selectedPaymentAmount.value}>, set new selected payment` +
+            ` amount to <${selectedPaymentAmount.value}>.`,
         );
-        selectedPaymentAmount.value = String(options[0].value);
       }
-      // no options, clear selected amount value
-      else if (options.length === 0) {
-        logger?.debug(
-          "No options for payment amount, setting selected amount to <''>",
-        );
+      // No payment options, clear selected amount value
+      else if (optsVals.length === 0) {
         selectedPaymentAmount.value = '';
+        logger?.debug(
+          'No payment options for payment amount, set selected amount to' +
+            ` <${selectedPaymentAmount.value}>.`,
+        );
       }
       logger?.debug(
-        `New selected amount <${selectedPaymentAmount.value}> for` +
+        `New selected payment amount <${selectedPaymentAmount.value}> for` +
           ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
           ' radio button element.',
       );


### PR DESCRIPTION
Update default price behaviour in `RegisterChallengePayment` based on available options.

When switching between payment subjects, available payment options may change (voucher discounts first available option). For better user experience and consistent data, update `selectedPaymentAmount` based on available options.

- If current `selectedPaymentAmount` value is available in new options, select that option
- If current is not available, and default option (from config) is available select that option (most likely the first)
- If neither of the above are available, select first available option.