### PR TITLE
src/components: add ability to create subsidiary in FormFieldCompanyAddress

### DIFF
--- a/src/adapters/subsidiaryAdapter.ts
+++ b/src/adapters/subsidiaryAdapter.ts
@@ -30,6 +30,7 @@ export const subsidiaryAdapter = {
    */
   toFormData(apiData: SubsidiaryPostApiResponse): FormCompanyAddressFields {
     return {
+      id: apiData.id,
       street: apiData.address.street,
       houseNumber: apiData.address.street_number,
       city: apiData.address.city,

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -154,11 +154,9 @@ describe('<FormFieldCompanyAddress>', () => {
             // set organization ID in store
             store.setOrganizationId(organizationId);
             cy.wrap(store.getOrganizationId).should('eq', organizationId);
-
             // open dialog
             cy.dataCy('button-add-address').click();
             cy.dataCy('dialog-add-address').should('be.visible');
-
             // fill the form
             cy.dataCy('form-add-subsidiary').within(() => {
               cy.dataCy('form-add-subsidiary-street').type(
@@ -187,16 +185,12 @@ describe('<FormFieldCompanyAddress>', () => {
                   .click();
               });
             });
-
             // submit form
             cy.dataCy('dialog-button-submit').click();
-
             // wait for API response
             cy.waitForSubsidiaryPostApi(subsidiaryResponse);
-
             // verify model was updated
             cy.wrap(model).its('value').should('eq', subsidiaryResponse.id);
-
             // verify dialog was closed
             cy.dataCy('dialog-add-address').should('not.exist');
           });

--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -123,28 +123,33 @@ describe('<FormFieldCompanyAddress>', () => {
     });
 
     it('renders dialog for adding a new address', () => {
-      cy.dataCy('button-add-address').click();
-      cy.dataCy('dialog-add-address').should('be.visible');
-      // title
-      cy.dataCy('dialog-add-address')
-        .find('h3')
-        .should('be.visible')
-        .and('have.css', 'font-size', '20px')
-        .and('have.css', 'font-weight', '500')
-        .and('contain', i18n.global.t('form.company.titleAddAddress'));
-      // message
-      cy.dataCy('add-subsidiary-text')
-        .should('be.visible')
-        .and('contain', i18n.global.t('form.company.textSubsidiaryAddress'));
-      // form
-      cy.dataCy('form-add-subsidiary').should('be.visible');
-      // buttons
-      cy.dataCy('dialog-button-cancel')
-        .should('be.visible')
-        .and('have.text', i18n.global.t('navigation.discard'));
-      cy.dataCy('dialog-button-submit')
-        .should('be.visible')
-        .and('have.text', i18n.global.t('form.company.buttonAddSubsidiary'));
+      cy.wrap(useRegisterChallengeStore()).then((store) => {
+        // set organization ID in store
+        store.setOrganizationId(organizationId);
+        cy.wrap(store.getOrganizationId).should('eq', organizationId);
+        cy.dataCy('button-add-address').click();
+        cy.dataCy('dialog-add-address').should('be.visible');
+        // title
+        cy.dataCy('dialog-add-address')
+          .find('h3')
+          .should('be.visible')
+          .and('have.css', 'font-size', '20px')
+          .and('have.css', 'font-weight', '500')
+          .and('contain', i18n.global.t('form.company.titleAddAddress'));
+        // message
+        cy.dataCy('add-subsidiary-text')
+          .should('be.visible')
+          .and('contain', i18n.global.t('form.company.textSubsidiaryAddress'));
+        // form
+        cy.dataCy('form-add-subsidiary').should('be.visible');
+        // buttons
+        cy.dataCy('dialog-button-cancel')
+          .should('be.visible')
+          .and('have.text', i18n.global.t('navigation.discard'));
+        cy.dataCy('dialog-button-submit')
+          .should('be.visible')
+          .and('have.text', i18n.global.t('form.company.buttonAddSubsidiary'));
+      });
     });
 
     it('allows user to create a new subsidiary', () => {

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -182,7 +182,7 @@ export default defineComponent({
                 // set subsidiary ID
                 subsidiaryId.value = data.id;
                 logger?.debug(
-                  `New subsidiary model set to <${JSON.stringify(subsidiaryId.value, null, 2)}>.`,
+                  `Subsidiary ID model set to <${subsidiaryId.value}>.`,
                 );
                 // push new subsidiary to subsidiaries list
                 const newSubsidiary: OrganizationSubsidiary = {

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -203,7 +203,7 @@ export default defineComponent({
       } else if (!isFormValid) {
         logger?.error('Form is not valid.');
       } else if (!store.getOrganizationId) {
-        logger?.info('Organization was not choosed.');
+        logger?.error('Organization was not choosed.');
         onClose();
       }
     };

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -251,6 +251,7 @@ export default defineComponent({
       isDialogOpen,
       isFilled,
       isLoading,
+      isLoadingCreateSubsidiary,
       onClose,
       onSubmit,
     };
@@ -342,6 +343,7 @@ export default defineComponent({
             outline
             color="primary"
             data-cy="dialog-button-cancel"
+            :disable="isLoadingCreateSubsidiary"
             @click="onClose"
           >
             {{ $t('navigation.discard') }}
@@ -351,6 +353,8 @@ export default defineComponent({
             unelevated
             color="primary"
             data-cy="dialog-button-submit"
+            :loading="isLoadingCreateSubsidiary"
+            :disable="isLoadingCreateSubsidiary"
             @click="onSubmit"
           >
             {{ $t('form.company.buttonAddSubsidiary') }}

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -41,8 +41,8 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, ref } from 'vue';
-import { QForm } from 'quasar';
+import { computed, defineComponent, defineExpose, inject, ref } from 'vue';
+import { QForm, QSelect } from 'quasar';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -125,6 +125,7 @@ export default defineComponent({
     const teamNew = ref<FormTeamFields>({
       name: '',
     });
+    const selectOrganizationRef = ref<typeof QSelect | null>(null);
 
     /**
      * Provides autocomplete functionality via computed property
@@ -258,6 +259,10 @@ export default defineComponent({
       return getSelectTableLabels(props.organizationLevel).titleDialog;
     });
 
+    defineExpose({
+      selectOrganizationRef,
+    });
+
     return {
       borderRadius,
       organizationNew,
@@ -277,6 +282,7 @@ export default defineComponent({
       onSubmit,
       OrganizationType,
       OrganizationLevel,
+      selectOrganizationRef,
     };
   },
 });
@@ -302,6 +308,7 @@ export default defineComponent({
       :rules="[
         (val: string) => isFilled(val) || $t('form.messageOptionRequired'),
       ]"
+      ref="selectOrganizationRef"
       data-cy="form-select-table-field"
     >
       <q-card

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -78,7 +78,7 @@ export default defineComponent({
           loadOrganizations(newValue).then(() => {
             logger?.info('All organizations data was loaded from the API.');
             // Lazy loading
-            opts.value = options.value;
+            opts.value = options;
           });
         }
       },
@@ -102,7 +102,7 @@ export default defineComponent({
     <form-field-select-table
       v-model="organizationId"
       :loading="isLoading"
-      :options="opts"
+      :options="opts.value"
       :organization-level="OrganizationLevel.organization"
       :organization-type="organizationType"
       :data-organization-type="organizationType"

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -46,6 +46,7 @@ export default defineComponent({
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
     const opts = ref<FormSelectOption[]>([]);
+    const formFieldSelectTableRef = ref(null);
     const { options, isLoading, loadOrganizations } =
       useApiGetOrganizations(logger);
 
@@ -85,13 +86,21 @@ export default defineComponent({
       { immediate: true },
     );
 
+    const onCloseAddSubsidiaryDialog = () => {
+      // Run organization validation proccess before open add subsidiary dialog
+      logger?.info('Run select organization widget validation process.');
+      formFieldSelectTableRef.value.selectOrganizationRef.validate();
+    };
+
     return {
+      formFieldSelectTableRef,
       isLoading,
       organizationId,
       opts,
       subsidiaryId,
       OrganizationLevel,
       organizationType,
+      onCloseAddSubsidiaryDialog,
     };
   },
 });
@@ -106,11 +115,13 @@ export default defineComponent({
       :organization-level="OrganizationLevel.organization"
       :organization-type="organizationType"
       :data-organization-type="organizationType"
+      ref="formFieldSelectTableRef"
       data-cy="form-select-table-company"
     />
     <form-field-company-address
       v-model="subsidiaryId"
       data-cy="form-company-address"
+      @close:addSubsidiaryDialog="onCloseAddSubsidiaryDialog"
     />
   </div>
 </template>

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -27,6 +27,7 @@ export type FormCompanyFields = {
 };
 
 export type FormCompanyAddressFields = {
+  id?: number;
   street: string;
   houseNumber: string;
   city: string;

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -29,7 +29,7 @@ export interface Organization {
 
 export interface OrganizationSubsidiary {
   id: number;
-  title: string;
+  title?: string;
   address?: FormCompanyAddressFields;
   teams: OrganizationTeam[];
 }

--- a/test/cypress/fixtures/apiPostSubsidiaryRequest.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryRequest.json
@@ -6,5 +6,5 @@
     "city": "Subsidiary City",
     "psc": "12345"
   },
-  "city_id": 4
+  "city_id": 41
 }

--- a/test/cypress/fixtures/apiPostSubsidiaryResponse.json
+++ b/test/cypress/fixtures/apiPostSubsidiaryResponse.json
@@ -1,10 +1,10 @@
 {
   "id": 5351,
-  "city_id": 4,
+  "city_id": 41,
   "active": true,
   "address": {
-    "street": "Test Subsidiary Street 4",
-    "street_number": "004",
+    "street": "Subsidiary Street",
+    "street_number": "4",
     "recipient": "Recipient 4",
     "psc": 50004,
     "city": "City 4"


### PR DESCRIPTION
Add ability to create subsidiary in `FormFieldCompanyAddress` component.

* Add composable `useApiPostSubsidiary` and use the `createSubsidiary` method.
* Update API data adapter to pass the created subsidiary `id` value to the output object.
* Rename inner variable `address` to `subsidiaryId`.
* Update logic for loading subsidiaries (without clearing `subsidiaryId` value on load).
* Add E2E and component tests.
* Update fixture to match selected challenge city ID.