### PR TITLE
src/components/types: change FormCompanyFields type address field from multivalue to single value

### DIFF
--- a/src/components/__tests__/FormAddCompany.cy.js
+++ b/src/components/__tests__/FormAddCompany.cy.js
@@ -139,16 +139,16 @@ describe('<FormAddCompany>', () => {
         // fill in address fields
         cy.dataCy(selectorFormStreet)
           .find('input')
-          .type(companyAddress.address[0].street);
+          .type(companyAddress.address.street);
         cy.dataCy(selectorFormHouseNumber)
           .find('input')
-          .type(companyAddress.address[0].houseNumber);
+          .type(companyAddress.address.houseNumber);
         cy.dataCy(selectorFormCity)
           .find('input')
-          .type(companyAddress.address[0].city);
+          .type(companyAddress.address.city);
         cy.dataCy(selectorFormZip)
           .find('input')
-          .type(companyAddress.address[0].zip);
+          .type(companyAddress.address.zip);
         cy.dataCy(selectorFormCityChallenge).click();
         cy.get(classSelectorDropdownMenu)
           .should('be.visible')
@@ -156,13 +156,12 @@ describe('<FormAddCompany>', () => {
             cy.get(classSelectorDropdownItem).first().click();
           });
         cy.dataCy(selectorFormDepartment).type(
-          companyAddress.address[0].department,
+          companyAddress.address.department,
         );
         cy.dataCy(selectorFormDepartment).blur();
         // override cityChallenge with fixture data to get correct ID
         cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
-          companyAddress.address[0].cityChallenge =
-            citiesResponse.results[0].id;
+          companyAddress.address.cityChallenge = citiesResponse.results.id;
         });
         // verify model updates
         cy.wrap(model).its('value').should('deep.equal', companyAddress);

--- a/src/components/__tests__/FormAddCompany.cy.js
+++ b/src/components/__tests__/FormAddCompany.cy.js
@@ -161,7 +161,7 @@ describe('<FormAddCompany>', () => {
         cy.dataCy(selectorFormDepartment).blur();
         // override cityChallenge with fixture data to get correct ID
         cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
-          companyAddress.address.cityChallenge = citiesResponse.results.id;
+          companyAddress.address.cityChallenge = citiesResponse.results[0].id;
         });
         // verify model updates
         cy.wrap(model).its('value').should('deep.equal', companyAddress);

--- a/src/components/form/FormAddCompany.vue
+++ b/src/components/form/FormAddCompany.vue
@@ -83,8 +83,6 @@ export default defineComponent({
 
     const { isFilled } = useValidation();
 
-    const addressIndex = 0;
-
     const isCompany = computed((): boolean => {
       return props.organizationType === OrganizationType.company;
     });
@@ -95,7 +93,6 @@ export default defineComponent({
     });
 
     return {
-      addressIndex,
       company,
       titleDialog,
       OrganizationType,
@@ -159,7 +156,7 @@ export default defineComponent({
       </div>
       <!-- TODO: validate the method of accessing address -->
       <form-add-subsidiary
-        v-model="company.address[addressIndex]"
+        v-model="company.address"
         @update:model-value="onUpdate"
         data-cy="form-add-company-subsidiary"
       />

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -110,19 +110,17 @@ export default defineComponent({
     // user input for filtering
     const query = ref<string>('');
     const formRef = ref<typeof QForm | null>(null);
-    const companyNew = ref<FormCompanyFields>({
+    const organizationNew = ref<FormCompanyFields>({
       name: '',
       vatId: '',
-      address: [
-        {
-          street: '',
-          houseNumber: '',
-          city: '',
-          zip: '',
-          cityChallenge: null,
-          department: '',
-        },
-      ],
+      address: {
+        street: '',
+        houseNumber: '',
+        city: '',
+        zip: '',
+        cityChallenge: null,
+        department: '',
+      },
     });
     const teamNew = ref<FormTeamFields>({
       name: '',
@@ -262,7 +260,7 @@ export default defineComponent({
 
     return {
       borderRadius,
-      companyNew,
+      organizationNew,
       contactEmail,
       filteredOptions,
       formRef,
@@ -418,7 +416,7 @@ export default defineComponent({
             <q-form ref="formRef">
               <form-add-company
                 v-if="organizationLevel === OrganizationLevel.organization"
-                v-model="companyNew"
+                v-model="organizationNew"
                 :organization-type="organizationType"
                 class="q-mb-lg"
               ></form-add-company>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -52,6 +52,7 @@ import { useOrganizations } from 'src/composables/useOrganizations';
 import { useValidation } from 'src/composables/useValidation';
 
 // enums
+import { FormAddCompanyVariantProp } from '../enums/Form';
 import { OrganizationType } from '../types/Organization';
 
 // types
@@ -67,16 +68,14 @@ import { deepObjectWithSimplePropsCopy } from 'src/utils';
 export const emptyFormCompanyFields: FormCompanyFields = {
   name: '',
   vatId: '',
-  address: [
-    {
-      street: '',
-      houseNumber: '',
-      city: '',
-      zip: '',
-      cityChallenge: null,
-      department: '',
-    },
-  ],
+  address: {
+    street: '',
+    houseNumber: '',
+    city: '',
+    zip: '',
+    cityChallenge: null,
+    department: '',
+  },
 };
 
 export default defineComponent({
@@ -281,6 +280,7 @@ export default defineComponent({
       onFilter,
       onSubmit,
       organizationFieldValidationTransStrings,
+      FormAddCompanyVariantProp,
       OrganizationType,
     };
   },
@@ -368,7 +368,7 @@ export default defineComponent({
         <q-form ref="formRef">
           <form-add-company
             v-model="companyNew"
-            variant="simple"
+            :variant="FormAddCompanyVariantProp.simple"
             :organization-type="organizationType"
           ></form-add-company>
         </q-form>

--- a/src/components/types/Form.ts
+++ b/src/components/types/Form.ts
@@ -26,7 +26,7 @@ export type FormSelectOption = {
 export type FormCompanyFields = {
   name: string;
   vatId: string;
-  address: FormCompanyAddressFields[];
+  address: FormCompanyAddressFields;
 };
 
 export type FormCompanyAddressFields = {

--- a/src/components/types/apiOrganization.ts
+++ b/src/components/types/apiOrganization.ts
@@ -2,6 +2,13 @@ export interface PostOrganizationPayload {
   name: string;
   vatId: string;
   organization_type: string;
+  address?: {
+    street: string;
+    street_number: string;
+    city: string;
+    zip: string;
+    recipient: string;
+  };
 }
 
 export interface PostOrganizationResponse {

--- a/test/cypress/fixtures/companyAddress.json
+++ b/test/cypress/fixtures/companyAddress.json
@@ -1,14 +1,12 @@
 {
   "name": "Test Company",
   "vatId": "12345678",
-  "address": [
-    {
-      "street": "Test Street",
-      "houseNumber": "123",
-      "city": "Test City",
-      "zip": "12345",
-      "cityChallenge": 123123,
-      "department": "Test Department"
-    }
-  ]
+  "address": {
+    "street": "Test Street",
+    "houseNumber": "123",
+    "city": "Test City",
+    "zip": "12345",
+    "cityChallenge": 123123,
+    "department": "Test Department"
+  }
 }


### PR DESCRIPTION
Change `FormCompanyFields` type `address` prop from multivalue to single value across codebase.
Prop was created as multivalue in early stages of development and does not have a purpose in current data structure.
Making `address` single value simplifies working with the form fields.

Additional changes:
* Rename the form state variable `companyNew` in FormFieldSelectTable.vue to `organizationNew`.
* Use enum for component variant `simple` in `FormFieldCompany` component.