### PR TITLE
src/stores: load registration options data to registerChallenge store

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -68,8 +68,8 @@ describe('<FormFieldSelectTable>', () => {
             ...apiGetTeamsResponseNext.results,
           ];
           // map teams to options
-          const { mapTeamsToOptions } = useApiGetTeams();
-          optionsTeams = mapTeamsToOptions(teams);
+          const { mapTeamToOption } = useApiGetTeams();
+          optionsTeams = teams.map(mapTeamToOption);
         });
       });
     });

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -79,7 +79,7 @@ export default defineComponent({
     /**
      * Handle option created event
      * When option is created in the child component, push the result into
-     * the teams store
+     * the `teams` array in the `registerChallenge` store.
      * @param {TeamPostApiResponse} data - Team data
      * @returns {void}
      */

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -43,8 +43,8 @@ export default defineComponent({
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
-    const { mapTeamToOption } = useApiGetTeams(logger);
     const registerChallengeStore = useRegisterChallengeStore();
+    const { mapTeamToOption } = useApiGetTeams(logger);
 
     const team = computed({
       get: () => {
@@ -90,7 +90,7 @@ export default defineComponent({
         subsidiary: registerChallengeStore.getSubsidiaryId as number,
         members: [],
       };
-      const updatedTeams = [...teams.value, newTeam];
+      const updatedTeams = [newTeam, ...teams.value];
       registerChallengeStore.setTeams(updatedTeams);
     };
 

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -16,7 +16,7 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, watch, ref } from 'vue';
+import { computed, defineComponent, inject, watch } from 'vue';
 
 // components
 import FormFieldSelectTable from './FormFieldSelectTable.vue';
@@ -34,6 +34,7 @@ import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 import type { Logger } from '../types/Logger';
 import type { OrganizationTeam } from '../types/Organization';
 import type { TeamPostApiResponse } from '../types/ApiTeam';
+import type { FormSelectTableOption } from '../types/Form';
 
 export default defineComponent({
   name: 'FormSelectTeam',
@@ -42,7 +43,7 @@ export default defineComponent({
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
-
+    const { mapTeamToOption } = useApiGetTeams(logger);
     const registerChallengeStore = useRegisterChallengeStore();
 
     const team = computed({
@@ -54,21 +55,22 @@ export default defineComponent({
       },
     });
 
-    const { options, isLoading, teams, loadTeams } = useApiGetTeams(logger);
-    const opts = ref([]);
+    const isLoading = computed(() => registerChallengeStore.isLoadingTeams);
+    const teams = computed(() => registerChallengeStore.getTeams);
+    const options = computed<FormSelectTableOption[]>(() =>
+      teams.value.map(mapTeamToOption),
+    );
+
     // load teams when subsidiary ID changes
     watch(
       () => registerChallengeStore.getSubsidiaryId,
-      (newValue: number | null) => {
+      async (newValue: number | null) => {
         logger?.debug(
           `Register challenge store subsidiary ID changed to <${newValue}>.`,
         );
         if (newValue) {
           logger?.info('Loading teams.');
-          // Lazy loading
-          loadTeams(newValue).then(() => {
-            opts.value = options;
-          });
+          await registerChallengeStore.loadTeamsToStore(logger);
         }
       },
       { immediate: true },
@@ -77,7 +79,7 @@ export default defineComponent({
     /**
      * Handle option created event
      * When option is created in the child component, push the result into
-     * the `teams` array (options are computed from `teams` array).
+     * the teams store
      * @param {TeamPostApiResponse} data - Team data
      * @returns {void}
      */
@@ -88,12 +90,13 @@ export default defineComponent({
         subsidiary: registerChallengeStore.getSubsidiaryId as number,
         members: [],
       };
-      teams.value.push(newTeam);
+      const updatedTeams = [...teams.value, newTeam];
+      registerChallengeStore.setTeams(updatedTeams);
     };
 
     return {
       isLoading,
-      opts,
+      options,
       team,
       OrganizationLevel,
       onOptionCreated,
@@ -112,7 +115,7 @@ export default defineComponent({
     <form-field-select-table
       v-model="team"
       :organization-level="OrganizationLevel.team"
-      :options="opts.value"
+      :options="options"
       :loading="isLoading"
       @create:option="onOptionCreated"
       data-cy="form-select-table-team"

--- a/src/components/types/Organization.ts
+++ b/src/components/types/Organization.ts
@@ -87,5 +87,5 @@ export type useApiGetTeamsReturn = {
   options: Ref<FormSelectTableOption[]>;
   isLoading: Ref<boolean>;
   loadTeams: (subsidiaryId: number) => Promise<void>;
-  mapTeamsToOptions: (teams: OrganizationTeam[]) => FormSelectTableOption[];
+  mapTeamToOption: (team: OrganizationTeam) => FormSelectTableOption;
 };

--- a/src/composables/useApiGetTeams.ts
+++ b/src/composables/useApiGetTeams.ts
@@ -115,20 +115,14 @@ export const useApiGetTeams = (logger: Logger | null): useApiGetTeamsReturn => {
 
   // Push results to options
   const options = computed<FormSelectTableOption[]>(() => {
-    return mapTeamsToOptions(teams.value);
+    return teams.value.map(mapTeamToOption);
   });
 
-  const mapTeamsToOptions = (
-    teams: OrganizationTeam[],
-  ): FormSelectTableOption[] => {
-    return teams.map((team: OrganizationTeam): FormSelectTableOption => {
-      return {
-        label: team.name,
-        value: team.id,
-        members: team.members,
-        maxMembers: challengeStore.getMaxTeamMembers,
-      };
-    });
+  const mapTeamToOption = (team: OrganizationTeam): FormSelectTableOption => {
+    return {
+      label: team.name,
+      value: team.id,
+    };
   };
 
   return {
@@ -136,6 +130,6 @@ export const useApiGetTeams = (logger: Logger | null): useApiGetTeamsReturn => {
     options,
     isLoading,
     loadTeams,
-    mapTeamsToOptions,
+    mapTeamToOption,
   };
 };

--- a/src/composables/useApiGetTeams.ts
+++ b/src/composables/useApiGetTeams.ts
@@ -122,6 +122,8 @@ export const useApiGetTeams = (logger: Logger | null): useApiGetTeamsReturn => {
     return {
       label: team.name,
       value: team.id,
+      members: team.members,
+      maxMembers: challengeStore.getMaxTeamMembers,
     };
   };
 

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 
 // composables
 import { useApiGetSubsidiaries } from 'src/composables/useApiGetSubsidiaries';
+import { useApiGetOrganizations } from 'src/composables/useApiGetOrganizations';
 
 // enums
 import { Gender } from '../components/types/Profile';
@@ -10,6 +11,7 @@ import { NewsletterType } from '../components/types/Newsletter';
 import {
   OrganizationSubsidiary,
   OrganizationType,
+  OrganizationOption,
 } from '../components/types/Organization';
 import { PaymentSubject } from '../components/enums/Payment';
 
@@ -45,7 +47,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     paymentSubject: PaymentSubject.individual,
     voucher: '' as ValidatedCoupon | string,
     subsidiaries: [] as OrganizationSubsidiary[],
+    organizations: [] as OrganizationOption[],
     isLoadingSubsidiaries: false,
+    isLoadingOrganizations: false,
   }),
 
   getters: {
@@ -59,6 +63,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getPaymentSubject: (state): PaymentSubject => state.paymentSubject,
     getVoucher: (state): ValidatedCoupon | string => state.voucher,
     getSubsidiaries: (state): OrganizationSubsidiary[] => state.subsidiaries,
+    getOrganizations: (state): OrganizationOption[] => state.organizations,
   },
 
   actions: {
@@ -89,6 +94,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     setSubsidiaries(subsidiaries: OrganizationSubsidiary[]) {
       this.subsidiaries = subsidiaries;
     },
+    setOrganizations(organizations: OrganizationOption[]) {
+      this.organizations = organizations;
+    },
     async loadSubsidiariesToStore(logger: Logger | null) {
       const { subsidiaries, loadSubsidiaries } = useApiGetSubsidiaries(logger);
       if (this.organizationId) {
@@ -105,9 +113,26 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         this.isLoadingSubsidiaries = false;
       }
     },
+    async loadOrganizationsToStore(logger: Logger | null) {
+      const { organizations, loadOrganizations } =
+        useApiGetOrganizations(logger);
+      if (this.organizationType !== OrganizationType.none) {
+        logger?.debug(
+          `Load organizations for type <${this.organizationType}>` +
+            ' and save them into store.',
+        );
+        this.isLoadingOrganizations = true;
+        await loadOrganizations(this.organizationType);
+        this.organizations = organizations.value;
+        logger?.debug(
+          `Loaded organizations <${this.organizations}> saved into store.`,
+        );
+        this.isLoadingOrganizations = false;
+      }
+    },
   },
 
   persist: {
-    omit: ['subsidiaries'],
+    omit: ['subsidiaries', 'organizations'],
   },
 });

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia';
 // composables
 import { useApiGetSubsidiaries } from 'src/composables/useApiGetSubsidiaries';
 import { useApiGetOrganizations } from 'src/composables/useApiGetOrganizations';
+import { useApiGetTeams } from 'src/composables/useApiGetTeams';
 
 // enums
 import { Gender } from '../components/types/Profile';
@@ -12,6 +13,7 @@ import {
   OrganizationSubsidiary,
   OrganizationType,
   OrganizationOption,
+  OrganizationTeam,
 } from '../components/types/Organization';
 import { PaymentSubject } from '../components/enums/Payment';
 
@@ -48,8 +50,10 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     voucher: '' as ValidatedCoupon | string,
     subsidiaries: [] as OrganizationSubsidiary[],
     organizations: [] as OrganizationOption[],
+    teams: [] as OrganizationTeam[],
     isLoadingSubsidiaries: false,
     isLoadingOrganizations: false,
+    isLoadingTeams: false,
   }),
 
   getters: {
@@ -64,6 +68,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getVoucher: (state): ValidatedCoupon | string => state.voucher,
     getSubsidiaries: (state): OrganizationSubsidiary[] => state.subsidiaries,
     getOrganizations: (state): OrganizationOption[] => state.organizations,
+    getTeams: (state): OrganizationTeam[] => state.teams,
   },
 
   actions: {
@@ -96,6 +101,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     setOrganizations(organizations: OrganizationOption[]) {
       this.organizations = organizations;
+    },
+    setTeams(teams: OrganizationTeam[]) {
+      this.teams = teams;
     },
     async loadSubsidiariesToStore(logger: Logger | null) {
       const { subsidiaries, loadSubsidiaries } = useApiGetSubsidiaries(logger);
@@ -130,9 +138,23 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         this.isLoadingOrganizations = false;
       }
     },
+    async loadTeamsToStore(logger: Logger | null) {
+      const { teams, loadTeams } = useApiGetTeams(logger);
+      if (this.subsidiaryId) {
+        logger?.debug(
+          `Load subsidiary ID <${this.subsidiaryId}>` +
+            ' teams and save them into store.',
+        );
+        this.isLoadingTeams = true;
+        await loadTeams(this.subsidiaryId);
+        this.teams = teams.value;
+        logger?.debug(`Loaded teams <${this.teams}> saved into store.`);
+        this.isLoadingTeams = false;
+      }
+    },
   },
 
   persist: {
-    omit: ['subsidiaries', 'organizations'],
+    omit: ['subsidiaries', 'organizations', 'teams'],
   },
 });

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia';
 import { useApiGetSubsidiaries } from 'src/composables/useApiGetSubsidiaries';
 import { useApiGetOrganizations } from 'src/composables/useApiGetOrganizations';
 import { useApiGetTeams } from 'src/composables/useApiGetTeams';
+import { useApiGetMerchandise } from 'src/composables/useApiGetMerchandise';
 
 // enums
 import { Gender } from '../components/types/Profile';
@@ -21,6 +22,10 @@ import { PaymentSubject } from '../components/enums/Payment';
 import type { Logger } from '../components/types/Logger';
 import type { RegisterChallengePersonalDetailsForm } from '../components/types/RegisterChallenge';
 import type { ValidatedCoupon } from '../components/types/Coupon';
+import type {
+  MerchandiseCard,
+  MerchandiseItem,
+} from '../components/types/Merchandise';
 
 const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
@@ -51,9 +56,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     subsidiaries: [] as OrganizationSubsidiary[],
     organizations: [] as OrganizationOption[],
     teams: [] as OrganizationTeam[],
+    merchandiseItems: [] as MerchandiseItem[],
+    merchandiseCards: {} as Record<Gender, MerchandiseCard[]>,
     isLoadingSubsidiaries: false,
     isLoadingOrganizations: false,
     isLoadingTeams: false,
+    isLoadingMerchandise: false,
   }),
 
   getters: {
@@ -69,6 +77,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getSubsidiaries: (state): OrganizationSubsidiary[] => state.subsidiaries,
     getOrganizations: (state): OrganizationOption[] => state.organizations,
     getTeams: (state): OrganizationTeam[] => state.teams,
+    getMerchandiseItems: (state): MerchandiseItem[] => state.merchandiseItems,
+    getMerchandiseCards: (state): Record<Gender, MerchandiseCard[]> =>
+      state.merchandiseCards,
   },
 
   actions: {
@@ -104,6 +115,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     setTeams(teams: OrganizationTeam[]) {
       this.teams = teams;
+    },
+    setMerchandiseItems(items: MerchandiseItem[]) {
+      this.merchandiseItems = items;
+    },
+    setMerchandiseCards(cards: Record<Gender, MerchandiseCard[]>) {
+      this.merchandiseCards = cards;
     },
     async loadSubsidiariesToStore(logger: Logger | null) {
       const { subsidiaries, loadSubsidiaries } = useApiGetSubsidiaries(logger);
@@ -152,9 +169,28 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         this.isLoadingTeams = false;
       }
     },
+    async loadMerchandiseToStore(logger: Logger | null) {
+      const { merchandiseItems, merchandiseCards, loadMerchandise } =
+        useApiGetMerchandise(logger);
+      logger?.debug('Loading merchandise data into store.');
+      this.isLoadingMerchandise = true;
+      await loadMerchandise();
+      this.merchandiseItems = merchandiseItems.value;
+      this.merchandiseCards = merchandiseCards.value;
+      logger?.debug(
+        `Loaded merchandise items <${this.merchandiseItems.length}> and cards saved into store.`,
+      );
+      this.isLoadingMerchandise = false;
+    },
   },
 
   persist: {
-    omit: ['subsidiaries', 'organizations', 'teams'],
+    omit: [
+      'subsidiaries',
+      'organizations',
+      'teams',
+      'merchandiseItems',
+      'merchandiseCards',
+    ],
   },
 });


### PR DESCRIPTION
For `teams`, `organizations` and `merchandise` - refactor code to load data into `registerChallenge` store instead of individual components.

This will allow to access the options values from any component (e.g. the summary).

In `FormListMerch` connect the `selectedSize` variable with store value for `merchId`.