### PR TITLE
src/components: add logic for resetting organization, subsidiary, and team IDs

### DIFF
--- a/src/components/debug/ShowOrganizationIds.vue
+++ b/src/components/debug/ShowOrganizationIds.vue
@@ -1,0 +1,63 @@
+<script lang="ts">
+/**
+ * Show organization IDs
+ *
+ * @description * Use this component to debug Cypress component/e2e tests
+ * Note: Shows organizationId, subsidiaryId, and teamId from registerChallengeStore
+ *       Only visible in Cypress testing environment
+ *
+ * @example
+ * <show-organization-ids />
+ *
+ */
+
+// libraries
+import { defineComponent, computed } from 'vue';
+
+// stores
+import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
+
+export default defineComponent({
+  name: 'ShowOrganizationIds',
+  setup() {
+    let organizationId;
+    let subsidiaryId;
+    let teamId;
+
+    const showComponent = computed(() => !!window.Cypress);
+
+    if (showComponent.value) {
+      const registerChallengeStore = useRegisterChallengeStore();
+
+      organizationId = computed(() => registerChallengeStore.getOrganizationId);
+      subsidiaryId = computed(() => registerChallengeStore.getSubsidiaryId);
+      teamId = computed(() => registerChallengeStore.getTeamId);
+    }
+
+    return {
+      organizationId,
+      subsidiaryId,
+      teamId,
+      showComponent,
+    };
+  },
+});
+</script>
+
+<template>
+  <div v-if="showComponent" data-cy="debug-register-challenge-ids">
+    <div class="text-red text-bold">
+      <div data-cy="debug-organization-id">
+        DEBUG: organizationId:
+        <span data-cy="debug-organization-id-value">{{ organizationId }}</span>
+      </div>
+      <div data-cy="debug-subsidiary-id">
+        DEBUG: subsidiaryId:
+        <span data-cy="debug-subsidiary-id-value">{{ subsidiaryId }}</span>
+      </div>
+      <div data-cy="debug-team-id">
+        DEBUG: teamId: <span data-cy="debug-team-id-value">{{ teamId }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/debug/ShowOrganizationIds.vue
+++ b/src/components/debug/ShowOrganizationIds.vue
@@ -48,15 +48,15 @@ export default defineComponent({
   <div v-if="showComponent" data-cy="debug-register-challenge-ids">
     <div class="text-red text-bold">
       <div data-cy="debug-organization-id">
-        DEBUG: organizationId:
+        DEBUG: organization ID
         <span data-cy="debug-organization-id-value">{{ organizationId }}</span>
       </div>
       <div data-cy="debug-subsidiary-id">
-        DEBUG: subsidiaryId:
+        DEBUG: subsidiary ID
         <span data-cy="debug-subsidiary-id-value">{{ subsidiaryId }}</span>
       </div>
       <div data-cy="debug-team-id">
-        DEBUG: teamId: <span data-cy="debug-team-id-value">{{ teamId }}</span>
+        DEBUG: team ID <span data-cy="debug-team-id-value">{{ teamId }}</span>
       </div>
     </div>
   </div>

--- a/src/components/form/FormFieldOptionGroup.vue
+++ b/src/components/form/FormFieldOptionGroup.vue
@@ -25,7 +25,7 @@
 
 // libraries
 import { colors } from 'quasar';
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, inject } from 'vue';
 
 // composables
 import { useValidation } from 'src/composables/useValidation';
@@ -38,15 +38,12 @@ import { OrganizationType } from 'src/components/types/Organization';
 import { PaymentSubject } from 'src/components/enums/Payment';
 
 // types
-import { FormOption } from '../../components/types/Form';
+import type { FormOption } from '../../components/types/Form';
+import type { Logger } from '../types/Logger';
 
 export default defineComponent({
   name: 'FormFieldOptionGroup',
   props: {
-    modelValue: {
-      type: String as () => OrganizationType,
-      required: true,
-    },
     name: {
       type: String,
       required: true,
@@ -56,16 +53,28 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['update:modelValue'],
-  setup(props, { emit }) {
-    const inputValue = computed({
-      get(): OrganizationType {
-        return props.modelValue;
-      },
-      set(value: OrganizationType) {
-        emit('update:modelValue', value);
+  setup() {
+    const logger = inject('vuejs3-logger') as Logger | null;
+
+    const organizationType = computed({
+      get: (): OrganizationType => registerChallengeStore.getOrganizationType,
+      set: (value: OrganizationType) => {
+        // set value
+        registerChallengeStore.setOrganizationType(value);
       },
     });
+
+    const onOrganizationTypeChange = () => {
+      // reset organizationId on organizationType change
+      logger?.debug('reset organizationId on organizationType change');
+      registerChallengeStore.setOrganizationId(null);
+      // reset subsidiaryId on organizationType change
+      logger?.debug('reset subsidiaryId on organizationType change');
+      registerChallengeStore.setSubsidiaryId(null);
+      // reset teamId on organizationType change
+      logger?.debug('reset teamId on organizationType change');
+      registerChallengeStore.setTeamId(null);
+    };
 
     const { isFilled } = useValidation();
 
@@ -113,11 +122,12 @@ export default defineComponent({
     return {
       borderRadius,
       grey3,
-      inputValue,
+      organizationType,
       options,
       primary,
       primaryOpacity,
       isFilled,
+      onOrganizationTypeChange,
     };
   },
 });
@@ -128,26 +138,27 @@ export default defineComponent({
     dense
     borderless
     hide-bottom-space
-    :model-value="inputValue"
+    :model-value="organizationType"
     :rules="[(val) => !!val || $t('form.messageOptionRequired')]"
   >
     <q-option-group
-      v-model="inputValue"
+      v-model="organizationType"
       type="radio"
       :options="options"
       class="q-gutter-md"
       data-cy="form-field-option-group"
+      @update:model-value="onOrganizationTypeChange"
     >
       <!-- Custom option content -->
       <template v-slot:label="opt">
         <div
           class="full-width row items-center bg-white q-py-md q-px-md"
-          :class="[opt.value === inputValue ? '' : 'bg-white']"
+          :class="[opt.value === organizationType ? '' : 'bg-white']"
           :style="{
             'border-radius': borderRadius,
             'border-width': '1px',
             'border-style': 'solid',
-            'border-color': opt.value === inputValue ? primary : grey3,
+            'border-color': opt.value === organizationType ? primary : grey3,
           }"
           data-cy="form-field-option"
         >
@@ -179,7 +190,7 @@ export default defineComponent({
           <div class="col-auto q-ml-md">
             <q-avatar round size="24px" data-cy="form-field-option-check">
               <q-icon
-                v-show="opt.value === inputValue"
+                v-show="opt.value === organizationType"
                 name="done"
                 color="primary"
                 size="24px"
@@ -191,7 +202,6 @@ export default defineComponent({
     </q-option-group>
   </q-field>
 </template>
-
 <style scoped lang="scss">
 // hide radio button
 :deep(.q-radio__inner) {

--- a/src/components/form/FormFieldOptionGroup.vue
+++ b/src/components/form/FormFieldOptionGroup.vue
@@ -66,14 +66,23 @@ export default defineComponent({
 
     const onOrganizationTypeChange = () => {
       // reset organizationId on organizationType change
-      logger?.debug('reset organizationId on organizationType change');
       registerChallengeStore.setOrganizationId(null);
+      logger?.debug(
+        'Organization type change, reset' +
+          ` organization ID <${registerChallengeStore.getOrganizationId}>.`,
+      );
       // reset subsidiaryId on organizationType change
-      logger?.debug('reset subsidiaryId on organizationType change');
       registerChallengeStore.setSubsidiaryId(null);
+      logger?.debug(
+        'Organization type change, reset' +
+          ` subsidiary ID <${registerChallengeStore.getSubsidiaryId}>.`,
+      );
       // reset teamId on organizationType change
-      logger?.debug('reset teamId on organizationType change');
       registerChallengeStore.setTeamId(null);
+      logger?.debug(
+        'Organization type change, reset' +
+          ` team ID <${registerChallengeStore.getTeamId}>.`,
+      );
     };
 
     const { isFilled } = useValidation();

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -96,17 +96,25 @@ export default defineComponent({
 
     const onOrganizationIdChange = (): void => {
       // reset subsidiaryId on organizationId change
-      logger?.debug('reset subsidiaryId on organizationId change');
       registerChallengeStore.setSubsidiaryId(null);
+      logger?.debug(
+        'Organization ID change, reset' +
+          ` subsidiary ID <${registerChallengeStore.getSubsidiaryId}>.`,
+      );
       // reset teamId on organizationId change
-      logger?.debug('reset teamId on organizationId change');
       registerChallengeStore.setTeamId(null);
+      logger?.debug(
+        'Organization ID change, reset' +
+          ` team ID <${registerChallengeStore.getTeamId}>.`,
+      );
     };
 
     const onSubsidiaryIdChange = (): void => {
-      // reset teamId on subsidiaryId change
-      logger?.debug('reset teamId on subsidiaryId change');
       registerChallengeStore.setTeamId(null);
+      logger?.debug(
+        'Subsidiary ID change, reset' +
+          ` team ID <${registerChallengeStore.getTeamId}>.`,
+      );
     };
 
     const onCloseAddSubsidiaryDialog = () => {

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -94,6 +94,15 @@ export default defineComponent({
       { immediate: true },
     );
 
+    const onOrganizationIdChange = () => {
+      // reset subsidiaryId on organizationId change
+      logger?.debug('reset subsidiaryId on organizationId change');
+      registerChallengeStore.setSubsidiaryId(null);
+      // reset teamId on organizationId change
+      logger?.debug('reset teamId on organizationId change');
+      registerChallengeStore.setTeamId(null);
+    };
+
     const onCloseAddSubsidiaryDialog = () => {
       if (formFieldSelectTableRef.value) {
         // Run organization validation proccess before open add subsidiary dialog
@@ -128,6 +137,7 @@ export default defineComponent({
       organizationType,
       onCloseAddSubsidiaryDialog,
       onCreateOption,
+      onOrganizationIdChange,
     };
   },
 });
@@ -144,6 +154,7 @@ export default defineComponent({
       :organization-type="organizationType"
       :data-organization-type="organizationType"
       @create:option="onCreateOption"
+      @update:model-value="onOrganizationIdChange"
       data-cy="form-select-table-company"
     />
     <form-field-company-address

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -94,12 +94,18 @@ export default defineComponent({
       { immediate: true },
     );
 
-    const onOrganizationIdChange = () => {
+    const onOrganizationIdChange = (): void => {
       // reset subsidiaryId on organizationId change
       logger?.debug('reset subsidiaryId on organizationId change');
       registerChallengeStore.setSubsidiaryId(null);
       // reset teamId on organizationId change
       logger?.debug('reset teamId on organizationId change');
+      registerChallengeStore.setTeamId(null);
+    };
+
+    const onSubsidiaryIdChange = (): void => {
+      // reset teamId on subsidiaryId change
+      logger?.debug('reset teamId on subsidiaryId change');
       registerChallengeStore.setTeamId(null);
     };
 
@@ -138,6 +144,7 @@ export default defineComponent({
       onCloseAddSubsidiaryDialog,
       onCreateOption,
       onOrganizationIdChange,
+      onSubsidiaryIdChange,
     };
   },
 });
@@ -160,6 +167,7 @@ export default defineComponent({
     <form-field-company-address
       v-model="subsidiaryId"
       data-cy="form-company-address"
+      @update:model-value="onSubsidiaryIdChange"
       @close:addSubsidiaryDialog="onCloseAddSubsidiaryDialog"
     />
   </div>

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -16,7 +16,7 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, watch } from 'vue';
+import { computed, defineComponent, inject, ref, watch } from 'vue';
 
 // components
 import FormFieldSelectTable from './FormFieldSelectTable.vue';
@@ -73,9 +73,7 @@ export default defineComponent({
           `Register challenge store subsidiary ID changed to <${newValue}>.`,
         );
         if (newValue) {
-          // reset team ID in store
-          logger?.debug(`Resetting team ID from <${team.value}> to <null>.`);
-          team.value = null;
+          // load teams
           logger?.info('Loading teams.');
           await registerChallengeStore.loadTeamsToStore(logger);
         }

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -43,7 +43,6 @@ export default defineComponent({
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
-
     const registerChallengeStore = useRegisterChallengeStore();
     const { mapTeamToOption } = useApiGetTeams(logger);
 
@@ -70,7 +69,6 @@ export default defineComponent({
           `Register challenge store subsidiary ID changed to <${newValue}>.`,
         );
         if (newValue) {
-          // load teams
           logger?.info('Loading teams.');
           await registerChallengeStore.loadTeamsToStore(logger);
         }

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -16,7 +16,7 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, ref, watch } from 'vue';
+import { computed, defineComponent, inject, watch } from 'vue';
 
 // components
 import FormFieldSelectTable from './FormFieldSelectTable.vue';
@@ -43,9 +43,6 @@ export default defineComponent({
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
-    const formFieldSelectTableRef = ref<typeof FormFieldSelectTable | null>(
-      null,
-    );
 
     const registerChallengeStore = useRegisterChallengeStore();
     const { mapTeamToOption } = useApiGetTeams(logger);
@@ -100,7 +97,6 @@ export default defineComponent({
     };
 
     return {
-      formFieldSelectTableRef,
       isLoading,
       options,
       team,
@@ -119,7 +115,6 @@ export default defineComponent({
     </div>
     <!-- Select table -->
     <form-field-select-table
-      ref="formFieldSelectTableRef"
       v-model="team"
       :organization-level="OrganizationLevel.team"
       :options="options"

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -31,10 +31,10 @@ import { OrganizationLevel } from 'src/components/types/Organization';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
-import type { FormSelectTableOption } from '../types/Form';
 import type { Logger } from '../types/Logger';
 import type { OrganizationTeam } from '../types/Organization';
 import type { TeamPostApiResponse } from '../types/ApiTeam';
+import type { FormSelectTableOption } from '../types/Form';
 
 export default defineComponent({
   name: 'FormSelectTeam',

--- a/src/components/form/FormSelectTeam.vue
+++ b/src/components/form/FormSelectTeam.vue
@@ -31,10 +31,10 @@ import { OrganizationLevel } from 'src/components/types/Organization';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
+import type { FormSelectTableOption } from '../types/Form';
 import type { Logger } from '../types/Logger';
 import type { OrganizationTeam } from '../types/Organization';
 import type { TeamPostApiResponse } from '../types/ApiTeam';
-import type { FormSelectTableOption } from '../types/Form';
 
 export default defineComponent({
   name: 'FormSelectTeam',
@@ -43,6 +43,10 @@ export default defineComponent({
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
+    const formFieldSelectTableRef = ref<typeof FormFieldSelectTable | null>(
+      null,
+    );
+
     const registerChallengeStore = useRegisterChallengeStore();
     const { mapTeamToOption } = useApiGetTeams(logger);
 
@@ -69,6 +73,9 @@ export default defineComponent({
           `Register challenge store subsidiary ID changed to <${newValue}>.`,
         );
         if (newValue) {
+          // reset team ID in store
+          logger?.debug(`Resetting team ID from <${team.value}> to <null>.`);
+          team.value = null;
           logger?.info('Loading teams.');
           await registerChallengeStore.loadTeamsToStore(logger);
         }
@@ -95,6 +102,7 @@ export default defineComponent({
     };
 
     return {
+      formFieldSelectTableRef,
       isLoading,
       options,
       team,
@@ -113,6 +121,7 @@ export default defineComponent({
     </div>
     <!-- Select table -->
     <form-field-select-table
+      ref="formFieldSelectTableRef"
       v-model="team"
       :organization-level="OrganizationLevel.team"
       :options="options"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -38,6 +38,7 @@ import FormSelectTeam from 'src/components/form/FormSelectTeam.vue';
 import LoginRegisterHeader from 'components/global/LoginRegisterHeader.vue';
 import RegisterChallengePayment from 'src/components/register/RegisterChallengePayment.vue';
 import RegisterChallengeSummary from 'src/components/register/RegisterChallengeSummary.vue';
+import ShowOrganizationIds from 'src/components/debug/ShowOrganizationIds.vue';
 import TopBarCountdown from 'src/components/global/TopBarCountdown.vue';
 
 // composables
@@ -61,6 +62,7 @@ export default defineComponent({
     LoginRegisterHeader,
     RegisterChallengePayment,
     RegisterChallengeSummary,
+    ShowOrganizationIds,
     TopBarCountdown,
   },
   setup() {
@@ -218,6 +220,7 @@ export default defineComponent({
         class="q-mx-auto q-mt-xl"
         :style="{ 'max-width': containerFormWidth }"
       >
+        <show-organization-ids />
         <!-- Page title -->
         <h1
           class="text-h5 text-bold text-white q-my-none"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -142,7 +142,7 @@ export default defineComponent({
     const { getOrganizationLabels } = useOrganizations();
     const organizationStepTitle = computed(() => {
       return getOrganizationLabels(
-        organizationType.value || OrganizationType.company,
+        registerChallengeStore.getOrganizationType || OrganizationType.company,
       ).labelShort;
     });
 
@@ -319,7 +319,6 @@ export default defineComponent({
                 {{ $t('form.participation.titleParticipation') }}
               </p>
               <form-field-option-group
-                v-model="organizationType"
                 name="participation"
                 label="form.labelParticipation"
               />

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -118,10 +118,17 @@ describe('Register Challenge page', () => {
                 win.i18n,
                 formOrganizationOptions[0].id,
               );
+              // intercept teams for first subsidiary
               cy.interceptTeamsGetApi(
                 config,
                 win.i18n,
                 formOrganizationOptions[0].subsidiaries[0].id,
+              );
+              // intercept teams for second subsidiary
+              cy.interceptTeamsGetApi(
+                config,
+                win.i18n,
+                formOrganizationOptions[0].subsidiaries[1].id,
               );
               cy.interceptTeamPostApi(
                 config,
@@ -1013,6 +1020,111 @@ describe('Register Challenge page', () => {
         cy.dataCy('step-2-continue').should('be.visible').click();
         cy.dataCy('step-3-continue').should('be.visible');
       });
+    });
+
+    it('reset organization, subsidiary and team on parent data change', () => {
+      passToStep5();
+      // select a team
+      cy.dataCy('form-select-table-team')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .first()
+        .click();
+      // organization, subsidiary and team are set (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-organization-id-value').should('not.be.empty');
+          cy.dataCy('debug-subsidiary-id-value').should('not.be.empty');
+          cy.dataCy('debug-team-id-value').should('not.be.empty');
+        });
+      // go back
+      cy.dataCy('step-5-back').should('be.visible').click();
+      // select a different address
+      cy.dataCy('form-company-address-input').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').eq(1).click();
+        });
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      // team is reset (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-team-id-value').should('be.empty');
+        });
+      // select a team
+      cy.dataCy('form-select-table-team')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .first()
+        .click();
+      // team is set (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-team-id-value').should('not.be.empty');
+        });
+      // go back
+      cy.dataCy('step-5-back').should('be.visible').click();
+      // select a different organization
+      cy.dataCy('form-select-table-company')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .eq(1)
+        .click();
+      // subsidiary and team are reset (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-subsidiary-id-value').should('be.empty');
+          cy.dataCy('debug-team-id-value').should('be.empty');
+        });
+      // select the first organization
+      cy.dataCy('form-select-table-company')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .first()
+        .click();
+      // set subsidiary
+      cy.dataCy('form-company-address-input').click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
+      // go to step 5
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      // select a team
+      cy.dataCy('form-select-table-team')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .first()
+        .click();
+      // organization, subsidiary and team are set (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-organization-id-value').should('not.be.empty');
+          cy.dataCy('debug-subsidiary-id-value').should('not.be.empty');
+          cy.dataCy('debug-team-id-value').should('not.be.empty');
+        });
+      // go back
+      cy.dataCy('step-5-back').should('be.visible').click();
+      cy.dataCy('step-4-back').should('be.visible').click();
+      // select a different organization type
+      cy.dataCy('form-field-option').eq(1).click();
+      // organization, subsidiary and team are reset (check debug component)
+      cy.dataCy('debug-register-challenge-ids')
+        .should('be.visible')
+        .within(() => {
+          cy.dataCy('debug-organization-id-value').should('be.empty');
+          cy.dataCy('debug-subsidiary-id-value').should('be.empty');
+          cy.dataCy('debug-team-id-value').should('be.empty');
+        });
     });
   });
 });

--- a/test/cypress/fixtures/formOrganizationOptions.json
+++ b/test/cypress/fixtures/formOrganizationOptions.json
@@ -67,6 +67,17 @@
             ]
           }
         ]
+      },
+      {
+        "id": 805,
+        "address": {
+          "street": "Krkonošská",
+          "street_number": "177",
+          "recipient": "Vrchlabí",
+          "psc": "54301",
+          "city": "Vrchlabí"
+        },
+        "teams": []
       }
     ],
     "description": "Leading software solutions provider"


### PR DESCRIPTION
Add logic for correctly resetting organization, subsidiary, and team IDs:

* When `organizationType` changes reset `organizationId`, `subsidiaryId`, `teamId` (`FormFieldOptionGroup`).
* When `organizationId` changes reset `subsidiaryId`, `teamId` (`FormSelectOrganization`).
* When `subsidiaryId` changes reset `teamId` (`FormSelectOrganization`).

Additional changes:

* Rename variable `inputValue` to `organizationType`.
* Remove unnecessary v-model attribute on `<form-field-option-group>` component (`RegisterChallengePage`).
* Add debug component to show currently selected IDs in E2E tests.