### PR TITLE
src/components: fix FormFieldListMerch validation by correctly clearing value after no-merch uncheck

### DIFF
--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -286,7 +286,7 @@ export default defineComponent({
      * Scroll to merch tabs if you uncheck
      * "I don't want merch" checkbox widget
      */
-    let iDontWantMerchandiseCachedId;
+    let iDontWantMerchandiseCachedId: number | null = null;
     const onCheckboxUpdate = function (val: boolean): void {
       if (val) {
         if (!iDontWantMerchandiseCachedId) {
@@ -310,6 +310,9 @@ export default defineComponent({
         }
       } else {
         nextTick(() => {
+          // if no merch is selected, reset selected size
+          selectedSize.value = null;
+          // scroll to merch tabs
           tabsMerchRef.value?.$el.scrollIntoView({
             behavior: 'smooth',
             block: 'start',
@@ -357,6 +360,7 @@ export default defineComponent({
         :val="true"
         color="primary"
         @update:model-value="onCheckboxUpdate"
+        data-cy="form-merch-no-merch-checkbox"
       />
     </q-item-section>
     <q-item-section>

--- a/test/cypress/fixtures/apiGetMerchandiseResponseNone.json
+++ b/test/cypress/fixtures/apiGetMerchandiseResponseNone.json
@@ -1,0 +1,17 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 118,
+      "name": "Žádné-žádné triko nechci",
+      "sex": "",
+      "size": "",
+      "author": "",
+      "material": "",
+      "description": "",
+      "t_shirt_preview": "https://dpnk-test.s3.amazonaws.com/t_shirt_preview/2022_%C5%BE%C3%A1dn%C3%A9_triko_edited.jpg?AWSAccessKeyId=AKIAJ3R77G7P3TJECZ7Q&Signature=sOWjhKqzcJT0X23DIVzjBnMomqw%3D&Expires=2051185003"
+    }
+  ]
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1723,3 +1723,53 @@ Cypress.Commands.add('waitForRegisterChallengeGetApi', (response) => {
     }
   });
 });
+
+/**
+ * Intercept "I don't want merchandise" GET API call
+ * Provides `@getMerchandiseNone` alias
+ * @param {Config} config - App global config
+ * @param {I18n|string} i18n - i18n instance or locale lang string e.g. en
+ */
+Cypress.Commands.add('interceptMerchandiseNoneGetApi', (config, i18n) => {
+  const {
+    apiBase,
+    apiDefaultLang,
+    urlApiMerchandise,
+    iDontWantMerchandiseItemCode,
+  } = config;
+  const apiBaseUrl = getApiBaseUrlWithLang(null, apiBase, apiDefaultLang, i18n);
+  const urlApiMerchandiseNoneLocalized = `${apiBaseUrl}${urlApiMerchandise}${iDontWantMerchandiseItemCode}/`;
+
+  cy.fixture('apiGetMerchandiseResponseNone').then(
+    (merchandiseNoneResponse) => {
+      cy.intercept('GET', urlApiMerchandiseNoneLocalized, {
+        statusCode: httpSuccessfullStatus,
+        body: merchandiseNoneResponse,
+      }).as('getMerchandiseNone');
+    },
+  );
+});
+
+/**
+ * Wait for intercept "I don't want merchandise" API call and compare response object
+ * Wait for `@getMerchandiseNone` intercept
+ */
+Cypress.Commands.add('waitForMerchandiseNoneApi', () => {
+  cy.fixture('apiGetMerchandiseResponseNone').then(
+    (merchandiseNoneResponse) => {
+      cy.wait('@getMerchandiseNone').then((getMerchandiseNone) => {
+        expect(getMerchandiseNone.request.headers.authorization).to.include(
+          bearerTokeAuth,
+        );
+        if (getMerchandiseNone.response) {
+          expect(getMerchandiseNone.response.statusCode).to.equal(
+            httpSuccessfullStatus,
+          );
+          expect(getMerchandiseNone.response.body).to.deep.equal(
+            merchandiseNoneResponse,
+          );
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
Issue: `FormFieldListMerch` should not allow passing to next step if `merchId` is empty (disabled button). But when checkbox "no merch" is checked and unchecked again, the `merchId` stays - makes next-step button enabled.

Solution: Fix resetting value after checkbox is unchecked.
Add test for correct working of the disabled button.
