### PR TITLE
src/components: add logic to show selected no-merch option in FormFieldListMerch if loaded from API

### DIFF
--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -78,6 +78,7 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     // show merch checkbox
     const isNotMerch = ref<boolean>(false);
+    let iDontWantMerchandiseCachedId: number | null = null;
 
     // template ref
     const formMerchRef = ref<typeof QForm | null>(null);
@@ -117,9 +118,11 @@ export default defineComponent({
         await loadFilteredMerchandise(
           rideToWorkByBikeConfig.iDontWantMerchandiseItemCode,
         );
-        const iDontWantMerchandiseId = merchandise.value[0]['id'];
+        iDontWantMerchandiseCachedId = merchandise.value[0]['id'];
         // if merch ID is "none" check the checkbox
-        if (registerChallengeStore.getMerchId === iDontWantMerchandiseId) {
+        if (
+          registerChallengeStore.getMerchId === iDontWantMerchandiseCachedId
+        ) {
           isNotMerch.value = true;
         } else {
           // explicitly set to false
@@ -305,7 +308,6 @@ export default defineComponent({
      * Scroll to merch tabs if you uncheck
      * "I don't want merch" checkbox widget
      */
-    let iDontWantMerchandiseCachedId: number | null = null;
     const onCheckboxUpdate = function (val: boolean): void {
       if (val) {
         if (!iDontWantMerchandiseCachedId) {

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -77,7 +77,6 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     // show merch checkbox
     const isNotMerch = ref<boolean>(false);
-    let iDontWantMerchandiseCachedId: number | null = null;
 
     // template ref
     const formMerchRef = ref<typeof QForm | null>(null);
@@ -292,6 +291,7 @@ export default defineComponent({
      * Scroll to merch tabs if you uncheck
      * "I don't want merch" checkbox widget
      */
+    let iDontWantMerchandiseCachedId: number | null = null;
     const onCheckboxUpdate = function (val: boolean): void {
       if (val) {
         if (!iDontWantMerchandiseCachedId) {

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -49,7 +49,6 @@ import SliderMerch from './SliderMerch.vue';
 
 // composables
 import { i18n } from '../../boot/i18n';
-import { useApiGetFilteredMerchandise } from '../../composables/useApiGetFilteredMerchandise';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -101,8 +100,6 @@ export default defineComponent({
     // get merchandise data
     const registerChallengeStore = useRegisterChallengeStore();
 
-    const { merchandise, loadFilteredMerchandise } =
-      useApiGetFilteredMerchandise(logger);
     // load merchandise on mount
     onMounted(async () => {
       await registerChallengeStore.loadMerchandiseToStore(logger);
@@ -111,36 +108,23 @@ export default defineComponent({
         logger?.debug(
           `Merch ID <${registerChallengeStore.getMerchId}> is set.`,
         );
-        // load merch ID "none" to be able to compare
-        logger?.debug(
-          `Loading filtered merchandise data by code <${rideToWorkByBikeConfig.iDontWantMerchandiseItemCode}> for comparison.`,
+        // explicitly set to false
+        // find card that contains the merch ID
+        const item = merchandiseItems.value.find(
+          (item: MerchandiseItem) =>
+            item.id === registerChallengeStore.getMerchId,
         );
-        await loadFilteredMerchandise(
-          rideToWorkByBikeConfig.iDontWantMerchandiseItemCode,
-        );
-        iDontWantMerchandiseCachedId = merchandise.value[0]['id'];
-        // if merch ID is "none" check the checkbox
-        if (
-          registerChallengeStore.getMerchId === iDontWantMerchandiseCachedId
-        ) {
-          isNotMerch.value = true;
-        } else {
-          // explicitly set to false
+        // select gender and size
+        if (item) {
           isNotMerch.value = false;
-          // find card that contains the merch ID
-          const item = merchandiseItems.value.find(
-            (item) => item.id === registerChallengeStore.getMerchId,
+          logger?.debug(`Found item <${JSON.stringify(item, null, 2)}>.`);
+          selectedGender.value = item.gender;
+          selectedSize.value = item.id;
+        } else {
+          isNotMerch.value = true;
+          logger?.debug(
+            `No item found for merch ID <${registerChallengeStore.getMerchId}>, setting isNotMerch to <${isNotMerch.value}>.`,
           );
-          // select gender and size
-          if (item) {
-            logger?.debug(`Found item <${JSON.stringify(item, null, 2)}>.`);
-            selectedGender.value = item.gender;
-            selectedSize.value = item.id;
-          } else {
-            logger?.debug(
-              `No item found for merch ID <${registerChallengeStore.getMerchId}>.`,
-            );
-          }
         }
       }
     });

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -107,7 +107,6 @@ export default defineComponent({
         logger?.debug(
           `Merch ID <${registerChallengeStore.getMerchId}> is set.`,
         );
-        // explicitly set to false
         // find card that contains the merch ID
         const item = merchandiseItems.value.find(
           (item: MerchandiseItem) =>

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -121,7 +121,8 @@ export default defineComponent({
         } else {
           isNotMerch.value = true;
           logger?.debug(
-            `No item found for merch ID <${registerChallengeStore.getMerchId}>, setting isNotMerch to <${isNotMerch.value}>.`,
+            `No item found for merch ID <${registerChallengeStore.getMerchId}>,` +
+              ` setting isNotMerch to <${isNotMerch.value}>.`,
           );
         }
       }

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1570,7 +1570,11 @@ describe('Register Challenge page', () => {
                   .should('be.visible')
                   .and('not.be.disabled')
                   .click();
-                cy.testRegisterChallengeLoadedStepsThreeToSeven(
+                cy.testRegisterChallengeLoadedStepsThreeToFive(
+                  win.i18n,
+                  registerChallengeResponse,
+                );
+                cy.testRegisterChallengeLoadedStepSix(
                   win.i18n,
                   registerChallengeResponse,
                 );
@@ -1625,7 +1629,11 @@ describe('Register Challenge page', () => {
               .should('be.visible')
               .and('not.be.disabled')
               .click();
-            cy.testRegisterChallengeLoadedStepsThreeToSeven(
+            cy.testRegisterChallengeLoadedStepsThreeToFive(
+              win.i18n,
+              registerChallengeResponse,
+            );
+            cy.testRegisterChallengeLoadedStepSix(
               win.i18n,
               registerChallengeResponse,
             );
@@ -1645,6 +1653,84 @@ describe('Register Challenge page', () => {
       });
     });
   });
+
+  context(
+    'registration in progress (payment company - waiting + I dont want merch)',
+    () => {
+      beforeEach(() => {
+        cy.task('getAppConfig', process).then((config) => {
+          cy.interceptThisCampaignGetApi(config, defLocale);
+          // visit challenge inactive page to load campaign data
+          cy.visit('#' + routesConf['challenge_inactive']['path']);
+          cy.waitForThisCampaignApi();
+          cy.fixture('apiGetRegisterChallengeNoMerch.json').then((response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          });
+          // intercept common response (not currently used)
+          cy.interceptRegisterChallengePostApi(config, defLocale);
+          cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+        });
+        // config is defined without hash in the URL
+        cy.visit('#' + routesConf['register_challenge']['path']);
+        cy.viewport('macbook-16');
+      });
+
+      it('fetches the registration status on load', () => {
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          cy.fixture('apiGetRegisterChallengeNoMerch.json').then(
+            (registerChallengeResponse) => {
+              cy.testRegisterChallengeLoadedStepOne(
+                win.i18n,
+                registerChallengeResponse,
+              );
+              // go to next step
+              cy.dataCy('step-1-continue').should('be.visible').click();
+              // check that the company options is selected
+              cy.dataCy(getRadioOption(PaymentSubject.company))
+                .parents('.q-radio__label')
+                .siblings('.q-radio__inner')
+                .should('have.class', 'q-radio__inner--truthy');
+              // go to next step
+              cy.dataCy('step-2-continue')
+                .should('be.visible')
+                .and('not.be.disabled')
+                .click();
+              cy.testRegisterChallengeLoadedStepsThreeToFive(
+                win.i18n,
+                registerChallengeResponse,
+              );
+              // validate that step 6 contains "I don't want merch" selected
+              cy.dataCy('form-merch-no-merch-checkbox')
+                .should('be.visible')
+                .find('.q-checkbox__inner')
+                .should('have.class', 'q-checkbox__inner--truthy');
+              // merch cards should not be visible
+              cy.dataCy('list-merch').should('not.be.visible');
+              // go to next step
+              cy.dataCy('step-6-continue').should('be.visible').click();
+              // on step 7
+              cy.dataCy('step-7')
+                .find('.q-stepper__step-content')
+                .should('be.visible');
+              // message "waiting for confirmation" is displayed
+              cy.dataCy('step-7-registration-waiting-message')
+                .should('be.visible')
+                .and(
+                  'contain',
+                  win.i18n.global.t(
+                    'register.challenge.textRegistrationWaitingForConfirmation',
+                  ),
+                );
+              cy.dataCy('step-7-continue')
+                .should('be.visible')
+                .and('be.disabled');
+            },
+          );
+        });
+      });
+    },
+  );
 
   context('registration in progress (payment company - no_admission)', () => {
     beforeEach(() => {
@@ -1726,7 +1812,11 @@ describe('Register Challenge page', () => {
               .should('be.visible')
               .and('not.be.disabled')
               .click();
-            cy.testRegisterChallengeLoadedStepsThreeToSeven(
+            cy.testRegisterChallengeLoadedStepsThreeToFive(
+              win.i18n,
+              registerChallengeResponse,
+            );
+            cy.testRegisterChallengeLoadedStepSix(
               win.i18n,
               registerChallengeResponse,
             );

--- a/test/cypress/fixtures/apiGetRegisterChallengeNoMerch.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeNoMerch.json
@@ -1,0 +1,31 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "waiting",
+        "payment_amount": 390
+      },
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 118
+    }
+  ]
+}


### PR DESCRIPTION
Add logic to show "I don't want merchandise" option in `FormFieldListMerch` as selected if loaded from API.

- In component, load merch-none ID for comparison (saving to an existing variable `iDontWantMerchandiseCachedId`).
- In tests, rework check for individual steps (after loading data from register-challenge GET endpoint) to allow for modification in testing the Merch step.
- Add test for fixture with selected merch-none ID `118`.