### PR TITLE
src/router: add rule to disable register-challenge route once registration is complete

### DIFF
--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -140,6 +140,8 @@ export default defineComponent({
     );
     const paymentState = computed(() => registerChallengeStore.getPaymentState);
 
+    const router = useRouter();
+
     onMounted(async () => {
       // make sure price level is loaded
       if (!challengeStore.getPriceLevel.length) {
@@ -182,6 +184,12 @@ export default defineComponent({
         // if payment is done, it should always be safe to continue
         onContinue();
       }
+      // handle redirect for completed registration
+      if (registerChallengeStore.getIsRegistrationComplete) {
+        if (router) {
+          router.push(routesConf['home']['path']);
+        }
+      }
     });
 
     const organizationType = computed({
@@ -221,9 +229,10 @@ export default defineComponent({
       stepMerchRef,
     });
 
-    const router = useRouter();
     const onCompleteRegistration = () => {
-      router.push(routesConf['home']['path']);
+      if (router) {
+        router.push(routesConf['home']['path']);
+      }
     };
 
     // Payment-related logic

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -99,17 +99,13 @@ export default route(function (/* { store, ssrContext } */) {
         );
         next({ path: routesConf['verify_email']['path'] });
       } else if (
-      /**
-       * If authenticated and on login page or register page or confirm email
-       * page, redirect to home page.
-       */
         isAuthenticated &&
         isEmailVerified &&
         isChallengeActive &&
         isRegistrationComplete &&
         /**
-         * These pages are not accessible when authenticated and verified and
-         * registration is complete.
+         * These pages are not accessible when authenticated and verified,
+         * challenge is active and registration is complete.
          */
         to.matched.some(
           (record) =>
@@ -200,10 +196,10 @@ export default route(function (/* { store, ssrContext } */) {
         );
         next({ path: routesConf['register_challenge']['path'] });
       } else if (
-      /**
-       * If not authenticated and not on pages: login, register, confirm_email
-       * redirect to login page.
-       */
+        /**
+         * If not authenticated and not on pages: login, register, confirm_email
+         * redirect to login page.
+         */
         !isAuthenticated &&
         !to.matched.some(
           (record) =>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -70,7 +70,6 @@ export default route(function (/* { store, ssrContext } */) {
         `Router is registration complete <${isRegistrationComplete}>.`,
       );
 
-      // if authenticated and not verified email, redirect to confirm email page
       if (
         isAuthenticated &&
         !isEmailVerified &&
@@ -97,6 +96,7 @@ export default route(function (/* { store, ssrContext } */) {
         logger?.debug(
           `Router path redirect to page URL <${routesConf['verify_email']['path']}>.`,
         );
+        // redirect to verify email page
         next({ path: routesConf['verify_email']['path'] });
       } else if (
         isAuthenticated &&
@@ -136,6 +136,7 @@ export default route(function (/* { store, ssrContext } */) {
         logger?.debug(
           `Router path redirect to page URL <${routesConf['home']['path']}>.`,
         );
+        // redirect to home page
         next({ path: routesConf['home']['path'] });
       } else if (
         isAuthenticated &&
@@ -162,10 +163,9 @@ export default route(function (/* { store, ssrContext } */) {
         logger?.debug(
           `Router path redirect to page URL <${routesConf['challenge_inactive']['path']}>.`,
         );
+        // redirect to challenge inactive page
         next({ path: routesConf['challenge_inactive']['path'] });
-      }
-      // if authenticated and verified but registration is not complete
-      else if (
+      } else if (
         isAuthenticated &&
         isEmailVerified &&
         isChallengeActive &&
@@ -194,6 +194,7 @@ export default route(function (/* { store, ssrContext } */) {
         logger?.debug(
           `Router path redirect to page URL <${routesConf['register_challenge']['path']}>.`,
         );
+        // redirect to register challenge page
         next({ path: routesConf['register_challenge']['path'] });
       } else if (
         /**
@@ -225,6 +226,7 @@ export default route(function (/* { store, ssrContext } */) {
         logger?.debug(
           `Router path redirect to page URL <${routesConf['login']['path']}>.`,
         );
+        // redirect to login page
         next({ path: routesConf['login']['path'] });
       }
       // pass

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -98,14 +98,19 @@ export default route(function (/* { store, ssrContext } */) {
           `Router path redirect to page URL <${routesConf['verify_email']['path']}>.`,
         );
         next({ path: routesConf['verify_email']['path'] });
-      }
-      // if authenticated and on login page or register page or confirm email page, redirect to home page
-      else if (
+      } else if (
+      /**
+       * If authenticated and on login page or register page or confirm email
+       * page, redirect to home page.
+       */
         isAuthenticated &&
         isEmailVerified &&
         isChallengeActive &&
         isRegistrationComplete &&
-        // these pages are not accessible when authenticated and verified
+        /**
+         * These pages are not accessible when authenticated and verified and
+         * registration is complete.
+         */
         to.matched.some(
           (record) =>
             record.path === routesConf['login']['path'] ||
@@ -142,8 +147,8 @@ export default route(function (/* { store, ssrContext } */) {
         !isChallengeActive &&
         !to.matched.some(
           /**
-           * only these pages are accessible when authenticated, verified email
-           * and challenge is not active
+           * Only these pages are accessible when authenticated, verified email
+           * and challenge is not active.
            */
           (record) => record.path === routesConf['challenge_inactive']['path'],
         )
@@ -170,8 +175,8 @@ export default route(function (/* { store, ssrContext } */) {
         isChallengeActive &&
         !isRegistrationComplete &&
         /**
-         * only these pages are accessible when authenticated, verified email
-         * challenge is active and registration is not complete
+         * Only these pages are accessible when authenticated, verified email
+         * challenge is active and registration is not complete.
          */
         !to.matched.some(
           (record) => record.path === routesConf['register_challenge']['path'],
@@ -194,9 +199,11 @@ export default route(function (/* { store, ssrContext } */) {
           `Router path redirect to page URL <${routesConf['register_challenge']['path']}>.`,
         );
         next({ path: routesConf['register_challenge']['path'] });
-      }
-      // if not authenticated and not on pages: login, register, confirm_email redirect to login page.
-      else if (
+      } else if (
+      /**
+       * If not authenticated and not on pages: login, register, confirm_email
+       * redirect to login page.
+       */
         !isAuthenticated &&
         !to.matched.some(
           (record) =>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -180,7 +180,7 @@ export default route(function (/* { store, ssrContext } */) {
       ) {
         logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
         logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
-        logger?.debug(`Router challenge is active <${isChallengeActive}>`);
+        logger?.debug(`Router challenge is active <${isChallengeActive}>.`);
         logger?.debug(
           `Router registration is not complete <${!isRegistrationComplete}>.`,
         );

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -186,6 +186,44 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getIpAddress: (state): string => state.ipAddressData?.ip || '',
     getIsPayuTransactionInitiated: (state): boolean =>
       state.isPayuTransactionInitiated,
+    getIsPersonalDetailsComplete(): boolean {
+      return (
+        this.personalDetails.firstName !== '' &&
+        this.personalDetails.lastName !== '' &&
+        this.personalDetails.nickname !== '' &&
+        this.personalDetails.gender !== Gender.none &&
+        this.personalDetails.terms === true
+      );
+    },
+    getIsPaymentComplete(): boolean {
+      return this.paymentState === PaymentState.done;
+    },
+    getIsOrganizationTypeComplete(): boolean {
+      return this.organizationType !== OrganizationType.none;
+    },
+    getIsOrganizationIdComplete(): boolean {
+      return this.organizationId !== null;
+    },
+    getIsSubsidiaryIdComplete(): boolean {
+      return this.subsidiaryId !== null;
+    },
+    getIsTeamIdComplete(): boolean {
+      return this.teamId !== null;
+    },
+    getIsMerchIdComplete(): boolean {
+      return this.merchId !== null;
+    },
+    getIsRegistrationComplete(): boolean {
+      return (
+        this.getIsPersonalDetailsComplete &&
+        this.getIsPaymentComplete &&
+        this.getIsOrganizationTypeComplete &&
+        this.getIsOrganizationIdComplete &&
+        this.getIsSubsidiaryIdComplete &&
+        this.getIsTeamIdComplete &&
+        this.getIsMerchIdComplete
+      );
+    },
   },
 
   actions: {

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -188,30 +188,31 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       state.isPayuTransactionInitiated,
     getIsPersonalDetailsComplete(): boolean {
       return (
-        this.personalDetails.firstName !== '' &&
-        this.personalDetails.lastName !== '' &&
-        this.personalDetails.nickname !== '' &&
-        this.personalDetails.gender !== Gender.none &&
-        this.personalDetails.terms === true
+        this.getPersonalDetails.firstName !== '' &&
+        this.getPersonalDetails.lastName !== '' &&
+        this.getPersonalDetails.nickname !== '' &&
+        this.getPersonalDetails.gender !== Gender.none &&
+        this.getPersonalDetails.terms === true
       );
     },
     getIsPaymentComplete(): boolean {
-      return this.paymentState === PaymentState.done;
+      return this.getPaymentState === PaymentState.done;
     },
     getIsOrganizationTypeComplete(): boolean {
-      return this.organizationType !== OrganizationType.none;
+      return this.getOrganizationType !== OrganizationType.none;
     },
+
     getIsOrganizationIdComplete(): boolean {
-      return this.organizationId !== null;
+      return this.getOrganizationId !== null;
     },
     getIsSubsidiaryIdComplete(): boolean {
-      return this.subsidiaryId !== null;
+      return this.getSubsidiaryId !== null;
     },
     getIsTeamIdComplete(): boolean {
-      return this.teamId !== null;
+      return this.getTeamId !== null;
     },
     getIsMerchIdComplete(): boolean {
-      return this.merchId !== null;
+      return this.getMerchId !== null;
     },
     getIsRegistrationComplete(): boolean {
       return (

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -16,8 +16,6 @@ import { defLocale } from '../../../src/i18n/def_locale';
 
 // selectors
 const selectorLogoutButton = 'logout-button';
-const selectorUserSelectDesktop = 'user-select-desktop';
-const selectorUserSelectInput = 'user-select-input';
 const selectorEmailVerificationRegisterLink =
   'email-verification-register-link';
 const selectorChallengeInactiveInfo = 'challenge-inactive-info';
@@ -395,16 +393,14 @@ describe('Register page', () => {
             });
           });
 
-          // redirected to home page
-          cy.url().should('contain', routesConf['home']['path']);
-          // click user select
-          cy.dataCy(selectorUserSelectDesktop).within(() => {
-            cy.dataCy(selectorUserSelectInput).should('be.visible').click();
-          });
-          // logout
-          cy.dataCy('menu-item')
-            .contains(win.i18n.global.t('userSelect.logout'))
-            .click();
+          // challenge is active - redirect to register challenge page
+          cy.url().should('contain', routesConf['register_challenge']['path']);
+          // logout via header button
+          cy.dataCy('login-register-header')
+            .should('be.visible')
+            .within(() => {
+              cy.dataCy('logout-button').click();
+            });
           // redirected to login page
           cy.url().should('include', routesConf['login']['path']);
         });

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1570,6 +1570,10 @@ describe('Register Challenge page', () => {
                   .should('be.visible')
                   .and('not.be.disabled')
                   .click();
+                cy.testRegisterChallengeLoadedStepsThreeToFive(
+                  win.i18n,
+                  registerChallengeResponse,
+                );
               },
             );
           });

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1570,14 +1570,6 @@ describe('Register Challenge page', () => {
                   .should('be.visible')
                   .and('not.be.disabled')
                   .click();
-                cy.testRegisterChallengeLoadedStepsThreeToFive(
-                  win.i18n,
-                  registerChallengeResponse,
-                );
-                cy.testRegisterChallengeLoadedStepSix(
-                  win.i18n,
-                  registerChallengeResponse,
-                );
               },
             );
           });

--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -54,8 +54,10 @@ describe('Router rules', () => {
       cy.visit('#' + routesConf['login']['path']);
 
       cy.task('getAppConfig', process).then((config) => {
+        cy.wrap(config).as('config');
         cy.window().should('have.property', 'i18n');
         cy.window().then((win) => {
+          cy.wrap(win.i18n).as('i18n');
           cy.fixture('refreshTokensResponseChallengeActive').then(
             (refreshTokensResponseChallengeActive) => {
               cy.fixture('loginRegisterResponseChallengeActive').then(
@@ -77,13 +79,113 @@ describe('Router rules', () => {
       });
     });
 
-    it('after login, redirects to home page', () => {
+    it('after login, redirects to register-challenge page', () => {
       cy.fillAndSubmitLoginForm();
       cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
       cy.url().should('not.include', routesConf['login']['path']);
       cy.url().should('not.include', routesConf['verify_email']['path']);
       cy.url().should('not.include', routesConf['challenge_inactive']['path']);
-      cy.url().should('include', routesConf['home']['path']);
+      cy.url().should('include', routesConf['register_challenge']['path']);
+    });
+
+    it('when registration is empty (not started), does not allow to access any pages except register-challenge', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.fixture('apiGetRegisterChallengeEmpty').then((emptyResponse) => {
+            // intercept register-challenge GET request with incomplete registration
+            cy.interceptRegisterChallengeGetApi(
+              config,
+              i18n,
+              emptyResponse,
+              null,
+            );
+          });
+        });
+      });
+      cy.fillAndSubmitLoginForm();
+      cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
+      cy.url().should('include', routesConf['register_challenge']['path']);
+      cy.testAccessRegisterChallengeOnly();
+    });
+
+    it('when company registration with no admission, does not allow to access any pages except register-challenge', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.fixture('apiGetRegisterChallengeCompanyNoAdmission.json').then(
+            (response) => {
+              // intercept register-challenge GET request with incomplete registration
+              cy.interceptRegisterChallengeGetApi(config, i18n, response, null);
+            },
+          );
+        });
+      });
+      cy.fillAndSubmitLoginForm();
+      cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
+      cy.url().should('include', routesConf['register_challenge']['path']);
+      cy.testAccessRegisterChallengeOnly();
+    });
+
+    it('when company registration waiting for payment, does not allow to access any pages except register-challenge', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.fixture('apiGetRegisterChallengeCompanyWaiting.json').then(
+            (response) => {
+              cy.interceptRegisterChallengeGetApi(config, i18n, response, null);
+            },
+          );
+        });
+      });
+      cy.fillAndSubmitLoginForm();
+      cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
+      cy.url().should('include', routesConf['register_challenge']['path']);
+      cy.testAccessRegisterChallengeOnly();
+    });
+
+    it('when individual registration is not paid, does not allow to access any pages except register-challenge', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.fixture('apiGetRegisterChallengeIndividualNotPaid.json').then(
+            (response) => {
+              cy.interceptRegisterChallengeGetApi(config, i18n, response, null);
+            },
+          );
+        });
+      });
+      cy.fillAndSubmitLoginForm();
+      cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
+      cy.url().should('include', routesConf['register_challenge']['path']);
+      cy.testAccessRegisterChallengeOnly();
+    });
+
+    it('when individual registration is complete, allows to access all pages but not register-challenge', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.fixture('apiGetRegisterChallengeIndividualPaid').then(
+            (response) => {
+              cy.interceptRegisterChallengeGetApi(config, i18n, response, null);
+            },
+          );
+        });
+      });
+      cy.fillAndSubmitLoginForm();
+      cy.wait(['@loginRequest', '@verifyEmailRequest', '@thisCampaignRequest']);
+      cy.url().should('not.include', routesConf['register_challenge']['path']);
+      // test that we are on home page
+      cy.dataCy('index-title').should('be.visible');
+      // try accessing register-challenge page
+      cy.visit('#' + routesConf['register_challenge']['path']);
+      cy.url().should('not.include', routesConf['register_challenge']['path']);
+      // redirects to home page
+      cy.dataCy('index-title').should('be.visible');
+      // go to profile page
+      cy.visit('#' + routesConf['profile']['path']);
+      cy.url().should('include', routesConf['profile']['path']);
+      cy.dataCy('profile-page-title').should('be.visible');
+      // try accessing register-challenge page again
+      cy.visit('#' + routesConf['register_challenge']['path']);
+      cy.url().should('not.include', routesConf['register_challenge']['path']);
+      // redirects to home page
+      cy.dataCy('index-title').should('be.visible');
     });
   });
 });

--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -160,7 +160,7 @@ describe('Router rules', () => {
     it('when individual registration is complete, allows to access all pages but not register-challenge', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          cy.fixture('apiGetRegisterChallengeIndividualPaid').then(
+          cy.fixture('apiGetRegisterChallengeIndividualPaidComplete').then(
             (response) => {
               cy.interceptRegisterChallengeGetApi(config, i18n, response, null);
             },

--- a/test/cypress/fixtures/apiGetRegisterChallengeIndividualPaidComplete.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeIndividualPaidComplete.json
@@ -26,7 +26,7 @@
       "team_id": 2451,
       "organization_id": 987,
       "subsidiary_id": 1358,
-      "t_shirt_size_id": null
+      "t_shirt_size_id": 133
     }
   ]
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -41,6 +41,7 @@ import {
 import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_lang';
 import { bearerTokeAuth } from '../../../src/utils';
 import { OrganizationType } from '../../../src/components/types/Organization';
+import { routesConf } from '../../../src/router/routes_conf';
 
 // Fix for ResizeObserver loop issue in Firefox
 // see https://stackoverflow.com/questions/74947338/i-keep-getting-error-resizeobserver-loop-limit-exceeded-in-cypress
@@ -2174,3 +2175,34 @@ Cypress.Commands.add(
     );
   },
 );
+
+/**
+ * Test that user cannot access any page except register-challenge
+ */
+Cypress.Commands.add('testAccessRegisterChallengeOnly', () => {
+  // not allowed to access home page
+  cy.visit('#' + routesConf['home']['path']);
+  // test home page with title element because url `/` is included in all paths
+  cy.dataCy('index-title').should('not.exist');
+  cy.url().should('include', routesConf['register_challenge']['path']);
+  // not allowed to access routes page
+  cy.visit('#' + routesConf['routes']['path']);
+  cy.url().should('not.include', routesConf['routes']['path']);
+  cy.url().should('include', routesConf['register_challenge']['path']);
+  // not allowed to access results page
+  cy.visit('#' + routesConf['results']['path']);
+  cy.url().should('not.include', routesConf['results']['path']);
+  cy.url().should('include', routesConf['register_challenge']['path']);
+  // not allowed to access prizes page
+  cy.visit('#' + routesConf['prizes']['path']);
+  cy.url().should('not.include', routesConf['prizes']['path']);
+  cy.url().should('include', routesConf['register_challenge']['path']);
+  // not allowed to access coordinator page
+  cy.visit('#' + routesConf['coordinator']['path']);
+  cy.url().should('not.include', routesConf['coordinator']['path']);
+  cy.url().should('include', routesConf['register_challenge']['path']);
+  // not allowed to access profile page
+  cy.visit('#' + routesConf['profile']['path']);
+  cy.url().should('not.include', routesConf['profile']['path']);
+  cy.url().should('include', routesConf['register_challenge']['path']);
+});


### PR DESCRIPTION
Add router rule to disable `/register-challenge` route once registration is complete.

* Add getter to `registerChallenge` store.
* Add check if registration complete onMounted in `RegisterChallengePage`.
* Extend router rules with new condition.
* Test redirections in `router_rules` E2E test.
* Update `register_challenge` individual-paid test to work with incomplete data (otherwise it would be redirected).