### PR TITLE
src/composables: fix refreshing access token, if token is not available before every REST API call

### DIFF
--- a/src/boot/pinia.js
+++ b/src/boot/pinia.js
@@ -1,7 +1,6 @@
 import { markRaw } from 'vue';
 import { boot } from 'quasar/wrappers';
 import { createPinia } from 'pinia';
-import { useLoginStore } from '../stores/login';
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
 
 /**
@@ -28,10 +27,4 @@ export default boot(({ app, router }) => {
     store.$router = markRaw(router);
   });
   app.use(pinia);
-
-  // refresh access token on each reload (as it is not persisted)
-  const loginStore = useLoginStore();
-  if (loginStore.refreshToken) {
-    loginStore.refreshTokens();
-  }
 });

--- a/src/composables/useApiGetCampaign.ts
+++ b/src/composables/useApiGetCampaign.ts
@@ -87,7 +87,8 @@ export const useApiGetCampaign = (
     logger?.debug(`Fetching next page of campaign from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<ThisCampaignResponse>({

--- a/src/composables/useApiGetCities.ts
+++ b/src/composables/useApiGetCities.ts
@@ -61,7 +61,8 @@ export const useApiGetCities = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch cities
     const { data } = await apiFetch<GetCitiesResponse>({
@@ -94,7 +95,8 @@ export const useApiGetCities = (
     logger?.debug(`Fetching next page of cities from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<GetCitiesResponse>({

--- a/src/composables/useApiGetDiscountCoupon.ts
+++ b/src/composables/useApiGetDiscountCoupon.ts
@@ -48,7 +48,8 @@ export const useApiGetDiscountCoupon = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     const { data } = await apiFetch<DiscountCouponResponse>({
       endpoint: `${rideToWorkByBikeConfig.urlApiDiscountCoupon}${code}`,

--- a/src/composables/useApiGetFilteredMerchandise.ts
+++ b/src/composables/useApiGetFilteredMerchandise.ts
@@ -56,7 +56,8 @@ export const useApiGetFilteredMerchandise = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch merchandise
     const { data } = await apiFetch<GetMerchandiseResponse>({
@@ -89,7 +90,8 @@ export const useApiGetFilteredMerchandise = (
     logger?.debug(`Fetching next page of filtered merchandise from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<GetMerchandiseResponse>({

--- a/src/composables/useApiGetHasOrganizationAdmin.ts
+++ b/src/composables/useApiGetHasOrganizationAdmin.ts
@@ -58,7 +58,8 @@ export const useApiGetHasOrganizationAdmin = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     const { data } = await apiFetch<HasOrganizationAdminResponse>({
       endpoint: `${rideToWorkByBikeConfig.urlApiHasOrganizationAdmin}${organizationId}/`,

--- a/src/composables/useApiGetMerchandise.ts
+++ b/src/composables/useApiGetMerchandise.ts
@@ -67,7 +67,8 @@ export const useApiGetMerchandise = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch merchandise
     const { data } = await apiFetch<GetMerchandiseResponse>({
@@ -103,7 +104,8 @@ export const useApiGetMerchandise = (
     logger?.debug(`Fetching next page of merchandise from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<GetMerchandiseResponse>({

--- a/src/composables/useApiGetOrganizations.ts
+++ b/src/composables/useApiGetOrganizations.ts
@@ -67,7 +67,8 @@ export const useApiGetOrganizations = (
     isLoading.value = true;
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
     // fetch organizations
     const { data } = await apiFetch<GetOrganizationsResponse>({
       endpoint: `${rideToWorkByBikeConfig.urlApiOrganizations}${organizationType}/`,
@@ -96,7 +97,8 @@ export const useApiGetOrganizations = (
     logger?.debug(`Fetching next page of organizations from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
     // fetch next page
     const { data } = await apiFetch<GetOrganizationsResponse>({
       endpoint: url,

--- a/src/composables/useApiGetRegisterChallenge.ts
+++ b/src/composables/useApiGetRegisterChallenge.ts
@@ -60,7 +60,8 @@ export const useApiGetRegisterChallenge = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch registrations
     const { data } = await apiFetch<RegisterChallengeResponse>({

--- a/src/composables/useApiGetSubsidiaries.ts
+++ b/src/composables/useApiGetSubsidiaries.ts
@@ -65,7 +65,8 @@ export const useApiGetSubsidiaries = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch subsidiaries
     const { data } = await apiFetch<GetSubsidiariesResponse>({
@@ -98,7 +99,8 @@ export const useApiGetSubsidiaries = (
     logger?.debug(`Fetching next page of subsidiaries from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<GetSubsidiariesResponse>({

--- a/src/composables/useApiGetTeams.ts
+++ b/src/composables/useApiGetTeams.ts
@@ -57,7 +57,8 @@ export const useApiGetTeams = (logger: Logger | null): useApiGetTeamsReturn => {
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch teams
     const { data } = await apiFetch<GetTeamsResponse>({
@@ -90,7 +91,8 @@ export const useApiGetTeams = (logger: Logger | null): useApiGetTeamsReturn => {
     logger?.debug(`Fetching next page of teams from <${url}>.`);
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // fetch next page
     const { data } = await apiFetch<GetTeamsResponse>({

--- a/src/composables/useApiPostOrganization.ts
+++ b/src/composables/useApiPostOrganization.ts
@@ -62,7 +62,8 @@ export const useApiPostOrganization = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // data
     const payload: PostOrganizationPayload = {

--- a/src/composables/useApiPostPayuCreateOrder.ts
+++ b/src/composables/useApiPostPayuCreateOrder.ts
@@ -56,7 +56,8 @@ export const useApiPostPayuCreateOrder = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // post order
     const { data } = await apiFetch<PayuCreateOrderResponse>({

--- a/src/composables/useApiPostRegisterChallenge.ts
+++ b/src/composables/useApiPostRegisterChallenge.ts
@@ -54,7 +54,8 @@ export const useApiPostRegisterChallenge = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // post registration
     const { data } = await apiFetch<RegisterChallengePostResponse>({

--- a/src/composables/useApiPostSubsidiary.ts
+++ b/src/composables/useApiPostSubsidiary.ts
@@ -66,7 +66,8 @@ export const useApiPostSubsidiary = (
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // post subsidiary
     const { data } = await apiFetch<SubsidiaryPostApiResponse>({

--- a/src/composables/useApiPostTeam.ts
+++ b/src/composables/useApiPostTeam.ts
@@ -55,7 +55,8 @@ export const useApiPostTeam = (logger: Logger | null): UseApiPostTeamReturn => {
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
-    requestTokenHeader_.Authorization += loginStore.getAccessToken;
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
 
     // post team
     const { data } = await apiFetch<TeamPostApiResponse>({

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -118,6 +118,22 @@ export const useLoginStore = defineStore('login', {
       }
     },
     /**
+     * Get access token, if token does not exists
+     * refresh it
+     * @returns Promise<string> - Access token
+     */
+    async getAccessTokenWithRefresh(): Promise<string> {
+      if (!this.getAccessToken) {
+        this.$log?.debug(
+          `Access token does not exists <${this.getAccessToken}>,` +
+            ' get (refresh) it again.',
+        );
+        await this.refreshTokens();
+        this.$log?.debug(`New access token <${this.getAccessToken}>.`);
+      }
+      return this.getAccessToken;
+    },
+    /**
      * Login user
      * Checks if email and password are set.
      * If not, shows a notification.

--- a/src/stores/register.ts
+++ b/src/stores/register.ts
@@ -139,7 +139,8 @@ export const useRegisterStore = defineStore('register', {
       );
       // Append access token into HTTP header
       const requestTokenHeader_ = { ...requestTokenHeader };
-      requestTokenHeader_.Authorization += loginStore.getAccessToken;
+      requestTokenHeader_.Authorization +=
+        await loginStore.getAccessTokenWithRefresh();
       // check email verification
       const { data } = await apiFetch<HasVerifiedEmailResponse>({
         endpoint: rideToWorkByBikeConfig.urlApiHasUserVerifiedEmail,

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -213,12 +213,6 @@ describe('Login page', () => {
           cy.reload();
           // check that we are on homepage
           cy.testRoute(routesConf['home']['path']);
-          // refresh tokens should be called on load
-          cy.wait('@refreshTokens').then((interception) => {
-            expect(interception.response.statusCode).to.equal(
-              httpSuccessfullStatus,
-            );
-          });
         });
       });
     });


### PR DESCRIPTION
 Fix refreshing access token if token doesn't exists , before every REST API call.
 
Fix issue when PayU successful payment redirection to RTWBB URL register-challenge/ was successful (page reload), but access token is not available, and REST API register-challenge/ URL endpoint be called.