### PR TITLE
src/stores: connect fields telephone and telephoneOptIn to registerChallenge store and API request

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -46,6 +46,8 @@ export const registerChallengeAdapter = {
       subsidiaryId: apiData.subsidiary_id,
       teamId: apiData.team_id,
       merchId: apiData.t_shirt_size_id,
+      telephone: apiData.personal_details.telephone,
+      telephoneOptIn: apiData.personal_details.telephone_opt_in,
       voucher: apiData.personal_details.discount_coupon,
     };
   },
@@ -107,6 +109,12 @@ export const registerChallengeAdapter = {
     }
     if (storeState.merchId !== undefined) {
       payload.t_shirt_size_id = storeState.merchId;
+    }
+    if (storeState.telephone !== undefined) {
+      payload.telephone = storeState.telephone;
+    }
+    if (storeState.telephoneOptIn !== undefined) {
+      payload.telephone_opt_in = storeState.telephoneOptIn;
     }
 
     return payload;

--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -87,9 +87,14 @@ export default defineComponent({
       get: () => registerChallengeStore.getMerchId,
       set: (value: number | null) => registerChallengeStore.setMerchId(value),
     });
-    const phone = ref<string>('');
-    const trackDelivery = ref<boolean>(false);
-    const newsletter = ref<boolean>(false);
+    const phone = computed<string>({
+      get: () => registerChallengeStore.getTelephone,
+      set: (value: string) => registerChallengeStore.setTelephone(value),
+    });
+    const telephoneOptIn = computed<boolean>({
+      get: () => registerChallengeStore.getTelephoneOptIn,
+      set: (value: boolean) => registerChallengeStore.setTelephoneOptIn(value),
+    });
     // dialog
     const isOpen = ref<boolean>(false);
 
@@ -332,7 +337,7 @@ export default defineComponent({
       Gender,
       isNotMerch,
       isOpen,
-      newsletter,
+      telephoneOptIn,
       optionsFemale,
       optionsMale,
       optionsUnisex,
@@ -342,7 +347,6 @@ export default defineComponent({
       selectedGender,
       currentGenderOptions,
       currentSizeOptions,
-      trackDelivery,
       onSelectCardOption,
       onSubmit,
       isSelected,
@@ -489,32 +493,22 @@ export default defineComponent({
 
     <!-- Input: Phone number -->
     <form-field-phone
+      v-if="!isNotMerch"
       v-model="phone"
       :hint="$t('form.merch.hintPhone')"
-      :required="trackDelivery"
+      :required="true"
       data-cy="form-merch-phone-input"
-    />
-    <!-- Input: Track delivery checkbox -->
-    <q-checkbox
-      dense
-      v-model="trackDelivery"
-      color="primary"
-      :false-value="false"
-      :label="$t('form.merch.labelTrackDelivery')"
-      :true-value="true"
-      class="text-grey-10 q-mt-lg"
-      data-cy="form-merch-tracking-input"
     />
     <!-- Input: News checkbox -->
     <q-checkbox
       dense
-      v-model="newsletter"
+      v-model="telephoneOptIn"
       color="primary"
       :false-value="false"
       :label="$t('form.merch.labelNewsletter')"
       :true-value="true"
       class="text-grey-10 q-mt-md"
-      data-cy="form-terms-input"
+      data-cy="form-merch-phone-opt-in-input"
     />
 
     <!-- Dialog -->

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -76,4 +76,6 @@ export interface ToApiPayloadStoreState {
   teamId?: number | null;
   merchId?: number | null;
   voucher?: ValidatedCoupon | null;
+  telephone?: string;
+  telephoneOptIn?: boolean;
 }

--- a/src/components/types/RegisterChallenge.ts
+++ b/src/components/types/RegisterChallenge.ts
@@ -45,4 +45,6 @@ export interface RegisterChallengePostRequest {
   personalDetails: RegisterChallengePersonalDetailsApi;
   newsletter: NewsletterType[];
   teamId?: number | null;
+  telephone?: string;
+  telephoneOptIn?: boolean;
 }

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -104,6 +104,8 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     formRegisterCoordinator: deepObjectWithSimplePropsCopy(
       emptyFormRegisterCoordinator,
     ),
+    telephone: '',
+    telephoneOptIn: false,
     isLoadingRegisterChallenge: false,
     ipAddressData: null as IpAddressResponse | null,
     isLoadingSubsidiaries: false,
@@ -142,6 +144,8 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       state.isSelectedRegisterCoordinator,
     getFormRegisterCoordinator: (state): RegisterChallengeCoordinatorForm =>
       state.formRegisterCoordinator,
+    getTelephone: (state): string => state.telephone,
+    getTelephoneOptIn: (state): boolean => state.telephoneOptIn,
     getSelectedOrganizationLabel: (state): string => {
       if (state.organizationId) {
         const organization = state.organizations.find(
@@ -301,6 +305,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     setMerchandiseCards(cards: Record<Gender, MerchandiseCard[]>) {
       this.merchandiseCards = cards;
     },
+    setTelephone(telephone: string) {
+      this.telephone = telephone;
+    },
+    setTelephoneOptIn(telephoneOptIn: boolean) {
+      this.telephoneOptIn = telephoneOptIn;
+    },
     setIsPayuTransactionInitiated(isPayuTransactionInitiated: boolean) {
       this.isPayuTransactionInitiated = isPayuTransactionInitiated;
     },
@@ -419,7 +429,11 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         [RegisterChallengeStep.participation]: {},
         [RegisterChallengeStep.organization]: {},
         [RegisterChallengeStep.team]: { teamId: this.teamId },
-        [RegisterChallengeStep.merch]: { merchId: this.merchId },
+        [RegisterChallengeStep.merch]: {
+          merchId: this.merchId,
+          telephone: this.telephone,
+          telephoneOptIn: this.telephoneOptIn,
+        },
         [RegisterChallengeStep.summary]: {},
       };
       // convert store state to API payload

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -407,6 +407,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       this.$log?.debug(`Team ID store updated to <${this.getTeamId}>.`);
       this.setMerchId(parsedResponse.merchId);
       this.$log?.debug(`Merch ID store updated to <${this.getMerchId}>.`);
+      this.setTelephone(parsedResponse.telephone);
+      this.$log?.debug(`Telephone store updated to <${this.getTelephone}>.`);
+      this.setTelephoneOptIn(parsedResponse.telephoneOptIn);
+      this.$log?.debug(
+        `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
+      );
     },
     /**
      * Submit a registration step

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1440,6 +1440,16 @@ describe('Register Challenge page', () => {
       cy.dataCy('dialog-close').click();
       // verify dialog is closed
       cy.dataCy('dialog-merch').should('not.exist');
+      // fill in phone number
+      cy.fixture('apiPostRegisterChallengeMerchandiseRequest.json').then(
+        (request) => {
+          cy.dataCy('form-merch-phone-input')
+            .find('input')
+            .type(request.telephone);
+        },
+      );
+      // enable telephone opt-in
+      cy.dataCy('form-merch-phone-opt-in-input').click();
       // go to next step
       cy.dataCy('step-6-continue').should('be.visible').click();
       // test API post request (merchandise)

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -763,61 +763,97 @@ describe('Register Challenge page', () => {
     });
 
     it('validates sixth step (merch)', () => {
-      passToStep6();
-      checkActiveIcon(6);
-      // by default, next step button is disabled
-      cy.dataCy('step-6-continue').should('be.visible').and('be.disabled');
-      // check no merch checkbox
-      cy.dataCy('form-merch-no-merch-checkbox').should('be.visible').click();
-      cy.waitForMerchandiseNoneApi();
-      // go to next step
-      cy.dataCy('step-6-continue')
-        .should('be.visible')
-        .and('not.be.disabled')
-        .click();
-      cy.dataCy('step-6').find('.q-stepper__step-content').should('not.exist');
-      cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
-      // go back to step 6
-      cy.dataCy('step-7-back').should('be.visible').click();
-      cy.dataCy('step-6').find('.q-stepper__step-content').should('be.visible');
-      // uncheck no merch checkbox
-      cy.dataCy('form-merch-no-merch-checkbox').should('be.visible').click();
-      // next step button is disabled
-      cy.dataCy('step-6-continue').should('be.visible').and('be.disabled');
-      // select size
-      cy.fixture('apiGetMerchandiseResponse').then((response) => {
-        const item = response.results[0];
-        // open dialog
-        cy.dataCy('form-card-merch-female')
-          .first()
-          .find('[data-cy="button-more-info"]')
-          .click();
-        cy.dataCy('dialog-merch')
+      cy.get('@i18n').then((i18n) => {
+        passToStep6();
+        checkActiveIcon(6);
+        // by default, next step button is disabled
+        cy.dataCy('step-6-continue').should('be.visible').and('be.disabled');
+        // check no merch checkbox
+        cy.dataCy('form-merch-no-merch-checkbox').should('be.visible').click();
+        cy.waitForMerchandiseNoneApi();
+        // go to next step
+        cy.dataCy('step-6-continue')
           .should('be.visible')
-          .within(() => {
-            cy.contains(item.name).should('be.visible');
-            cy.contains(item.description).should('be.visible');
-          });
-        cy.dataCy('slider-merch').should('be.visible');
-        // close dialog
-        cy.dataCy('dialog-close').click();
-        // first option is selected
-        cy.dataCy('form-card-merch-female')
-          .first()
-          .find('[data-cy="button-selected"]')
-          .should('be.visible');
-        cy.dataCy('form-card-merch-female')
-          .first()
-          .find('[data-cy="button-more-info"]')
+          .and('not.be.disabled')
+          .click();
+        cy.dataCy('step-6')
+          .find('.q-stepper__step-content')
           .should('not.exist');
+        cy.dataCy('step-7')
+          .find('.q-stepper__step-content')
+          .should('be.visible');
+        // go back to step 6
+        cy.dataCy('step-7-back').should('be.visible').click();
+        cy.dataCy('step-6')
+          .find('.q-stepper__step-content')
+          .should('be.visible');
+        // uncheck no merch checkbox
+        cy.dataCy('form-merch-no-merch-checkbox').should('be.visible').click();
+        // next step button is disabled
+        cy.dataCy('step-6-continue').should('be.visible').and('be.disabled');
+        // select size
+        cy.fixture('apiGetMerchandiseResponse').then((response) => {
+          const item = response.results[0];
+          // open dialog
+          cy.dataCy('form-card-merch-female')
+            .first()
+            .find('[data-cy="button-more-info"]')
+            .click();
+          cy.dataCy('dialog-merch')
+            .should('be.visible')
+            .within(() => {
+              cy.contains(item.name).should('be.visible');
+              cy.contains(item.description).should('be.visible');
+            });
+          cy.dataCy('slider-merch').should('be.visible');
+          // close dialog
+          cy.dataCy('dialog-close').click();
+          // first option is selected
+          cy.dataCy('form-card-merch-female')
+            .first()
+            .find('[data-cy="button-selected"]')
+            .should('be.visible');
+          cy.dataCy('form-card-merch-female')
+            .first()
+            .find('[data-cy="button-more-info"]')
+            .should('not.exist');
+        });
+        // next step button is enabled
+        cy.dataCy('step-6-continue')
+          .should('be.visible')
+          .and('not.be.disabled')
+          .click();
+        // validation does not pass (phone is required)
+        cy.dataCy('step-6')
+          .find('.q-stepper__step-content')
+          .should('be.visible');
+        // phone error message is shown
+        cy.contains(
+          i18n.global.t('form.messageFieldRequired', {
+            fieldName: i18n.global.t('form.labelPhone'),
+          }),
+        ).should('be.visible');
+        // fill in phone number
+        cy.fixture('apiPostRegisterChallengeMerchandiseRequest').then(
+          (request) => {
+            cy.dataCy('form-merch-phone-input')
+              .find('input')
+              .type(request.telephone);
+          },
+        );
+        // next step button is enabled
+        cy.dataCy('step-6-continue')
+          .should('be.visible')
+          .and('not.be.disabled')
+          .click();
+        // go to next step
+        cy.dataCy('step-6')
+          .find('.q-stepper__step-content')
+          .should('not.exist');
+        cy.dataCy('step-7')
+          .find('.q-stepper__step-content')
+          .should('be.visible');
       });
-      // next step button is enabled
-      cy.dataCy('step-6-continue')
-        .should('be.visible')
-        .and('not.be.disabled')
-        .click();
-      cy.dataCy('step-6').find('.q-stepper__step-content').should('not.exist');
-      cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
     });
 
     it('allows user to create a new team', () => {
@@ -2001,27 +2037,29 @@ function passToStep6() {
 
 function passToStep7() {
   passToStep6();
-  // select merch
-  cy.dataCy('form-card-merch-female')
-    .first()
-    .find('[data-cy="form-card-merch-link"]')
-    .click();
-  // close dialog
-  cy.dataCy('dialog-close').click();
-  // verify dialog is closed
-  cy.dataCy('dialog-merch').should('not.exist');
-  // select package tracking
-  cy.dataCy('form-merch-tracking-input').click();
-  // fill phone number
-  cy.dataCy('form-merch-phone-input')
-    .should('be.visible')
-    .find('input')
-    .type('736 123 456');
-  // go to next step
-  cy.dataCy('step-6-continue').should('be.visible').click();
-  cy.dataCy('step-6-continue').find('.q-spinner').should('be.visible');
-  // on step 7
-  cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
+  cy.fixture('apiPostRegisterChallengeMerchandiseRequest').then((request) => {
+    // select merch
+    cy.dataCy('form-card-merch-female')
+      .first()
+      .find('[data-cy="form-card-merch-link"]')
+      .click();
+    // close dialog
+    cy.dataCy('dialog-close').click();
+    // verify dialog is closed
+    cy.dataCy('dialog-merch').should('not.exist');
+    // fill phone number
+    cy.dataCy('form-merch-phone-input')
+      .should('be.visible')
+      .find('input')
+      .type(request.telephone);
+    // opt in to info phone calls
+    cy.dataCy('form-merch-phone-opt-in-input').should('be.visible').click();
+    // go to next step
+    cy.dataCy('step-6-continue').should('be.visible').click();
+    cy.dataCy('step-6-continue').find('.q-spinner').should('be.visible');
+    // on step 7
+    cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
+  });
 }
 
 function checkActiveIcon(activeStep) {

--- a/test/cypress/fixtures/apiGetRegisterChallengeCompanyWaiting.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeCompanyWaiting.json
@@ -10,7 +10,7 @@
         "nickname": "FB",
         "sex": "male",
         "telephone": "736123456",
-        "telephone_opt_in": false,
+        "telephone_opt_in": true,
         "language": "cs",
         "occupation": "",
         "age_group": null,

--- a/test/cypress/fixtures/apiPostRegisterChallengeMerchandiseRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeMerchandiseRequest.json
@@ -1,5 +1,5 @@
 {
+  "t_shirt_size_id": 133,
   "telephone": "736123456",
-  "telephone_opt_in": true,
-  "t_shirt_size_id": 133
+  "telephone_opt_in": true
 }

--- a/test/cypress/fixtures/apiPostRegisterChallengeMerchandiseRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeMerchandiseRequest.json
@@ -1,3 +1,5 @@
 {
+  "telephone": "736123456",
+  "telephone_opt_in": true,
   "t_shirt_size_id": 133
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2043,6 +2043,23 @@ Cypress.Commands.add(
           .should('contain', item.size);
       });
     });
+    // phone number is preselected
+    cy.dataCy('form-phone-input').should(
+      'have.value',
+      registerChallengeResponse.results[0].personal_details.telephone,
+    );
+    // phone opt-in is preselected
+    if (
+      registerChallengeResponse.results[0].personal_details.telephone_opt_in
+    ) {
+      cy.dataCy('form-merch-phone-opt-in-input')
+        .find('.q-checkbox__inner')
+        .should('have.class', 'q-checkbox__inner--truthy');
+    } else {
+      cy.dataCy('form-merch-phone-opt-in-input')
+        .find('.q-checkbox__inner')
+        .should('have.class', 'q-checkbox__inner--falsy');
+    }
     // go to next step
     cy.dataCy('step-6-continue').should('be.visible').click();
     // verify step 7 is active

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -36,6 +36,7 @@ import {
   httpTooManyRequestsStatusMessage,
   userAgentHeader,
   interceptOrganizationsApi,
+  interceptedRequestResponseDelay,
   waitForOrganizationsApi,
 } from './commonTests';
 import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_lang';
@@ -1667,6 +1668,7 @@ Cypress.Commands.add(
             ? responseStatusCode
             : httpSuccessfullStatus,
           body: responseBody ? responseBody : registerChallengeResponse,
+          delay: interceptedRequestResponseDelay,
         }).as('postRegisterChallenge');
       },
     );

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -589,6 +589,7 @@ export const userAgentHeader = {
   'User-Agent':
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
 };
+export const interceptedRequestResponseDelay = 300;
 
 // access token expiration time: Tuesday 24. September 2024 22:36:03
 const fixtureTokenExpiration = new Date('2024-09-24T20:36:03Z');


### PR DESCRIPTION
Connect fields `telephone` and `telephoneOptIn` to `registerChallenge` store and API request.

* Update UI fields in `FormFieldListMerch` (remove delivery notification checkbox + make `telephone` field always required)
* Connect fields `telephone` and `telephoneOptIn` dynamically to `registerChallenge`.
* Send new values to API via `registerChallengeAdapter`
* Update component and E2E tests to check a) saving values to store b) sending correct values in post register-challenge request c) loading correct values to UI from get register-challenge request.