### PR TITLE
src/composables: update phone validation regex in useValidation to be less strict

### DIFF
--- a/src/components/__tests__/FormFieldPhone.cy.js
+++ b/src/components/__tests__/FormFieldPhone.cy.js
@@ -194,9 +194,9 @@ function testPhoneNumberValidation() {
     cy.dataCy('form-phone-input').type('+41 79 123 45 67');
     cy.dataCy('form-phone-input').blur();
     cy.get('.q-field__messages').should('not.be.visible');
-    // slovenian number
+    // british number
     cy.dataCy('form-phone-input').clear();
-    cy.dataCy('form-phone-input').type('+386 40 123 456');
+    cy.dataCy('form-phone-input').type('+44 20 7123 4567');
     cy.dataCy('form-phone-input').blur();
     cy.get('.q-field__messages').should('not.be.visible');
   });

--- a/src/components/__tests__/FormFieldPhone.cy.js
+++ b/src/components/__tests__/FormFieldPhone.cy.js
@@ -145,73 +145,58 @@ function testPhoneNumberValidation() {
         i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
       );
     cy.dataCy('form-phone-input').clear();
-    // invalid phone
-    cy.dataCy('form-phone-input').type('+420 609 234 567');
-    cy.dataCy('form-phone-input').blur();
-    cy.dataCy('form-phone')
-      .find('.q-field__messages')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
-      );
-    cy.dataCy('form-phone-input').clear();
-    // invalid phone
-    cy.dataCy('form-phone-input').type('+420 500 234 567');
-    cy.dataCy('form-phone-input').blur();
-    cy.dataCy('form-phone')
-      .find('.q-field__messages')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
-      );
-    cy.dataCy('form-phone-input').clear();
-    // invalid phone
-    cy.dataCy('form-phone-input').type('123 456 789');
-    cy.dataCy('form-phone-input').blur();
-    cy.dataCy('form-phone')
-      .find('.q-field__messages')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
-      );
-    cy.dataCy('form-phone-input').clear();
-    // invalid phone
-    cy.dataCy('form-phone-input').type('+420 6012 34567');
-    cy.dataCy('form-phone-input').blur();
-    cy.dataCy('form-phone')
-      .find('.q-field__messages')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
-      );
-    cy.dataCy('form-phone-input').clear();
-    // invalid phone
-    cy.dataCy('form-phone-input').type('602 3456 78');
-    cy.dataCy('form-phone-input').blur();
-    cy.dataCy('form-phone')
-      .find('.q-field__messages')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.coordinator.form.messagePhoneInvalid'),
-      );
-    cy.dataCy('form-phone-input').clear();
     // valid phone
-    cy.dataCy('form-phone-input').type('+420 736 123 456');
+    cy.dataCy('form-phone-input').type('+420 736 661 234');
     cy.dataCy('form-phone-input').blur();
     cy.get('.q-field__messages').should('not.be.visible');
     cy.dataCy('form-phone-input').clear();
     // valid phone
-    cy.dataCy('form-phone-input').type('+420736123456');
+    cy.dataCy('form-phone-input').type('+420736661234');
     cy.dataCy('form-phone-input').blur();
     cy.get('.q-field__messages').should('not.be.visible');
     cy.dataCy('form-phone-input').clear();
     // valid phone
-    cy.dataCy('form-phone-input').type('736123456');
+    cy.dataCy('form-phone-input').type('736661234');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // slovak number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+421 901 234 567');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // german number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+49 151 12345678');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // austrian number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+43 660 123456');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // polish number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+48 600 123 456');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // french number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+33 6 12 34 56 78');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // italian number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+39 345 123 4567');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // swiss number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+41 79 123 45 67');
+    cy.dataCy('form-phone-input').blur();
+    cy.get('.q-field__messages').should('not.be.visible');
+    // slovenian number
+    cy.dataCy('form-phone-input').clear();
+    cy.dataCy('form-phone-input').type('+386 40 123 456');
     cy.dataCy('form-phone-input').blur();
     cy.get('.q-field__messages').should('not.be.visible');
   });

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -31,18 +31,16 @@ export const useValidation = () => {
       return false;
     }
     /**
-     * Match international phone number entered with delimiters
+     * Matches Czech phone number entered with delimiters
      * (spaces, dots, brackets, etc.)
-     *
-     * Note: does not account for specific mistakes such as:
-     * Leading Zero in Area Code: +420 012 345 678
-     * Too Many Digits: +420 123 456 7890
-     * Starts with an Invalid Country Code: +999 123 456 789
-     *
-     * https://uibakery.io/regex-library/email
      */
-    const regex =
-      /^(\+420\s?)?((5\d{2}|60[1-8]|70[2-5]|72\d|73[0-9]|77[0-9])\s?\d{3}\s?\d{3})$/;
+    // const regex = /^(\+420\s?)?((5\d{2}|60[1-8]|70[2-5]|72\d|73[0-9]|77[0-9])\s?\d{3}\s?\d{3})$/;
+
+    /**
+     * Matches a generic format of a phone number with allowed delimiters.
+     * https://stackoverflow.com/a/20349730
+     */
+    const regex = /^(\+|00)?[1-9][0-9 \-\(\)\.]{7,32}$/;
     return regex.test(value);
   };
 

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1292,9 +1292,12 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-5-back').should('be.visible').click();
       // organization and address inputs are visible
       cy.dataCy('form-select-table-company').should('be.visible');
-      cy.dataCy('form-company-address-input').should('be.visible');
       // select a different address
-      cy.dataCy('form-company-address-input').click();
+      cy.dataCy('form-company-address')
+        .should('be.visible')
+        .find('.q-field__append')
+        .last()
+        .click();
       // select option
       cy.get('.q-menu')
         .should('be.visible')
@@ -1342,7 +1345,11 @@ describe('Register Challenge page', () => {
         .first()
         .click();
       // set subsidiary
-      cy.dataCy('form-company-address-input').click();
+      cy.dataCy('form-company-address')
+        .should('be.visible')
+        .find('.q-field__append')
+        .last()
+        .click();
       // select option
       cy.get('.q-menu')
         .should('be.visible')


### PR DESCRIPTION
Update phone validation regex in `useValidation` composable to be less strict and allow for international phone numbers.

* Change regex
* Update tests - relax requirements for delimiters between numbers + add examples of international numbers