### PR TITLE
src/pages: submit voucher data to register-challenge endpoint before creating a PayU order 

### DIFF
--- a/test/cypress/fixtures/apiPostRegisterChallengeVoucherFullRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeVoucherFullRequest.json
@@ -1,0 +1,3 @@
+{
+  "discount_coupon": "ZD-CZBGSD"
+}


### PR DESCRIPTION
Submit voucher data to register-challenge endpoint before creating a PayU order.

This happens in
- `100%` discount voucher + donation
- `< 100%` discount voucher (min or custom amount)

Add test for intercepting the register-challenge `post` request before PayU create order request.