### PR TITLE
test/cypress/e2e: update register_challenge test for resetting IDs on parent data change

### DIFF
--- a/test/cypress/fixtures/formOrganizationOptions.json
+++ b/test/cypress/fixtures/formOrganizationOptions.json
@@ -83,7 +83,7 @@
     "description": "Leading software solutions provider"
   },
   {
-    "id": 12346,
+    "id": 774,
     "title": "GreenLeaf Eco",
     "identificationNumber": "87654321",
     "identificationNumberVat": "CZ87654321",
@@ -94,7 +94,7 @@
     },
     "subsidiaries": [
       {
-        "id": 23456,
+        "id": 1358,
         "title": "Recycling",
         "address": {
           "street": "Sustainability Road",
@@ -126,7 +126,7 @@
         ]
       },
       {
-        "id": 23457,
+        "id": 805,
         "title": "Renewable Energy",
         "address": {
           "street": "Knowledge Lane",


### PR DESCRIPTION
Issue: `register_challenge` E2E test often fails on test:
```
  1) Register Challenge page
       desktop
         reset organization, subsidiary and team on parent data change:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-cy=form-select-table-team]`, but never found it.
```

Description: Organization is switched back and forth to reload subsidiaries, but, these do not update fast enough to display correct values in select (debugged in video output).

Solution:
1) Setup intercept for organization no. 2 in the list so we do not have to switch organization twice.
2) Add `waitForSubsidiariesApi` command to ensure loading data before the UI action is carried out.