### PR TITLE
src/components: add autocomplete functionality to FormFieldCompanyAddress

### DIFF
--- a/src/components/__tests__/FormFieldCompanyAddress.cy.js
+++ b/src/components/__tests__/FormFieldCompanyAddress.cy.js
@@ -127,7 +127,11 @@ describe('<FormFieldCompanyAddress>', () => {
                 subsidiariesResponse,
                 subsidiariesResponseNext,
               );
-              cy.dataCy('form-company-address').find('.q-select').click();
+              // open select menu
+              cy.dataCy('form-company-address')
+                .find('.q-field__append')
+                .last()
+                .click();
               // select option
               cy.get('.q-menu')
                 .should('be.visible')
@@ -143,6 +147,45 @@ describe('<FormFieldCompanyAddress>', () => {
                 .its('value')
                 .should('eq', subsidiariesResponse.results[0].id);
             });
+          },
+        );
+      });
+    });
+
+    it('allows to search through options', () => {
+      cy.wrap(useRegisterChallengeStore()).then((store) => {
+        store.setOrganizationId(organizationId);
+        cy.wrap(store.getOrganizationId).should('eq', organizationId);
+        /**
+         * Manually load subsidiaries.
+         * In the live application, this is handled by `onMounted` hook,
+         * or calling `loadSubsidiariesToStore` method in another
+         * component.
+         */
+        store.loadSubsidiariesToStore(null);
+        // search for option
+        cy.fixture('apiGetSubsidiariesResponse.json').then(
+          (apiGetSubsidiariesResponse) => {
+            cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+              (apiGetSubsidiariesResponseNext) => {
+                cy.waitForSubsidiariesApi(
+                  apiGetSubsidiariesResponse,
+                  apiGetSubsidiariesResponseNext,
+                );
+                cy.dataCy('form-company-address')
+                  .find('.q-field__append')
+                  .type(apiGetSubsidiariesResponse.results[2].address.street);
+                // select first option from filtered results
+                cy.get('.q-item__label')
+                  .should('have.length', 1)
+                  .first()
+                  .click();
+                cy.get('.q-menu').should('not.exist');
+                cy.wrap(model)
+                  .its('value')
+                  .should('eq', apiGetSubsidiariesResponse.results[2].id);
+              },
+            );
           },
         );
       });

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -68,8 +68,24 @@ export default defineComponent({
 
     const subsidiaryId = computed<number | null>({
       get: (): number | null => registerChallengeStore.getSubsidiaryId,
-      set: (value: number | null) =>
-        registerChallengeStore.setSubsidiaryId(value),
+      set: (value: number | null) => {
+        /**
+         * Reset teamId if new value is different from current value
+         * to avoid reset on component mount.
+         */
+        logger?.debug(
+          `Subsidiary ID change to <${value}>, current value is <${registerChallengeStore.getSubsidiaryId}>.`,
+        );
+        if (value !== registerChallengeStore.getSubsidiaryId) {
+          registerChallengeStore.setTeamId(null);
+          logger?.debug(
+            'Subsidiary ID change, reset' +
+              ` team ID <${registerChallengeStore.getTeamId}>.`,
+          );
+        }
+        // set new subsidiaryId value
+        registerChallengeStore.setSubsidiaryId(value);
+      },
     });
 
     const isLoading = computed(
@@ -109,14 +125,6 @@ export default defineComponent({
       );
     };
 
-    const onSubsidiaryIdChange = (): void => {
-      registerChallengeStore.setTeamId(null);
-      logger?.debug(
-        'Subsidiary ID change, reset' +
-          ` team ID <${registerChallengeStore.getTeamId}>.`,
-      );
-    };
-
     const onCloseAddSubsidiaryDialog = () => {
       if (formFieldSelectTableRef.value) {
         // Run organization validation proccess before open add subsidiary dialog
@@ -152,7 +160,6 @@ export default defineComponent({
       onCloseAddSubsidiaryDialog,
       onCreateOption,
       onOrganizationIdChange,
-      onSubsidiaryIdChange,
     };
   },
 });
@@ -175,7 +182,6 @@ export default defineComponent({
     <form-field-company-address
       v-model="subsidiaryId"
       data-cy="form-company-address"
-      @update:model-value="onSubsidiaryIdChange"
       @close:addSubsidiaryDialog="onCloseAddSubsidiaryDialog"
     />
   </div>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -50,6 +50,7 @@ import { useApiGetOrganizations } from 'src/composables/useApiGetOrganizations';
 import { useApiPostOrganization } from 'src/composables/useApiPostOrganization';
 import { useOrganizations } from 'src/composables/useOrganizations';
 import { useValidation } from 'src/composables/useValidation';
+import { useSelectSearch } from 'src/composables/useSelectSearch';
 
 // enums
 import { FormAddCompanyVariantProp } from '../enums/Form';
@@ -100,7 +101,6 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const logger = inject('vuejs3-logger') as Logger | null;
-    const optionsFiltered = ref<FormSelectOption[]>([]);
     const {
       options,
       isLoading: isLoadingGetOrganization,
@@ -111,6 +111,8 @@ export default defineComponent({
     logger?.debug(
       `Initial organization ID model value is <${props.modelValue}>.`,
     );
+
+    const { optionsFiltered, onFilter } = useSelectSearch(options);
 
     // load options on component mount
     onMounted(async () => {
@@ -128,37 +130,15 @@ export default defineComponent({
     };
     watch(selectedOrganization, (newValue, oldValue) => {
       logger?.debug(
-        `Selected organization changed from <${JSON.stringify(oldValue, 2, null)}>` +
-          ` to <${JSON.stringify(newValue, 2, null)}>.`,
+        `Selected organization changed from <${JSON.stringify(oldValue, null, 2)}>` +
+          ` to <${JSON.stringify(newValue, null, 2)}>.`,
       );
       if (newValue) {
-        emit('update:modelValue', parseInt(newValue.value));
+        emit('update:modelValue', parseInt(newValue.value as string));
       } else {
         emit('update:modelValue', null);
       }
     });
-
-    /**
-     * Autocomplete functionality for company select
-     * Upon typing, find strings which contain query entered into the select
-     *
-     * Limitation: does not support fuzzy search
-     *
-     * Quasar types are not implemented yet so we provide custom typing
-     * for update function.
-     * See https://github.com/quasarframework/quasar/issues/8914#issuecomment-1313783889
-     *
-     * See https://quasar.dev/vue-components/select#example--text-autocomplete
-     */
-    const onFilter = (val: string, update: (fn: () => void) => void) => {
-      update(() => {
-        const valLowerCase = val.toLocaleLowerCase();
-        optionsFiltered.value = options.value.filter(
-          (option) =>
-            option.label.toLocaleLowerCase().indexOf(valLowerCase) > -1,
-        );
-      });
-    };
 
     /**
      * Logic for "Create company" action

--- a/src/composables/useSelectSearch.ts
+++ b/src/composables/useSelectSearch.ts
@@ -1,0 +1,44 @@
+// libraries
+import { ref, watch } from 'vue';
+
+// types
+import type { FormSelectOption } from '../components/types/Form';
+import type { Ref } from 'vue';
+
+/**
+ * Composable for handling search functionality in select components
+ * @param options The full list of options to search through
+ * @returns Object containing filtered options and filter function
+ */
+export const useSelectSearch = (options: Ref<FormSelectOption[]>) => {
+  const optionsFiltered = ref<FormSelectOption[]>([]);
+
+  /**
+   * Filter function for select components
+   * Upon typing, find strings which contain query entered into the select
+   * @param val The search value
+   * @param update Function to update the filtered options
+   */
+  const onFilter = (val: string, update: (fn: () => void) => void) => {
+    update(() => {
+      const valLowerCase = val.toLocaleLowerCase();
+      optionsFiltered.value = options.value.filter(
+        (option) => option.label.toLocaleLowerCase().indexOf(valLowerCase) > -1,
+      );
+    });
+  };
+
+  // Watch for changes in source options and update filtered options with empty query
+  watch(
+    () => options,
+    () => {
+      optionsFiltered.value = options.value;
+    },
+    { immediate: true },
+  );
+
+  return {
+    optionsFiltered,
+    onFilter,
+  };
+};

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -697,7 +697,7 @@ describe('Register Challenge page', () => {
       // not on step 5
       cy.dataCy('step-5').find('.q-stepper__step-content').should('not.exist');
       // select address
-      cy.dataCy('form-company-address-input').click();
+      cy.dataCy('form-company-address').find('.q-field__append').last().click();
       // select subsidiary from dropdown
       cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
         cy.fixture('apiGetSubsidiariesResponseNext').then(
@@ -770,8 +770,8 @@ describe('Register Challenge page', () => {
           // verify dialog was closed
           cy.dataCy('dialog-add-address').should('not.exist');
           // verify the new address is selected in the dropdown
-          cy.dataCy('form-company-address-input')
-            .find('input')
+          cy.dataCy('form-company-address')
+            .find('.q-field__input')
             .invoke('val')
             .should('contain', subsidiaryRequest.address.street);
           // verify we can proceed to step 5
@@ -1514,7 +1514,7 @@ describe('Register Challenge page', () => {
       // participation is preselected - continue
       cy.dataCy('step-3-continue').should('be.visible').click();
       // organization is preselected - select address
-      cy.dataCy('form-company-address').should('be.visible').click();
+      cy.dataCy('form-company-address').find('.q-field__append').last().click();
       // select option
       cy.get('.q-menu')
         .should('be.visible')
@@ -2425,8 +2425,20 @@ function passToStep5() {
     .find('.q-radio')
     .first()
     .click();
+  cy.fixture('apiGetSubsidiariesResponse.json').then(
+    (apiGetSubsidiariesResponse) => {
+      cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+        (apiGetSubsidiariesResponseNext) => {
+          cy.waitForSubsidiariesApi(
+            apiGetSubsidiariesResponse,
+            apiGetSubsidiariesResponseNext,
+          );
+        },
+      );
+    },
+  );
   // select address
-  cy.dataCy('form-company-address-input').click();
+  cy.dataCy('form-company-address').find('.q-field__append').last().click();
   // select option
   cy.get('.q-menu')
     .should('be.visible')

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1319,10 +1319,6 @@ describe('Register Challenge page', () => {
       cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
         cy.fixture('apiGetSubsidiariesResponseNext').then(
           (subsidiariesResponseNext) => {
-            cy.waitForSubsidiariesApi(
-              subsidiariesResponse,
-              subsidiariesResponseNext,
-            );
             cy.waitForTeamsGetApi();
             // select first available team
             cy.dataCy('form-select-table-team')

--- a/test/cypress/fixtures/apiGetSubsidiariesResponse.json
+++ b/test/cypress/fixtures/apiGetSubsidiariesResponse.json
@@ -2,7 +2,6 @@
   "count": 20,
   "next": "https://test.dopracenakole.cz/rest/organizations/580/subsidiaries/?limit=20&offset=20",
   "previous": null,
-
   "results": [
     {
       "id": 1358,
@@ -20,9 +19,9 @@
       "address": {
         "street": "Krkonošská",
         "street_number": "177",
-        "recipient": "Vrchlabí",
-        "psc": "54301",
-        "city": "Vrchlabí"
+        "recipient": "Praha",
+        "psc": "10001",
+        "city": "Praha"
       },
       "teams": []
     },

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1998,10 +1998,10 @@ Cypress.Commands.add(
       .should('have.class', 'q-radio__inner--truthy');
     // address is preselected
     cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
-      cy.dataCy('form-company-address-input').should(
-        'contain',
-        subsidiariesResponse.results[0].address.street,
-      );
+      cy.dataCy('form-company-address')
+        .find('.q-field__input')
+        .invoke('val')
+        .should('contain', subsidiariesResponse.results[0].address.street);
       // go to next step
       cy.dataCy('step-4-continue').should('be.visible').click();
       // team is preselected


### PR DESCRIPTION
Add autocomplete functionality to `FormFieldCompanyAddress` component

* Create a `useSelectSearch` composable for common filtering method
* Use the new composable in `FormFieldCompany` and `FormFieldCompanyAddress`
* Update tests to handle `FormFieldCompanyAddress` menu open click.
* Update `FormSelectOrganization` team ID reset functionality to be triggered on model update, and check original value.
* Update `apiGetSubsidiariesResponse` to get rid of a confusing duplicate entry.