### PR TITLE
src/adapters: add adapter for GET subsidiary data to correctly display full address

### DIFF
--- a/src/adapters/subsidiaryAdapter.ts
+++ b/src/adapters/subsidiaryAdapter.ts
@@ -3,7 +3,9 @@ import type { FormCompanyAddressFields } from '../components/types/Form';
 import type {
   SubsidiaryPostApiPayload,
   SubsidiaryPostApiResponse,
+  SubsidiaryApi,
 } from '../components/types/ApiSubsidiary';
+import type { OrganizationSubsidiary } from '../components/types/Organization';
 
 /**
  * Adapter for converting between API and form subsidiary data formats
@@ -37,6 +39,25 @@ export const subsidiaryAdapter = {
       zip: String(apiData.address.psc),
       cityChallenge: apiData.city_id,
       department: apiData.address.recipient,
+    };
+  },
+
+  /**
+   * Convert API GET response to OrganizationSubsidiary format
+   */
+  fromApiPayloadGet(apiData: SubsidiaryApi): OrganizationSubsidiary {
+    return {
+      id: apiData.id,
+      teams: apiData.teams,
+      address: {
+        id: undefined,
+        street: apiData.address.street,
+        houseNumber: apiData.address.street_number,
+        city: apiData.address.city,
+        zip: String(apiData.address.psc),
+        cityChallenge: null,
+        department: apiData.address.recipient,
+      },
     };
   },
 

--- a/src/components/types/ApiSubsidiary.ts
+++ b/src/components/types/ApiSubsidiary.ts
@@ -2,6 +2,21 @@
  * API types for subsidiary-related operations
  */
 
+import type { OrganizationTeam } from './Organization';
+
+export interface GetSubsidiariesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: SubsidiaryApi[];
+}
+
+export interface SubsidiaryApi {
+  id: number;
+  address: SubsidiaryPostApiAddress;
+  teams: OrganizationTeam[];
+}
+
 export interface SubsidiaryPostApiAddress {
   street: string;
   street_number: string;

--- a/src/composables/useApiGetSubsidiaries.ts
+++ b/src/composables/useApiGetSubsidiaries.ts
@@ -13,16 +13,13 @@ import { useLoginStore } from '../stores/login';
 // types
 import type { Logger } from '../components/types/Logger';
 import type { OrganizationSubsidiary } from '../components/types/Organization';
+import type { GetSubsidiariesResponse } from '../components/types/ApiSubsidiary';
 
 // utils
 import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
-interface GetSubsidiariesResponse {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: OrganizationSubsidiary[];
-}
+// adapters
+import { subsidiaryAdapter } from '../adapters/subsidiaryAdapter';
 
 type UseApiGetSubsidiariesReturn = {
   subsidiaries: Ref<OrganizationSubsidiary[]>;
@@ -79,7 +76,9 @@ export const useApiGetSubsidiaries = (
     });
 
     if (data?.results?.length) {
-      subsidiaries.value.push(...data.results);
+      subsidiaries.value.push(
+        ...data.results.map(subsidiaryAdapter.fromApiPayloadGet),
+      );
     }
 
     // if data has multiple pages, fetch all pages
@@ -114,7 +113,9 @@ export const useApiGetSubsidiaries = (
 
     // store results
     if (data?.results?.length) {
-      subsidiaries.value.push(...data.results);
+      subsidiaries.value.push(
+        ...data.results.map(subsidiaryAdapter.fromApiPayloadGet),
+      );
     }
 
     // if data has multiple pages, fetch all pages

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -730,6 +730,16 @@ describe('Register Challenge page', () => {
         .find('.q-radio__label')
         .first()
         .click();
+      cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
+        cy.fixture('apiGetSubsidiariesResponseNext').then(
+          (subsidiariesResponseNext) => {
+            cy.waitForSubsidiariesApi(
+              subsidiariesResponse,
+              subsidiariesResponseNext,
+            );
+          },
+        );
+      });
       cy.fixture('apiPostSubsidiaryRequest').then((subsidiaryRequest) => {
         cy.fixture('apiPostSubsidiaryResponse').then((subsidiaryResponse) => {
           // open dialog

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -730,16 +730,6 @@ describe('Register Challenge page', () => {
         .find('.q-radio__label')
         .first()
         .click();
-      cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
-        cy.fixture('apiGetSubsidiariesResponseNext').then(
-          (subsidiariesResponseNext) => {
-            cy.waitForSubsidiariesApi(
-              subsidiariesResponse,
-              subsidiariesResponseNext,
-            );
-          },
-        );
-      });
       cy.fixture('apiPostSubsidiaryRequest').then((subsidiaryRequest) => {
         cy.fixture('apiPostSubsidiaryResponse').then((subsidiaryResponse) => {
           // open dialog

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2001,7 +2001,11 @@ Cypress.Commands.add(
       cy.dataCy('form-company-address')
         .find('.q-field__input')
         .invoke('val')
-        .should('contain', subsidiariesResponse.results[0].address.street);
+        .should('contain', subsidiariesResponse.results[0].address.street)
+        .and('contain', subsidiariesResponse.results[0].address.street_number)
+        .and('contain', subsidiariesResponse.results[0].address.recipient)
+        .and('contain', subsidiariesResponse.results[0].address.psc)
+        .and('contain', subsidiariesResponse.results[0].address.city);
       // go to next step
       cy.dataCy('step-4-continue').should('be.visible').click();
       // team is preselected


### PR DESCRIPTION
Add adapter for GET subsidiary data to correctly display full address.

Issue: When subsidiaries are loaded. Address is not displayed in full because of incorrect data structure

Solution: Add subsidiary get adapter to transcribe data from API into correct local data structure.

* Test that all subsidiary details are displayed.