### PR TITLE
src/stores: add payment_category and products to API POST request for organization payment

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -102,8 +102,13 @@ export const registerChallengeAdapter = {
       if (storeState.paymentAmount !== undefined) {
         payload.payment_amount = storeState.paymentAmount;
       }
+      if (storeState.paymentCategory) {
+        payload.payment_category = storeState.paymentCategory;
+      }
+      if (storeState.products) {
+        payload.products = storeState.products;
+      }
     }
-
     if (storeState.voucher) {
       payload.discount_coupon = storeState.voucher?.name;
     }

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -1,7 +1,7 @@
 import type { ValidatedCoupon } from './Coupon';
 import type { RegisterChallengePersonalDetailsForm } from './RegisterChallenge';
 import type { PaymentSubject } from '../enums/Payment';
-import type { PaymentCategory } from './ApiPayu';
+import type { PaymentCategory, PayuProduct } from './ApiPayu';
 
 // subset of personal details that can be sent in POST requests
 export type CorePersonalDetails = {
@@ -59,6 +59,8 @@ export type RegisterChallengePostPayload = {
   discount_coupon?: string;
   payment_subject?: string;
   payment_amount?: number | null;
+  payment_category?: PaymentCategory;
+  products?: PayuProduct[];
   team_id?: number | null;
   t_shirt_size_id?: number | null;
 };
@@ -75,6 +77,8 @@ export interface ToApiPayloadStoreState {
   personalDetails?: Partial<RegisterChallengePersonalDetailsForm>;
   paymentSubject?: PaymentSubject;
   paymentAmount?: number | null;
+  paymentCategory?: PaymentCategory;
+  products?: PayuProduct[];
   teamId?: number | null;
   merchId?: number | null;
   voucher?: ValidatedCoupon | null;

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -547,14 +547,28 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         },
         [RegisterChallengeStep.participation]: {},
         [RegisterChallengeStep.organization]: {},
-        [RegisterChallengeStep.team]: {
-          teamId: this.teamId,
-          // if payment subject is organization, we send payment subject and amount
-          paymentSubject: isPaymentOrganization ? this.paymentSubject : null,
-          paymentAmount: isPaymentOrganization
-            ? this.getDefaultPaymentAmountCompany
-            : null,
-        },
+        [RegisterChallengeStep.team]: isPaymentOrganization
+          ? /**
+             * If payment subject is organization, we send additional data
+             * paymentSubject - current payment subject
+             * paymentAmount - default payment amount for company
+             * paymentCategory - entry fee
+             * products - entry fee product
+             */
+            {
+              teamId: this.teamId,
+              paymentSubject: this.paymentSubject,
+              paymentAmount: this.getDefaultPaymentAmountCompany,
+              paymentCategory: PaymentCategory.entryFee,
+              products: [
+                {
+                  name: rideToWorkByBikeConfig.rtwbbChallengeEntryFeeOrderedProductName,
+                  unitPrice: this.getDefaultPaymentAmountCompany,
+                  quantity: 1,
+                },
+              ],
+            }
+          : { teamId: this.teamId },
         [RegisterChallengeStep.merch]: {
           merchId: this.merchId,
           telephone: this.telephone,

--- a/test/cypress/fixtures/apiPostRegisterChallengeTeamCompanyPaymentRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeTeamCompanyPaymentRequest.json
@@ -1,5 +1,13 @@
 {
   "payment_amount": 390,
   "payment_subject": "company",
+  "payment_category": "entry_fee",
+  "products": [
+    {
+      "name": "RTWBB challenge entry fee",
+      "unitPrice": 390,
+      "quantity": 1
+    }
+  ],
   "team_id": 2452
 }


### PR DESCRIPTION
Add `payment_category` and `products` fields to API POST request for organization payment.

* Add fields to adapter.
* Add fields to types.
* Add fields to data posted on Team step.
* Add fields to test fixture.