### PR TITLE
test/cypress/e2e: wait for subsidiaries before accessing select values to avoid no results failure

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1480,7 +1480,7 @@ describe('Register Challenge page', () => {
       });
     });
 
-    it('submits form state on 1st 2nd, 5th and 6th step (voucher payment)', () => {
+    it.only('submits form state on 1st 2nd, 5th and 6th step (voucher payment)', () => {
       cy.window().should('have.property', 'i18n');
       cy.get('@i18n').then((i18n) => {
         cy.get('@config').then((config) => {
@@ -1517,6 +1517,19 @@ describe('Register Challenge page', () => {
             .find('.q-radio')
             .first()
             .click();
+          // wait for subsidiaries to load
+          cy.fixture('apiGetSubsidiariesResponse.json').then(
+            (apiGetSubsidiariesResponse) => {
+              cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+                (apiGetSubsidiariesResponseNext) => {
+                  cy.waitForSubsidiariesApi(
+                    apiGetSubsidiariesResponse,
+                    apiGetSubsidiariesResponseNext,
+                  );
+                },
+              );
+            },
+          );
           // select address
           cy.dataCy('form-company-address').should('be.visible').click();
           // select option

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1480,7 +1480,7 @@ describe('Register Challenge page', () => {
       });
     });
 
-    it.only('submits form state on 1st 2nd, 5th and 6th step (voucher payment)', () => {
+    it('submits form state on 1st 2nd, 5th and 6th step (voucher payment)', () => {
       cy.window().should('have.property', 'i18n');
       cy.get('@i18n').then((i18n) => {
         cy.get('@config').then((config) => {


### PR DESCRIPTION
Add `waitForSubsidiariesApi` command before accessing address select values to avoid test failure caused by unavailable results.