### PR TITLE
src/stores: clear registerChallenge persistent store properties after logout

### DIFF
--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -18,6 +18,7 @@ import { routesConf } from '../router/routes_conf';
 // stores
 import { useRegisterStore } from './register';
 import { useChallengeStore } from './challenge';
+import { useRegisterChallengeStore } from './registerChallenge';
 
 // types
 import type { Logger } from '../components/types/Logger';
@@ -313,6 +314,9 @@ export const useLoginStore = defineStore('login', {
       this.$log?.debug(
         `Login store refresh token timeout <${this.getRefreshTokenTimeout}>.`,
       );
+      // clear registerChallenge store
+      const registerChallengeStore = useRegisterChallengeStore();
+      registerChallengeStore.resetPersistentProperties();
       // redirect to login page
       if (this.$router) {
         this.$log?.debug(

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -27,7 +27,6 @@ import { useApiIsUserOrganizationAdmin } from '../composables/useApiIsUserOrgani
 // enums
 import { Gender } from '../components/types/Profile';
 import { PaymentState } from '../components/enums/Payment';
-import { NewsletterType } from '../components/types/Newsletter';
 import {
   OrganizationSubsidiary,
   OrganizationType,
@@ -61,24 +60,14 @@ import type {
   RegisterChallengeResult,
   ToApiPayloadStoreState,
 } from '../components/types/ApiRegistration';
-import type { IpAddressResponse } from '../components/types/ApiIpAddress';
+
+// utils
 import { deepObjectWithSimplePropsCopy } from 'src/utils';
-
-const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
-  firstName: '',
-  lastName: '',
-  newsletter: [] as NewsletterType[],
-  nickname: '',
-  gender: null as Gender | null,
-  terms: true,
-};
-
-const emptyFormRegisterCoordinator: RegisterChallengeCoordinatorForm = {
-  jobTitle: '',
-  phone: '',
-  responsibility: false,
-  terms: false,
-};
+import {
+  emptyFormPersonalDetails,
+  emptyFormRegisterCoordinator,
+  getRegisterChallengeEmptyPersistentState,
+} from 'src/utils/get_register_challenge_empty_state';
 
 /**
  * Store for the register challenge page.
@@ -88,8 +77,8 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
   state: () => ({
     $log: null as Logger | null,
     personalDetails: deepObjectWithSimplePropsCopy(emptyFormPersonalDetails),
-    payment: null, // TODO: add data type options
     paymentAmount: null as number | null,
+    paymentCategory: PaymentCategory.none,
     paymentState: PaymentState.none,
     paymentSubject: PaymentSubject.individual,
     organizationType: OrganizationType.none,
@@ -109,20 +98,18 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     telephone: '',
     telephoneOptIn: false,
     isLoadingRegisterChallenge: false,
-    ipAddressData: null as IpAddressResponse | null,
     isLoadingSubsidiaries: false,
     isLoadingOrganizations: false,
     isLoadingTeams: false,
     isLoadingMerchandise: false,
     isLoadingFilteredMerchandise: false,
     isLoadingPayuOrder: false,
+    isLoadingUserOrganizationAdmin: false,
     isPayuTransactionInitiated: false,
     checkPaymentStatusRepetitionCount: 0,
     isSelectedRegisterCoordinator: false,
     hasOrganizationAdmin: null as boolean | null,
     isUserOrganizationAdmin: null as boolean | null,
-    isLoadingUserOrganizationAdmin: false,
-    paymentCategory: PaymentCategory.none,
   }),
 
   getters: {
@@ -219,8 +206,6 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       }
       return 0;
     },
-    getIpAddressData: (state): IpAddressResponse | null => state.ipAddressData,
-    getIpAddress: (state): string => state.ipAddressData?.ip || '',
     getIsPayuTransactionInitiated: (state): boolean =>
       state.isPayuTransactionInitiated,
     getIsPaymentCategoryDonation: (state): boolean => {
@@ -944,17 +929,41 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       );
       this.isLoadingUserOrganizationAdmin = false;
     },
+    /**
+     * Reset only persistent properties of the store to their initial empty state
+     * Non-persisted properties remain unchanged
+     */
+    resetPersistentProperties(): void {
+      const emptyPersistentState = getRegisterChallengeEmptyPersistentState();
+      this.$log?.debug(
+        `Reset registerChallenge persistent properties to <${JSON.stringify(
+          emptyPersistentState,
+          null,
+          2,
+        )}>.`,
+      );
+      this.$patch(deepObjectWithSimplePropsCopy(emptyPersistentState));
+    },
   },
 
   persist: {
     omit: [
+      '$log',
       'subsidiaries',
       'organizations',
       'teams',
       'merchandiseItems',
       'merchandiseCards',
-      'ipAddressData',
+      'isLoadingRegisterChallenge',
+      'isLoadingSubsidiaries',
+      'isLoadingOrganizations',
+      'isLoadingTeams',
+      'isLoadingMerchandise',
+      'isLoadingFilteredMerchandise',
+      'isLoadingPayuOrder',
       'checkPaymentStatusRepetitionCount',
+      'isUserOrganizationAdmin',
+      'isLoadingUserOrganizationAdmin',
     ],
   },
 });

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -21,7 +21,7 @@ export const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   newsletter: [] as NewsletterType[],
   nickname: '',
   gender: null as Gender | null,
-  terms: true,
+  terms: false,
 };
 
 export const emptyFormRegisterCoordinator: RegisterChallengeCoordinatorForm = {

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -3,6 +3,7 @@ import type {
   RegisterChallengePersonalDetailsForm,
   RegisterChallengeCoordinatorForm,
 } from '../components/types/RegisterChallenge';
+
 // enums
 import { Gender } from '../components/types/Profile';
 import { PaymentState } from '../components/enums/Payment';

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -1,0 +1,53 @@
+// types
+import type {
+  RegisterChallengePersonalDetailsForm,
+  RegisterChallengeCoordinatorForm,
+} from '../components/types/RegisterChallenge';
+// enums
+import { Gender } from '../components/types/Profile';
+import { PaymentState } from '../components/enums/Payment';
+import { PaymentSubject } from '../components/enums/Payment';
+import { OrganizationType } from '../components/types/Organization';
+import { PaymentCategory } from '../components/types/ApiPayu';
+import { NewsletterType } from '../components/types/Newsletter';
+
+// utils
+import { deepObjectWithSimplePropsCopy } from './index';
+
+export const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
+  firstName: '',
+  lastName: '',
+  newsletter: [] as NewsletterType[],
+  nickname: '',
+  gender: null as Gender | null,
+  terms: true,
+};
+
+export const emptyFormRegisterCoordinator: RegisterChallengeCoordinatorForm = {
+  jobTitle: '',
+  phone: '',
+  responsibility: false,
+  terms: false,
+};
+
+export const getRegisterChallengeEmptyPersistentState = () => ({
+  personalDetails: deepObjectWithSimplePropsCopy(emptyFormPersonalDetails),
+  paymentAmount: null,
+  paymentState: PaymentState.none,
+  paymentSubject: PaymentSubject.individual,
+  organizationType: OrganizationType.none,
+  organizationId: null,
+  subsidiaryId: null,
+  teamId: null,
+  merchId: null,
+  voucher: null,
+  formRegisterCoordinator: deepObjectWithSimplePropsCopy(
+    emptyFormRegisterCoordinator,
+  ),
+  telephone: '',
+  telephoneOptIn: false,
+  isPayuTransactionInitiated: false,
+  isSelectedRegisterCoordinator: false,
+  hasOrganizationAdmin: null,
+  paymentCategory: PaymentCategory.none,
+});

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1890,6 +1890,11 @@ describe('Register Challenge page', () => {
                 .find('.q-radio__label')
                 .first()
                 .click();
+              // agree with terms
+              cy.dataCy('form-personal-details-terms')
+                .find('.q-checkbox__inner')
+                .first()
+                .click();
               cy.dataCy('step-1-continue').should('be.visible').click();
               cy.dataCy('step-1-continue')
                 .find('.q-spinner')
@@ -1906,7 +1911,7 @@ describe('Register Challenge page', () => {
     it('does not allow to continue if fails to submit payment step', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           // override intercept for payment step POST request
           cy.interceptRegisterChallengePostApi(
             config,
@@ -1932,7 +1937,7 @@ describe('Register Challenge page', () => {
     it('does not allow to continue if fails to submit team step', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep5();
+          cy.passToStep5();
           // override intercept for team step POST request
           cy.interceptRegisterChallengePostApi(
             config,
@@ -1958,7 +1963,7 @@ describe('Register Challenge page', () => {
     it('does not allow to continue if fails to submit merchandise step', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep6();
+          cy.passToStep6();
           // override intercept for merchandise step POST request
           cy.interceptRegisterChallengePostApi(
             config,

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -377,6 +377,11 @@ describe('Register Challenge page', () => {
         .find('.q-radio__label')
         .first()
         .click();
+      // agree with terms
+      cy.dataCy('form-personal-details-terms')
+        .find('.q-checkbox__inner')
+        .first()
+        .click();
       // click
       cy.dataCy('step-1-continue').should('be.visible').click();
       // on step 2

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1767,7 +1767,7 @@ describe('Register Challenge page', () => {
       });
     });
 
-    it.only('allows to complete registration with voucher payment FULL', () => {
+    it('allows to complete registration with voucher payment FULL', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
           cy.passToStep2();

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -405,7 +405,7 @@ describe('Register Challenge page', () => {
               /**
                * Case: Individual payment - min amount
                */
-              passToStep2();
+              cy.passToStep2();
               // select individual payment
               cy.dataCy(getRadioOption(PaymentSubject.individual))
                 .should('be.visible')
@@ -519,7 +519,7 @@ describe('Register Challenge page', () => {
     it('allows to post company coordinator registration', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
             (responseIsUserOrganizationAdminFalse) => {
               // user status should reload
@@ -633,7 +633,7 @@ describe('Register Challenge page', () => {
     });
 
     it('validates third step (organization type)', () => {
-      passToStep3();
+      cy.passToStep3();
       checkActiveIcon(3);
 
       cy.dataCy('step-3-continue').should('be.visible').click();
@@ -647,7 +647,7 @@ describe('Register Challenge page', () => {
 
     it('pre-selects company in step 3 based on payment subject', () => {
       cy.get('@i18n').then((i18n) => {
-        passToStep2();
+        cy.passToStep2();
         // in payment step, select "paid by company"
         cy.dataCy(getRadioOption(OrganizationType.company))
           .should('be.visible')
@@ -669,7 +669,7 @@ describe('Register Challenge page', () => {
 
     it('pre-selects school in step 3 based on payment subject', () => {
       cy.get('@i18n').then((i18n) => {
-        passToStep2();
+        cy.passToStep2();
         // in payment step, select "paid by school"
         cy.dataCy(getRadioOption(OrganizationType.school))
           .should('be.visible')
@@ -690,7 +690,7 @@ describe('Register Challenge page', () => {
     });
 
     it('validates fourth step (organization and address)', () => {
-      passToStep4();
+      cy.passToStep4();
       checkActiveIcon(4);
 
       cy.dataCy('step-4-continue').should('be.visible').click();
@@ -732,7 +732,7 @@ describe('Register Challenge page', () => {
     });
 
     it('allows user to create a new subsidiary address', () => {
-      passToStep4();
+      cy.passToStep4();
       checkActiveIcon(4);
       // select company
       cy.dataCy('form-select-table-option')
@@ -793,7 +793,7 @@ describe('Register Challenge page', () => {
     });
 
     it('validates fifth step (team)', () => {
-      passToStep5();
+      cy.passToStep5();
       checkActiveIcon(5);
 
       // Try to continue without selecting a team
@@ -815,7 +815,7 @@ describe('Register Challenge page', () => {
 
     it('validates sixth step (merch)', () => {
       cy.get('@i18n').then((i18n) => {
-        passToStep6();
+        cy.passToStep6();
         checkActiveIcon(6);
         // by default, next step button is disabled
         cy.dataCy('step-6-continue').should('be.visible').and('be.disabled');
@@ -901,7 +901,7 @@ describe('Register Challenge page', () => {
     });
 
     it('allows user to create a new team', () => {
-      passToStep5();
+      cy.passToStep5();
       checkActiveIcon(5);
 
       // use formOrganizationOptions to get subsidiary id
@@ -945,7 +945,7 @@ describe('Register Challenge page', () => {
     });
 
     it('allows user to pass back and forth through stepper', () => {
-      passToStep7();
+      cy.passToStep7();
 
       // test back navigation in the stepper
       cy.dataCy('step-7-back').should('be.visible').click();
@@ -1020,7 +1020,7 @@ describe('Register Challenge page', () => {
     it('allows user to apply voucher HALF', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           // switch to paying via voucher
           cy.dataCy(getRadioOption(PaymentSubject.voucher))
             .should('be.visible')
@@ -1041,7 +1041,7 @@ describe('Register Challenge page', () => {
     it('allows user to apply voucher FULL', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           // switch to paying via voucher
           cy.dataCy(getRadioOption(PaymentSubject.voucher))
             .should('be.visible')
@@ -1057,7 +1057,7 @@ describe('Register Challenge page', () => {
     it('when company pays - disables other participation options', () => {
       cy.get('@i18n').then((i18n) => {
         // go to payment step
-        passToStep2();
+        cy.passToStep2();
         // select company
         cy.dataCy(getRadioOption(PaymentSubject.company))
           .should('be.visible')
@@ -1090,7 +1090,7 @@ describe('Register Challenge page', () => {
     it('when school pays - disables other participation options', () => {
       cy.get('@i18n').then((i18n) => {
         // go to payment step
-        passToStep2();
+        cy.passToStep2();
         // select school
         cy.dataCy(getRadioOption(PaymentSubject.school))
           .should('be.visible')
@@ -1119,7 +1119,7 @@ describe('Register Challenge page', () => {
 
     it('when individual payment - all participation options are enabled', () => {
       // go to payment step
-      passToStep2();
+      cy.passToStep2();
       // select individual
       cy.dataCy(getRadioOption(PaymentSubject.individual))
         .should('be.visible')
@@ -1136,7 +1136,7 @@ describe('Register Challenge page', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
           // go to payment step
-          passToStep2();
+          cy.passToStep2();
           // select voucher
           cy.dataCy(getRadioOption(PaymentSubject.voucher))
             .should('be.visible')
@@ -1160,7 +1160,7 @@ describe('Register Challenge page', () => {
     it('shows correct step title on organization step', () => {
       cy.get('@i18n').then((i18n) => {
         // go to step participation (organization type)
-        passToStep3();
+        cy.passToStep3();
         // select company
         cy.dataCy('form-field-option')
           .contains(i18n.global.t('form.participation.labelColleagues'))
@@ -1206,7 +1206,7 @@ describe('Register Challenge page', () => {
 
     it('shows correct summary data on summary step', () => {
       cy.get('@i18n').then((i18n) => {
-        passToStep7();
+        cy.passToStep7();
         // check personal details section
         cy.dataCy('summary-personal-name').should('contain', 'John Doe');
         cy.dataCy('summary-personal-gender').should(
@@ -1247,7 +1247,7 @@ describe('Register Challenge page', () => {
 
     it('validates coordinator form when user wants to become coordinator', () => {
       cy.get('@i18n').then((i18n) => {
-        passToStep2();
+        cy.passToStep2();
         // select company
         cy.dataCy(getRadioOption(PaymentSubject.company))
           .should('be.visible')
@@ -1317,7 +1317,7 @@ describe('Register Challenge page', () => {
     });
 
     it('reset organization, subsidiary and team on parent data change', () => {
-      passToStep5();
+      cy.passToStep5();
       cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
         cy.fixture('apiGetSubsidiariesResponseNext').then(
           (subsidiariesResponseNext) => {
@@ -1444,7 +1444,7 @@ describe('Register Challenge page', () => {
     it('when voucher FULL + donation, submits step before creating PayU order', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           cy.fixture(
             'apiPostRegisterChallengePersonalDetailsRequest.json',
           ).then((request) => {
@@ -1486,7 +1486,7 @@ describe('Register Challenge page', () => {
       cy.window().should('have.property', 'i18n');
       cy.get('@i18n').then((i18n) => {
         cy.get('@config').then((config) => {
-          passToStep2();
+          cy.passToStep2();
           // test API post request (personal details)
           cy.fixture(
             'apiPostRegisterChallengePersonalDetailsRequest.json',
@@ -1588,7 +1588,7 @@ describe('Register Challenge page', () => {
     });
 
     it('submits form state on 1st, 5th and 6th step (company payment)', () => {
-      passToStep2();
+      cy.passToStep2();
       // test API post request (personal details)
       cy.fixture('apiPostRegisterChallengePersonalDetailsRequest.json').then(
         (request) => {
@@ -1667,7 +1667,7 @@ describe('Register Challenge page', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
           // pass to step 2 (payment)
-          passToStep2();
+          cy.passToStep2();
 
           // case 1: individual payment
           cy.dataCy(getRadioOption(PaymentSubject.individual))
@@ -1767,10 +1767,10 @@ describe('Register Challenge page', () => {
       });
     });
 
-    it('allows to complete registration with voucher payment FULL', () => {
+    it.only('allows to complete registration with voucher payment FULL', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {
-          passToStep2();
+          cy.passToStep2();
           cy.dataCy(getRadioOption(PaymentSubject.voucher))
             .should('be.visible')
             .click();
@@ -2752,129 +2752,6 @@ describe('Register Challenge page', () => {
     });
   });
 });
-
-function passToStep2() {
-  cy.fixture('apiPostRegisterChallengePersonalDetailsRequest').then(
-    (personalDetailsRequest) => {
-      cy.dataCy('form-firstName-input').type(personalDetailsRequest.first_name);
-      cy.dataCy('form-lastName-input').type(personalDetailsRequest.last_name);
-      cy.dataCy('form-nickname-input').type(personalDetailsRequest.nickname);
-      cy.dataCy('newsletter-option').each((newsletterOption) => {
-        cy.wrap(newsletterOption).click();
-      });
-      cy.dataCy('form-personal-details-gender')
-        .find('.q-radio__label')
-        .first()
-        .click();
-      cy.dataCy('step-1-continue').should('be.visible').click();
-      cy.dataCy('step-1-continue').find('.q-spinner').should('be.visible');
-      // on step 2
-      cy.dataCy('step-2').find('.q-stepper__step-content').should('be.visible');
-    },
-  );
-}
-
-function passToStep3() {
-  cy.get('@config').then((config) => {
-    cy.get('@i18n').then((i18n) => {
-      passToStep2();
-      // payment - choose a free pass voucher
-      cy.dataCy(getRadioOption(PaymentSubject.voucher))
-        .should('be.visible')
-        .click();
-      cy.applyFullVoucher(config, i18n);
-      // next step button should be visible and enabled
-      cy.dataCy('step-2-continue').should('be.visible').click();
-      cy.dataCy('step-2-continue').find('.q-spinner').should('be.visible');
-      // on step 3
-      cy.dataCy('step-3').find('.q-stepper__step-content').should('be.visible');
-    });
-  });
-}
-
-function passToStep4() {
-  passToStep3();
-  cy.dataCy('form-field-option').first().click();
-  cy.dataCy('step-3-continue').should('be.visible').click();
-  // step 3 skip check for loading spinner (not sending data to API)
-  // on step 4
-  cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
-}
-
-function passToStep5() {
-  passToStep4();
-  // select company
-  cy.dataCy('form-select-table-company')
-    .should('be.visible')
-    .find('.q-radio')
-    .first()
-    .click();
-  cy.fixture('apiGetSubsidiariesResponse.json').then(
-    (apiGetSubsidiariesResponse) => {
-      cy.fixture('apiGetSubsidiariesResponseNext.json').then(
-        (apiGetSubsidiariesResponseNext) => {
-          cy.waitForSubsidiariesApi(
-            apiGetSubsidiariesResponse,
-            apiGetSubsidiariesResponseNext,
-          );
-        },
-      );
-    },
-  );
-  // select address
-  cy.dataCy('form-company-address').find('.q-field__append').last().click();
-  // select option
-  cy.get('.q-menu')
-    .should('be.visible')
-    .within(() => {
-      cy.get('.q-item').first().click();
-    });
-  cy.dataCy('step-4-continue').should('be.visible').click();
-  // step 4 skip check for loading spinner (not sending data to API)
-  // on step 5
-  cy.dataCy('step-5').find('.q-stepper__step-content').should('be.visible');
-}
-
-function passToStep6() {
-  passToStep5();
-  // select a team
-  cy.dataCy('form-select-table-team')
-    .should('be.visible')
-    .find('.q-radio:not(.disabled)')
-    .first()
-    .click();
-  cy.dataCy('step-5-continue').should('be.visible').click();
-  cy.dataCy('step-5-continue').find('.q-spinner').should('be.visible');
-  // on step 6
-  cy.dataCy('step-6').find('.q-stepper__step-content').should('be.visible');
-}
-
-function passToStep7() {
-  passToStep6();
-  cy.fixture('apiPostRegisterChallengeMerchandiseRequest').then((request) => {
-    // select merch
-    cy.dataCy('form-card-merch-female')
-      .first()
-      .find('[data-cy="form-card-merch-link"]')
-      .click();
-    // close dialog
-    cy.dataCy('dialog-close').click();
-    // verify dialog is closed
-    cy.dataCy('dialog-merch').should('not.exist');
-    // fill phone number
-    cy.dataCy('form-merch-phone-input')
-      .should('be.visible')
-      .find('input')
-      .type(request.telephone);
-    // opt in to info phone calls
-    cy.dataCy('form-merch-phone-opt-in-input').should('be.visible').click();
-    // go to next step
-    cy.dataCy('step-6-continue').should('be.visible').click();
-    cy.dataCy('step-6-continue').find('.q-spinner').should('be.visible');
-    // on step 7
-    cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
-  });
-}
 
 function checkActiveIcon(activeStep) {
   const steps = [1, 2, 3, 4, 5, 6, 7];

--- a/test/cypress/e2e/register_challenge_storage.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_storage.spec.cy.js
@@ -1,0 +1,180 @@
+import {
+  interceptOrganizationsApi,
+  interceptRegisterCoordinatorApi,
+} from '../support/commonTests';
+import { routesConf } from '../../../src/router/routes_conf';
+import { defLocale } from '../../../src/i18n/def_locale';
+import { getRegisterChallengeEmptyPersistentState } from '../../../src/utils/get_register_challenge_empty_state';
+import { OrganizationType } from '../../../src/components/types/Organization';
+
+describe('Register challenge storage', () => {
+  beforeEach(() => {
+    // clear local storage
+    cy.clearLocalStorage();
+    // load config
+    cy.task('getAppConfig', process).then((config) => {
+      // alias config
+      cy.wrap(config).as('config');
+
+      // intercept API calls
+      cy.interceptThisCampaignGetApi(config, defLocale);
+      cy.interceptRegisterChallengeGetApi(config, defLocale);
+
+      cy.fixture('formOrganizationOptions').then((formOrganizationOptions) => {
+        cy.fixture('formFieldCompany').then((formFieldCompanyResponse) => {
+          cy.fixture('apiPostRegisterChallengeResponsePaymentNone.json').then(
+            (registerChallengeResponse) => {
+              cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+                (responseIsUserOrganizationAdminFalse) => {
+                  interceptOrganizationsApi(
+                    config,
+                    defLocale,
+                    OrganizationType.company,
+                  );
+                  cy.interceptCitiesGetApi(config, defLocale);
+                  cy.interceptSubsidiariesGetApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[0].id,
+                  );
+                  // intercept query for subsidiaries of second organization
+                  cy.interceptSubsidiariesGetApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[1].id,
+                  );
+                  cy.interceptSubsidiaryPostApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[0].id,
+                  );
+                  // intercept teams for first subsidiary
+                  cy.interceptTeamsGetApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[0].subsidiaries[0].id,
+                  );
+                  // intercept teams for second subsidiary
+                  cy.interceptTeamsGetApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[0].subsidiaries[1].id,
+                  );
+                  cy.interceptTeamPostApi(
+                    config,
+                    defLocale,
+                    formOrganizationOptions[0].subsidiaries[0].id,
+                  );
+                  interceptOrganizationsApi(
+                    config,
+                    defLocale,
+                    OrganizationType.company,
+                  );
+                  interceptOrganizationsApi(
+                    config,
+                    defLocale,
+                    OrganizationType.school,
+                  );
+                  cy.interceptMerchandiseGetApi(config, defLocale);
+                  cy.interceptRegisterChallengePostApi(
+                    config,
+                    defLocale,
+                    registerChallengeResponse,
+                  );
+                  cy.interceptMerchandiseNoneGetApi(config, defLocale);
+                  cy.interceptIpAddressGetApi(config);
+                  cy.interceptPayuCreateOrderPostApi(config, defLocale);
+                  interceptRegisterCoordinatorApi(config, defLocale);
+                  cy.interceptIsUserOrganizationAdminGetApi(
+                    config,
+                    defLocale,
+                    responseIsUserOrganizationAdminFalse,
+                  );
+
+                  // for first organization, intercept API call with response true
+                  cy.fixture('apiGetHasOrganizationAdminResponseTrue').then(
+                    (response) => {
+                      cy.interceptHasOrganizationAdminGetApi(
+                        config,
+                        defLocale,
+                        formFieldCompanyResponse.results[0].id,
+                        response,
+                      );
+                    },
+                  );
+                  // for second organization, intercept API call with response false
+                  cy.fixture('apiGetHasOrganizationAdminResponseFalse').then(
+                    (response) => {
+                      cy.interceptHasOrganizationAdminGetApi(
+                        config,
+                        defLocale,
+                        formFieldCompanyResponse.results[1].id,
+                        response,
+                      );
+                    },
+                  );
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+    cy.viewport('macbook-16');
+    // config is defined without hash in the URL
+    cy.visit('#' + routesConf['register_challenge']['path']);
+    cy.window().should('have.property', 'i18n');
+    cy.window().then((win) => {
+      // alias i18n
+      cy.wrap(win.i18n).as('i18n');
+    });
+    // wait for loading of campaign data
+    cy.waitForThisCampaignApi();
+  });
+
+  it('handles local storage correctly during registration flow', () => {
+    // verify initial state of persistent properties of registerChallenge store
+    cy.window().then((win) => {
+      const store = JSON.parse(win.localStorage.getItem('registerChallenge'));
+      const emptyPersistentState = getRegisterChallengeEmptyPersistentState();
+      expect(store).to.deep.include(emptyPersistentState);
+    });
+
+    // go through registration
+    cy.passToStep7();
+
+    // verify state of persistent properties of registerChallenge store
+    cy.window().then((win) => {
+      const store = JSON.parse(win.localStorage.getItem('registerChallenge'));
+
+      cy.fixture('registerChallengeLocalStorageCompletedVoucherFull.json').then(
+        (persistentStateAfterRegistration) => {
+          expect(store).to.deep.include(persistentStateAfterRegistration);
+        },
+      );
+    });
+
+    // complete registration
+    cy.dataCy('step-7-continue').should('be.visible').click();
+
+    // verify we are on homepage
+    cy.dataCy('page-heading-title').should('be.visible');
+
+    // log out
+    cy.dataCy('user-select-desktop').within(() => {
+      cy.dataCy('user-select-input').should('be.visible').click();
+    });
+    cy.get('@i18n').then((i18n) => {
+      cy.dataCy('menu-item')
+        .contains(i18n.global.t('userSelect.logout'))
+        .click();
+    });
+
+    // verify that persistent properties of registerChallenge store are empty
+    cy.window().then((win) => {
+      const store = JSON.parse(win.localStorage.getItem('registerChallenge'));
+      const emptyPersistentState = getRegisterChallengeEmptyPersistentState();
+      expect(store).to.deep.include(emptyPersistentState);
+    });
+  });
+});

--- a/test/cypress/e2e/register_challenge_storage.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_storage.spec.cy.js
@@ -32,6 +32,7 @@ describe('Register challenge storage', () => {
                     OrganizationType.company,
                   );
                   cy.interceptCitiesGetApi(config, defLocale);
+                  // intercept query for subsidiaries of first organization
                   cy.interceptSubsidiariesGetApi(
                     config,
                     defLocale,

--- a/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
+++ b/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
@@ -1,0 +1,31 @@
+{
+  "personalDetails": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "newsletter": ["challenge", "events", "mobility"],
+    "nickname": "JD",
+    "gender": "male",
+    "terms": true
+  },
+  "paymentAmount": 0,
+  "paymentCategory": "",
+  "paymentState": "done",
+  "paymentSubject": "voucher",
+  "organizationType": "company",
+  "organizationId": 987,
+  "subsidiaryId": 1358,
+  "teamId": 2452,
+  "merchId": 133,
+  "voucher": { "valid": true, "discount": 100, "name": "ZD-CZBGSD" },
+  "formRegisterCoordinator": {
+    "jobTitle": "",
+    "phone": "",
+    "responsibility": false,
+    "terms": false
+  },
+  "telephone": "736123456",
+  "telephoneOptIn": true,
+  "isPayuTransactionInitiated": false,
+  "isSelectedRegisterCoordinator": false,
+  "hasOrganizationAdmin": true
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2304,6 +2304,10 @@ Cypress.Commands.add('passToStep2', () => {
         .find('.q-radio__label')
         .first()
         .click();
+      cy.dataCy('form-personal-details-terms')
+        .find('.q-checkbox__inner')
+        .first()
+        .click();
       cy.dataCy('step-1-continue').should('be.visible').click();
       cy.dataCy('step-1-continue').find('.q-spinner').should('be.visible');
       // on step 2

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -43,7 +43,7 @@ import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_
 import { bearerTokeAuth } from '../../../src/utils';
 import { OrganizationType } from '../../../src/components/types/Organization';
 import { routesConf } from '../../../src/router/routes_conf';
-import { getRadioOption } from 'test/cypress/utils';
+import { getRadioOption } from '../utils';
 import { PaymentSubject } from '../../../src/components/enums/Payment';
 
 // Fix for ResizeObserver loop issue in Firefox

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -43,6 +43,8 @@ import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_
 import { bearerTokeAuth } from '../../../src/utils';
 import { OrganizationType } from '../../../src/components/types/Organization';
 import { routesConf } from '../../../src/router/routes_conf';
+import { getRadioOption } from 'test/cypress/utils';
+import { PaymentSubject } from '../../../src/components/enums/Payment';
 
 // Fix for ResizeObserver loop issue in Firefox
 // see https://stackoverflow.com/questions/74947338/i-keep-getting-error-resizeobserver-loop-limit-exceeded-in-cypress
@@ -2288,3 +2290,133 @@ Cypress.Commands.add(
     );
   },
 );
+
+Cypress.Commands.add('passToStep2', () => {
+  cy.fixture('apiPostRegisterChallengePersonalDetailsRequest').then(
+    (personalDetailsRequest) => {
+      cy.dataCy('form-firstName-input').type(personalDetailsRequest.first_name);
+      cy.dataCy('form-lastName-input').type(personalDetailsRequest.last_name);
+      cy.dataCy('form-nickname-input').type(personalDetailsRequest.nickname);
+      cy.dataCy('newsletter-option').each((newsletterOption) => {
+        cy.wrap(newsletterOption).click();
+      });
+      cy.dataCy('form-personal-details-gender')
+        .find('.q-radio__label')
+        .first()
+        .click();
+      cy.dataCy('step-1-continue').should('be.visible').click();
+      cy.dataCy('step-1-continue').find('.q-spinner').should('be.visible');
+      // on step 2
+      cy.dataCy('step-2').find('.q-stepper__step-content').should('be.visible');
+    },
+  );
+});
+
+Cypress.Commands.add('passToStep3', () => {
+  cy.get('@config').then((config) => {
+    cy.get('@i18n').then((i18n) => {
+      cy.passToStep2();
+      // payment - choose a free pass voucher
+      cy.dataCy(getRadioOption(PaymentSubject.voucher))
+        .should('be.visible')
+        .click();
+      cy.applyFullVoucher(config, i18n);
+      // next step button should be visible and enabled
+      cy.dataCy('step-2-continue').should('be.visible').click();
+      cy.dataCy('step-2-continue').find('.q-spinner').should('be.visible');
+      // on step 3
+      cy.dataCy('step-3').find('.q-stepper__step-content').should('be.visible');
+
+      // override POST register-challenge response (payment status "done")
+      cy.fixture('apiPostRegisterChallengeResponsePaymentDone.json').then(
+        (response) => {
+          cy.interceptRegisterChallengePostApi(config, i18n, response);
+        },
+      );
+    });
+  });
+});
+
+Cypress.Commands.add('passToStep4', () => {
+  cy.passToStep3();
+  cy.dataCy('form-field-option').first().click();
+  cy.dataCy('step-3-continue').should('be.visible').click();
+  // step 3 skip check for loading spinner (not sending data to API)
+  // on step 4
+  cy.dataCy('step-4').find('.q-stepper__step-content').should('be.visible');
+});
+
+Cypress.Commands.add('passToStep5', () => {
+  cy.passToStep4();
+  // select company
+  cy.dataCy('form-select-table-company')
+    .should('be.visible')
+    .find('.q-radio')
+    .first()
+    .click();
+  cy.fixture('apiGetSubsidiariesResponse.json').then(
+    (apiGetSubsidiariesResponse) => {
+      cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+        (apiGetSubsidiariesResponseNext) => {
+          cy.waitForSubsidiariesApi(
+            apiGetSubsidiariesResponse,
+            apiGetSubsidiariesResponseNext,
+          );
+        },
+      );
+    },
+  );
+  // select address
+  cy.dataCy('form-company-address').find('.q-field__append').last().click();
+  // select option
+  cy.get('.q-menu')
+    .should('be.visible')
+    .within(() => {
+      cy.get('.q-item').first().click();
+    });
+  cy.dataCy('step-4-continue').should('be.visible').click();
+  // step 4 skip check for loading spinner (not sending data to API)
+  // on step 5
+  cy.dataCy('step-5').find('.q-stepper__step-content').should('be.visible');
+});
+
+Cypress.Commands.add('passToStep6', () => {
+  cy.passToStep5();
+  // select a team
+  cy.dataCy('form-select-table-team')
+    .should('be.visible')
+    .find('.q-radio:not(.disabled)')
+    .first()
+    .click();
+  cy.dataCy('step-5-continue').should('be.visible').click();
+  cy.dataCy('step-5-continue').find('.q-spinner').should('be.visible');
+  // on step 6
+  cy.dataCy('step-6').find('.q-stepper__step-content').should('be.visible');
+});
+
+Cypress.Commands.add('passToStep7', () => {
+  cy.passToStep6();
+  cy.fixture('apiPostRegisterChallengeMerchandiseRequest').then((request) => {
+    // select merch
+    cy.dataCy('form-card-merch-female')
+      .first()
+      .find('[data-cy="form-card-merch-link"]')
+      .click();
+    // close dialog
+    cy.dataCy('dialog-close').click();
+    // verify dialog is closed
+    cy.dataCy('dialog-merch').should('not.exist');
+    // fill phone number
+    cy.dataCy('form-merch-phone-input')
+      .should('be.visible')
+      .find('input')
+      .type(request.telephone);
+    // opt in to info phone calls
+    cy.dataCy('form-merch-phone-opt-in-input').should('be.visible').click();
+    // go to next step
+    cy.dataCy('step-6-continue').should('be.visible').click();
+    cy.dataCy('step-6-continue').find('.q-spinner').should('be.visible');
+    // on step 7
+    cy.dataCy('step-7').find('.q-stepper__step-content').should('be.visible');
+  });
+});


### PR DESCRIPTION
Contributes to fixing [Bug 21](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=21)
Clear `registerChallenge` persistent store properties after logout.

* Specify which properties should be persistent in `registerChallenge` by updating the `omit` array.
* Remove outdated and unused properties `payment` and `ipAddressData`.
* Define a new util function returning empty state for persistent properties.
* Use the empty state to reset `registerChallenge` store after logging out.
* Add a `register_challenge_storage.spec` file with test for the storage function.
* Refactor `passToStepX` functions from `register_challenge.spec` file, into Cypress commands so they can be shared.