### PR TITLE
src/composables: validate register challenge submitStep responses before allowing to continue

### DIFF
--- a/src/composables/useStepperValidation.ts
+++ b/src/composables/useStepperValidation.ts
@@ -55,10 +55,13 @@ export const useStepperValidation = ({
         const isValidPersonalDetails: boolean =
           await stepPersonalDetailsRef.value.validate();
         if (isValidPersonalDetails) {
-          await registerChallengeStore.submitStep(
+          const response = await registerChallengeStore.submitStep(
             RegisterChallengeStep.personalDetails,
           );
-          stepperRef.value.next();
+          // only if there is a valid response go next
+          if (response) {
+            stepperRef.value.next();
+          }
         } else {
           stepPersonalDetailsRef.value.$el.scrollIntoView({
             behavior: 'smooth',
@@ -70,12 +73,15 @@ export const useStepperValidation = ({
         if (!stepPaymentRef.value) return;
         const isValidPayment: boolean = await stepPaymentRef.value.validate();
         if (isValidPayment) {
-          await registerChallengeStore.submitStep(
+          const response = await registerChallengeStore.submitStep(
             RegisterChallengeStep.payment,
           );
           // register coordinator action (runs only if selected by user)
           await registerChallengeStore.registerCoordinator();
-          stepperRef.value.next();
+          // only if there is a valid response go next
+          if (response) {
+            stepperRef.value.next();
+          }
         } else {
           stepPaymentRef.value.$el.scrollIntoView({ behavior: 'smooth' });
         }
@@ -108,8 +114,13 @@ export const useStepperValidation = ({
         if (!stepTeamRef.value) return;
         const isValidTeam: boolean = await stepTeamRef.value.validate();
         if (isValidTeam) {
-          await registerChallengeStore.submitStep(RegisterChallengeStep.team);
-          stepperRef.value.next();
+          const response = await registerChallengeStore.submitStep(
+            RegisterChallengeStep.team,
+          );
+          // only if there is a valid response go next
+          if (response) {
+            stepperRef.value.next();
+          }
         } else {
           stepTeamRef.value.$el.scrollIntoView({ behavior: 'smooth' });
         }
@@ -119,8 +130,13 @@ export const useStepperValidation = ({
         if (!stepMerchRef.value) return;
         const isValidMerch: boolean = await stepMerchRef.value.validate();
         if (isValidMerch) {
-          await registerChallengeStore.submitStep(RegisterChallengeStep.merch);
-          stepperRef.value.next();
+          const response = await registerChallengeStore.submitStep(
+            RegisterChallengeStep.merch,
+          );
+          // only if there is a valid response go next
+          if (response) {
+            stepperRef.value.next();
+          }
         } else {
           stepMerchRef.value.$el.scrollIntoView({ behavior: 'smooth' });
         }

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -522,7 +522,8 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     /**
      * Submit a registration step
-     * @param step - The step being submitted
+     * @param {RegisterChallengeStep} step - The step being submitted
+     * @returns {Promise<RegisterChallengePostResponse | null | true>} - API response or true if no data to send
      */
     async submitStep(
       step: RegisterChallengeStep,

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -526,7 +526,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
      */
     async submitStep(
       step: RegisterChallengeStep,
-    ): Promise<RegisterChallengePostResponse | null> {
+    ): Promise<RegisterChallengePostResponse | null | true> {
       // payload map defines what data is sent to the API for each step
       const isPaymentOrganization = this.getIsPaymentSubjectOrganization;
       /**
@@ -587,7 +587,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         this.$log?.debug(
           `Empty payload <${JSON.stringify(payload, null, 2)}>, skipping API call.`,
         );
-        return null;
+        /**
+         * If request does not send because of empty payload
+         * (paymentSubject company and no voucher)
+         * return true for free pass through stepper response validation
+         */
+        return true;
       }
       // post payload to API
       return this.postRegisterChallenge(payload);


### PR DESCRIPTION
Contributes to fixing [Bug 53](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=53)
Validate register challenge `submitStep` responses before allowing to continue to next step of registration.
Add tests for "BadRequest" status code responses at different points of registration.