### PR TITLE
src/components: add notification messages for registration step summary

### DIFF
--- a/src/components/__tests__/RegisterChallengePaymentMessages.cy.js
+++ b/src/components/__tests__/RegisterChallengePaymentMessages.cy.js
@@ -11,194 +11,346 @@ describe('<RegisterChallengePaymentMessages>', () => {
         'textPayuPaymentFailed',
         'textPayuWaitingForPayment',
         'textRegistrationWaitingForConfirmation',
+        'textRegistrationWaitingForConfirmationNoCoordinator',
+        'textRegistrationWaitingForCoordinator',
       ],
       'register.challenge',
       i18n,
     );
   });
 
-  context('desktop', () => {
+  context('payment step', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       cy.mount(RegisterChallengePaymentMessages, {
-        props: {},
+        props: {
+          isPaymentStep: true,
+        },
       });
       cy.viewport('macbook-16');
     });
 
-    coreTests();
+    it('renders no messages for company no_admission', () => {
+      cy.fixture('apiGetRegisterChallengeCompanyNoAdmission.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders waiting for coordinator message for company waiting', () => {
+      cy.fixture('apiGetRegisterChallengeCompanyWaiting.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      cy.dataCy('registration-waiting-for-confirmation')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t(
+            'register.challenge.textRegistrationWaitingForConfirmation',
+          ),
+        );
+    });
+
+    it('renders waiting for coordinator and donation success messages for company waiting with donation', () => {
+      cy.fixture('apiGetRegisterChallengeCompanyWaitingWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      cy.dataCy('registration-waiting-for-confirmation')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t(
+            'register.challenge.textRegistrationWaitingForConfirmation',
+          ),
+        );
+      cy.dataCy('registration-donation-payment-successful')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
+        );
+    });
+
+    it('renders no messages for individual no_admission', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualNoAdmission.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders waiting for payment message for individual not paid', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualNotPaid.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+            store.setIsPayuTransactionInitiated(true);
+          });
+        },
+      );
+      cy.dataCy('registration-payu-waiting-for-payment')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textPayuWaitingForPayment'),
+        );
+    });
+
+    it('renders no messages for individual paid', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualPaid.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders donation success message for individual paid with donation', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualPaidWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      cy.dataCy('registration-donation-payment-successful')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
+        );
+    });
+
+    it('renders payment failed message for individual unknown', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualUnknown.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      cy.dataCy('registration-payu-payment-failed')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textPayuPaymentFailed'),
+        );
+    });
+
+    it('renders no messages for voucher full', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherFull.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders donation success message for voucher full with donation', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherFullWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      cy.dataCy('registration-donation-payment-successful')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
+        );
+    });
+
+    it('renders no messages for voucher half', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherHalf.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders donation success message for voucher half with donation', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherHalfWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      cy.dataCy('registration-donation-payment-successful')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
+        );
+    });
+  });
+
+  context('summary step', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.mount(RegisterChallengePaymentMessages, {
+        props: {
+          isPaymentStep: false,
+        },
+      });
+    });
+
+    it('renders message waiting for company coordinator approval', () => {
+      cy.fixture('apiGetRegisterChallengeCompanyWaiting.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+          store.setHasOrganizationAdmin(true);
+        });
+      });
+      cy.dataCy('registration-waiting-for-coordinator')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t(
+            'register.challenge.textRegistrationWaitingForCoordinator',
+          ),
+        );
+    });
+
+    it('renders message company has no coordinator', () => {
+      cy.fixture('apiGetRegisterChallengeCompanyWaiting.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+          store.setHasOrganizationAdmin(false);
+        });
+      });
+      cy.dataCy('registration-waiting-for-confirmation-no-coordinator')
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t(
+            'register.challenge.textRegistrationWaitingForConfirmationNoCoordinator',
+          ),
+        );
+    });
+
+    it('renders no messages for individual no_admission', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualNoAdmission.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for individual not paid', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualNotPaid.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+            store.setIsPayuTransactionInitiated(true);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for individual paid', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualPaid.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for individual paid with donation', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualPaidWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for individual unknown', () => {
+      cy.fixture('apiGetRegisterChallengeIndividualUnknown.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for voucher full', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherFull.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for voucher full with donation', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherFullWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for voucher half', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherHalf.json').then((data) => {
+        cy.wrap(useRegisterChallengeStore()).then((store) => {
+          store.setRegisterChallengeFromApi(data.results[0]);
+        });
+      });
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
+
+    it('renders no messages for voucher half with donation', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherHalfWithDonation.json').then(
+        (data) => {
+          cy.wrap(useRegisterChallengeStore()).then((store) => {
+            store.setRegisterChallengeFromApi(data.results[0]);
+          });
+        },
+      );
+      // no messages
+      cy.get('.q-banner').should('not.exist');
+    });
   });
 });
-
-function coreTests() {
-  it('renders no messages for company no_admission', () => {
-    cy.fixture('apiGetRegisterChallengeCompanyNoAdmission.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    // no messages
-    cy.get('.q-banner').should('not.exist');
-  });
-
-  it('renders waiting for coordinator message for company waiting', () => {
-    cy.fixture('apiGetRegisterChallengeCompanyWaiting.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-      });
-    });
-    cy.dataCy('registration-waiting-for-coordinator-message')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t(
-          'register.challenge.textRegistrationWaitingForConfirmation',
-        ),
-      );
-  });
-
-  it('renders waiting for coordinator and donation success messages for company waiting with donation', () => {
-    cy.fixture('apiGetRegisterChallengeCompanyWaitingWithDonation.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    cy.dataCy('registration-waiting-for-coordinator-message')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t(
-          'register.challenge.textRegistrationWaitingForConfirmation',
-        ),
-      );
-    cy.dataCy('registration-donation-payment-successful')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
-      );
-  });
-
-  it('renders no messages for individual no_admission', () => {
-    cy.fixture('apiGetRegisterChallengeIndividualNoAdmission.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    // no messages
-    cy.get('.q-banner').should('not.exist');
-  });
-
-  it('renders waiting for payment message for individual not paid', () => {
-    cy.fixture('apiGetRegisterChallengeIndividualNotPaid.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-        store.setIsPayuTransactionInitiated(true);
-      });
-    });
-    cy.dataCy('registration-waiting-for-payment-confirmation-message')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textPayuWaitingForPayment'),
-      );
-  });
-
-  it('renders no messages for individual paid', () => {
-    cy.fixture('apiGetRegisterChallengeIndividualPaid.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-      });
-    });
-    // no messages
-    cy.get('.q-banner').should('not.exist');
-  });
-
-  it('renders donation success message for individual paid with donation', () => {
-    cy.fixture('apiGetRegisterChallengeIndividualPaidWithDonation.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    cy.dataCy('registration-donation-payment-successful')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
-      );
-  });
-
-  it('renders payment failed message for individual unknown', () => {
-    cy.fixture('apiGetRegisterChallengeIndividualUnknown.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-      });
-    });
-    cy.dataCy('registration-payu-payment-failed')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textPayuPaymentFailed'),
-      );
-  });
-
-  it('renders no messages for voucher full', () => {
-    cy.fixture('apiGetRegisterChallengeVoucherFull.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-      });
-    });
-    // no messages
-    cy.get('.q-banner').should('not.exist');
-  });
-
-  it('renders donation success message for voucher full with donation', () => {
-    cy.fixture('apiGetRegisterChallengeVoucherFullWithDonation.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    cy.dataCy('registration-donation-payment-successful')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
-      );
-  });
-
-  it('renders no messages for voucher half', () => {
-    cy.fixture('apiGetRegisterChallengeVoucherHalf.json').then((data) => {
-      cy.wrap(useRegisterChallengeStore()).then((store) => {
-        store.setRegisterChallengeFromApi(data.results[0]);
-      });
-    });
-    // no messages
-    cy.get('.q-banner').should('not.exist');
-  });
-
-  it('renders donation success message for voucher half with donation', () => {
-    cy.fixture('apiGetRegisterChallengeVoucherHalfWithDonation.json').then(
-      (data) => {
-        cy.wrap(useRegisterChallengeStore()).then((store) => {
-          store.setRegisterChallengeFromApi(data.results[0]);
-        });
-      },
-    );
-    cy.dataCy('registration-donation-payment-successful')
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('register.challenge.textDonationPaymentSuccessful'),
-      );
-  });
-}

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -781,6 +781,8 @@ textPayuPaymentFailed = "Vaše platba byla zrušena nebo zamítnuta.  Můžete s
 textDonationPaymentSuccessful = "Vaše platba byla zpracována a benefiční příspěvek byl uhrazen. Děkujeme."
 textRegistrationPaid = "Startovné máte uhrazeno a po dokončení registrace můžete začít s výzvou. Máte-li otázky k platbě nebo jiným bodům registrace, můžete nás kontaktovat na <a href='mailto:{contactEmail}'>{contactEmail}</a>."
 textRegistrationWaitingForConfirmation = "Platbu vašeho startovného musí schválit koordinátor vybrané organizace. Prosím, zadejte adresu a tým, abychom mohli identifikovat vaši koordinátora*ku."
+textRegistrationWaitingForConfirmationNoCoordinator = "Vaše organizace ještě nemá firemního koordinátora, který by schválil vaší platbu. Zkuste proces popohnat, nebo se můžete stát koordinátorem sami."
+textRegistrationWaitingForCoordinator = "Platbu ještě musí schválit koordinátor vaší organizace."
 textPayuWaitingForPayment = "Vaši platbu stále zpracováváme. Prosím zkontrolujte stav registrace za několik minut."
 textTeamInfo = "V jednom týmu může být max. 5 členů."
 titleDeliveryAddress = "Doručovací adresa"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -776,6 +776,8 @@ textPayuPaymentFailed = "Your payment was canceled or rejected. You can try to p
 textDonationPaymentSuccessful = "Your payment was processed and the donation was paid. Thank you."
 textRegistrationPaid = "Your entry fee has been paid and you can start the challenge after completing registration. If you have any questions about the payment or other registration points, you can contact us at <a href='mailto:{contactEmail}'>{contactEmail}</a>."
 textRegistrationWaitingForConfirmation = "The payment of your entry fee must be approved by the coordinator of the selected organization. Please continue to select address and team, so we can identify your coordinator."
+textRegistrationWaitingForConfirmationNoCoordinator = "Your organization does not yet have a company coordinator to approve your payment. Try to speed up the process, or you can become a coordinator yourself."
+textRegistrationWaitingForCoordinator = "Your payment still needs to be approved by your organization's coordinator."
 textPayuWaitingForPayment = "We are still processing your payment. Please check your registration status in a few minutes."
 textTeamInfo = "In one team, there can be a maximum of 5 members."
 titleDeliveryAddress = "Delivery address"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -776,6 +776,8 @@ textPayuPaymentFailed = "Vaša platba bola zrušená alebo zamietnutá. Môžete
 textDonationPaymentSuccessful = "Vaša platba bola zpracovaná a benefíčny príspevok bol uhradený. Ďakujeme."
 textRegistrationPaid = "Štartovné máte uhradené a po dokončení registrácie môžete začať s výzvou. Ak máte otázky k platbe alebo iným bodom registrácie, môžete nás kontaktovať na <a href='mailto:{contactEmail}'>{contactEmail}</a>."
 textRegistrationWaitingForConfirmation = "Platbu vášho štartovného musí schváliť koordinátor vybranej organizácie. Prosím, zadejte adresu a tím, aby sme mohli identifikovať vášho koordinátora."
+textRegistrationWaitingForConfirmationNoCoordinator = "Vaša organizácia ešte nemá firemného koordinátora, ktorý by schválil vašu platbu. Skúste proces popohnať, alebo sa môžete stať koordinátorom sami."
+textRegistrationWaitingForCoordinator = "Platbu ešte musí schváliť koordinátor vašej organizácie."
 textPayuWaitingForPayment = "Vašu platbu stále spracovávame. Prosím skontrolujte stav registrácie o niekoľko minút."
 textTeamInfo = "V jednom tíme může být max. 5 členů."
 titleDeliveryAddress = "Doručovacia adresa"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -461,7 +461,10 @@ export default defineComponent({
             <!-- Form: Payment -->
             <q-form ref="stepPaymentRef">
               <!-- Payment messages -->
-              <register-challenge-payment-messages data-cy="payment-messages" />
+              <register-challenge-payment-messages
+                :is-payment-step="true"
+                data-cy="payment-messages"
+              />
               <!-- Text entry fee paid (displayed after PayU payment has been made) -->
               <div
                 v-if="isRegistrationEntryFeePaidViaPayu"
@@ -699,6 +702,7 @@ export default defineComponent({
             class="bg-white q-mt-lg"
             data-cy="step-7"
           >
+            <register-challenge-payment-messages data-cy="summary-messages" />
             <!-- Content: Summary -->
             <register-challenge-summary />
             <!-- Buttons: Summary -->


### PR DESCRIPTION
Fixes [Bug 16](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=16)
Add notification messages for registration step summary.

* Add message when "waiting for coordinator confirmation and organization has coordinator"
* Add message when "waiting for coordinator confirmation and organization does not have coordinator"
* Add prop to messages component and test different contexts
* Test messages in E2E tests.