### PR TITLE
src/components: disable other company options than the selected when payment subject is company

### DIFF
--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -143,9 +143,13 @@ export default defineComponent({
         if (newValue !== oldValue) {
           logger?.debug(
             `Selected subsidiary changed from <${oldValue}>` +
-              ` to <${newValue}>. Setting selectedSubsidiary`,
+              ` to <${newValue}>.`,
           );
           setSelectedSubsidiary();
+          logger?.debug(
+            'Set subsidiary form field option to' +
+              ` <${JSON.stringify(selectedSubsidiary.value, null, 2)}>.`,
+          );
         }
       },
     );
@@ -300,7 +304,7 @@ export default defineComponent({
         {{ labelAddress }}
       </label>
       <div class="col-12 col-sm" data-cy="col-input">
-        <!-- Input: Autocomplete -->
+        <!-- Subsidiary input: Autocomplete -->
         <q-select
           dense
           outlined

--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -124,6 +124,7 @@ export default defineComponent({
         );
       }
     });
+    // on selectedSubsidiary change, emit new value as update:modelValue
     watch(selectedSubsidiary, (newValue, oldValue) => {
       logger?.debug(
         `Selected subsidiary changed from <${JSON.stringify(oldValue, null, 2)}>` +
@@ -135,6 +136,19 @@ export default defineComponent({
         emit('update:modelValue', null);
       }
     });
+    // on props.modelValue change, set select value
+    watch(
+      () => props.modelValue,
+      (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          logger?.debug(
+            `Selected subsidiary changed from <${oldValue}>` +
+              ` to <${newValue}>. Setting selectedSubsidiary`,
+          );
+          setSelectedSubsidiary();
+        }
+      },
+    );
 
     const options = computed<FormSelectOption[]>((): FormSelectOption[] =>
       store.getSubsidiaries?.map(

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -410,13 +410,31 @@ export default defineComponent({
       selectOrganizationRef,
     });
 
+    // return true if this is organization select and company is paying
+    const isThisSelectOrganizationAndOrganizationPaying = computed<boolean>(
+      (): boolean => {
+        const isOrganizationSelect: boolean =
+          props.organizationLevel === OrganizationLevel.organization;
+        const isOrganizationPaying: boolean =
+          registerChallengeStore.getIsPaymentSubjectOrganization;
+        return isOrganizationSelect && isOrganizationPaying;
+      },
+    );
+
     const isDisabledOption = (option: FormSelectTableOption): boolean => {
+      // if team select and team has max members
       if (props.organizationLevel === OrganizationLevel.team) {
         if (option?.members && option?.maxMembers) {
           return option.members.length >= option.maxMembers;
         }
       }
-      return false;
+      const organizationId: number | null =
+        registerChallengeStore.getOrganizationId;
+      // if this is other than active option and paying company is selected
+      return (
+        isThisSelectOrganizationAndOrganizationPaying.value &&
+        option.value !== organizationId
+      );
     };
 
     return {
@@ -434,6 +452,7 @@ export default defineComponent({
       teamNew,
       titleDialog,
       isDisabledOption,
+      isThisSelectOrganizationAndOrganizationPaying,
       isFilled,
       isLoading,
       virtualScrollRef,
@@ -571,6 +590,7 @@ export default defineComponent({
             icon="mdi-plus"
             color="primary"
             data-cy="button-add-option"
+            :disable="isThisSelectOrganizationAndOrganizationPaying"
             @click.prevent="isDialogOpen = true"
           >
             <!-- Label -->

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -62,9 +62,8 @@ export default defineComponent({
         registerChallengeStore.getOrganizationId
           ? registerChallengeStore.getOrganizationId
           : null,
-      set: (value: number | null) => {
-        registerChallengeStore.setOrganizationId(value);
-      },
+      set: (value: number | null) =>
+        registerChallengeStore.setOrganizationId(value),
     });
 
     const subsidiaryId = computed<number | null>({

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -63,20 +63,6 @@ export default defineComponent({
           ? registerChallengeStore.getOrganizationId
           : null,
       set: (value: number | null) => {
-        /**
-         * Reset subsidiaryId if new value is different from current value
-         * to avoid reset on component mount.
-         */
-        logger?.debug(
-          `Organization ID change to <${value}>, current value is <${registerChallengeStore.getOrganizationId}>.`,
-        );
-        if (value !== registerChallengeStore.getOrganizationId) {
-          registerChallengeStore.setSubsidiaryId(null);
-          logger?.debug(
-            'Organization ID change, reset' +
-              ` subsidiary ID <${registerChallengeStore.getSubsidiaryId}>.`,
-          );
-        }
         registerChallengeStore.setOrganizationId(value);
       },
     });

--- a/src/components/form/FormSelectOrganization.vue
+++ b/src/components/form/FormSelectOrganization.vue
@@ -62,8 +62,23 @@ export default defineComponent({
         registerChallengeStore.getOrganizationId
           ? registerChallengeStore.getOrganizationId
           : null,
-      set: (value: number | null) =>
-        registerChallengeStore.setOrganizationId(value),
+      set: (value: number | null) => {
+        /**
+         * Reset subsidiaryId if new value is different from current value
+         * to avoid reset on component mount.
+         */
+        logger?.debug(
+          `Organization ID change to <${value}>, current value is <${registerChallengeStore.getOrganizationId}>.`,
+        );
+        if (value !== registerChallengeStore.getOrganizationId) {
+          registerChallengeStore.setSubsidiaryId(null);
+          logger?.debug(
+            'Organization ID change, reset' +
+              ` subsidiary ID <${registerChallengeStore.getSubsidiaryId}>.`,
+          );
+        }
+        registerChallengeStore.setOrganizationId(value);
+      },
     });
 
     const subsidiaryId = computed<number | null>({

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -198,8 +198,18 @@ export default defineComponent({
         registerChallengeStore.getOrganizationId
           ? registerChallengeStore.getOrganizationId
           : null,
-      set: (value: number | null) =>
-        registerChallengeStore.setOrganizationId(value),
+      set: (value: number | null) => {
+        if (value !== registerChallengeStore.getOrganizationId) {
+          // reset subsidiaryId
+          registerChallengeStore.setSubsidiaryId(null);
+          // reset teamId
+          registerChallengeStore.setTeamId(null);
+          // reset organizationId
+          registerChallengeStore.setOrganizationId(value);
+          // refetch subsidiaries
+          registerChallengeStore.loadSubsidiariesToStore(logger);
+        }
+      },
     });
     onMounted(() => {
       // following two checks can run in parallel

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1061,63 +1061,163 @@ describe('Register Challenge page', () => {
 
     it('when company pays - disables other participation options', () => {
       cy.get('@i18n').then((i18n) => {
-        // go to payment step
-        cy.passToStep2();
-        // select company
-        cy.dataCy(getRadioOption(PaymentSubject.company))
-          .should('be.visible')
-          .click();
-        // select paying company (required)
-        cy.selectRegisterChallengePayingOrganization();
-        // go to next step
-        cy.dataCy('step-2-continue').should('be.visible').click();
-        // other participation options are disabled
-        cy.dataCy('form-field-option-group').within(() => {
-          // one active option - company
-          cy.get('.q-radio:not(.disabled)')
-            .should('have.length', 1)
-            .and(
-              'contain',
-              i18n.global.t('form.participation.labelColleagues'),
-            );
-          // two disabled options - school and family
-          cy.get('.q-radio.disabled')
-            .should('have.length', 2)
-            .and(
-              'contain',
-              i18n.global.t('form.participation.labelSchoolmates'),
-            )
-            .and('contain', i18n.global.t('form.participation.labelFamily'));
+        cy.get('@allOrganizations').then((allOrganizations) => {
+          // go to payment step
+          cy.passToStep2();
+          // select company
+          cy.dataCy(getRadioOption(PaymentSubject.company))
+            .should('be.visible')
+            .click();
+          // select paying company (required)
+          cy.selectRegisterChallengePayingOrganization();
+          // go to next step
+          cy.dataCy('step-2-continue').should('be.visible').click();
+          // other participation options are disabled
+          cy.dataCy('form-field-option-group').within(() => {
+            // one active option - company
+            cy.get('.q-radio:not(.disabled)')
+              .should('have.length', 1)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelColleagues'),
+              );
+            // two disabled options - school and family
+            cy.get('.q-radio.disabled')
+              .should('have.length', 2)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelSchoolmates'),
+              )
+              .and('contain', i18n.global.t('form.participation.labelFamily'));
+          });
+          // go to next step
+          cy.dataCy('step-3-continue').should('be.visible').click();
+          // organization #1 is preselected
+          cy.dataCy('form-select-table-company')
+            .find('.q-radio__inner.q-radio__inner--truthy')
+            .siblings('.q-radio__label')
+            .should('contain', allOrganizations[0].name);
+          // all other options are disabled
+          cy.dataCy('form-select-table-company')
+            .find('.q-radio.disabled')
+            .should('have.length', allOrganizations.length - 1);
+          // select address
+          cy.fixture('apiGetSubsidiariesResponse.json').then(
+            (apiGetSubsidiariesResponse) => {
+              cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+                (apiGetSubsidiariesResponseNext) => {
+                  cy.waitForSubsidiariesApi(
+                    apiGetSubsidiariesResponse,
+                    apiGetSubsidiariesResponseNext,
+                  );
+                },
+              );
+            },
+          );
+          // select address
+          cy.dataCy('form-company-address')
+            .find('.q-field__append')
+            .last()
+            .click();
+          // select option
+          cy.get('.q-menu')
+            .should('be.visible')
+            .within(() => {
+              cy.get('.q-item').first().click();
+            });
+          // go back to step 3
+          cy.dataCy('step-4-back').should('be.visible').click();
+          // go back to step 2
+          cy.dataCy('step-3-back').should('be.visible').click();
+          // select payment subject school
+          cy.dataCy(getRadioOption(PaymentSubject.school))
+            .should('be.visible')
+            .click();
+          // open organization select
+          cy.selectRegisterChallengePayingOrganization(1);
+          // go to next step
+          cy.dataCy('step-2-continue').should('be.visible').click();
+          // other participation options are disabled
+          cy.dataCy('form-field-option-group').within(() => {
+            // one active option - school
+            cy.get('.q-radio:not(.disabled)')
+              .should('have.length', 1)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelSchoolmates'),
+              );
+            // two disabled options - company and family
+            cy.get('.q-radio.disabled')
+              .should('have.length', 2)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelColleagues'),
+              )
+              .and('contain', i18n.global.t('form.participation.labelFamily'));
+          });
+          // go to next step
+          cy.dataCy('step-3-continue').should('be.visible').click();
+          // organization #2 is preselected
+          cy.get('@allOrganizations').then((allOrganizations) => {
+            cy.dataCy('form-select-table-company')
+              .find('.q-radio__inner.q-radio__inner--truthy')
+              .siblings('.q-radio__label')
+              .should('contain', allOrganizations[1].name);
+          });
+          // all other options are disabled
+          cy.dataCy('form-select-table-company')
+            .find('.q-radio.disabled')
+            .should('have.length', allOrganizations.length - 1);
+          // address is cleared
+          cy.dataCy('form-company-address')
+            .find('input')
+            .should('have.value', '');
         });
       });
     });
 
     it('when school pays - disables other participation options', () => {
       cy.get('@i18n').then((i18n) => {
-        // go to payment step
-        cy.passToStep2();
-        // select school
-        cy.dataCy(getRadioOption(PaymentSubject.school))
-          .should('be.visible')
-          .click();
-        // select paying school (required)
-        cy.selectRegisterChallengePayingOrganization();
-        // go to next step
-        cy.dataCy('step-2-continue').should('be.visible').click();
-        // other participation options are disabled
-        cy.dataCy('form-field-option-group').within(() => {
-          // one active option - school
-          cy.get('.q-radio:not(.disabled)')
-            .should('have.length', 1)
-            .and(
-              'contain',
-              i18n.global.t('form.participation.labelSchoolmates'),
-            );
-          // two disabled options - company and family
-          cy.get('.q-radio.disabled')
-            .should('have.length', 2)
-            .and('contain', i18n.global.t('form.participation.labelColleagues'))
-            .and('contain', i18n.global.t('form.participation.labelFamily'));
+        cy.get('@allOrganizations').then((allOrganizations) => {
+          // go to payment step
+          cy.passToStep2();
+          // select school
+          cy.dataCy(getRadioOption(PaymentSubject.school))
+            .should('be.visible')
+            .click();
+          // select paying school (required)
+          cy.selectRegisterChallengePayingOrganization();
+          // go to next step
+          cy.dataCy('step-2-continue').should('be.visible').click();
+          // other participation options are disabled
+          cy.dataCy('form-field-option-group').within(() => {
+            // one active option - school
+            cy.get('.q-radio:not(.disabled)')
+              .should('have.length', 1)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelSchoolmates'),
+              );
+            // two disabled options - company and family
+            cy.get('.q-radio.disabled')
+              .should('have.length', 2)
+              .and(
+                'contain',
+                i18n.global.t('form.participation.labelColleagues'),
+              )
+              .and('contain', i18n.global.t('form.participation.labelFamily'));
+          });
+          // go to next step
+          cy.dataCy('step-3-continue').should('be.visible').click();
+          // organization #1 is preselected
+          cy.dataCy('form-select-table-company')
+            .find('.q-radio__inner.q-radio__inner--truthy')
+            .siblings('.q-radio__label')
+            .should('contain', allOrganizations[0].name);
+          // all other options are disabled
+          cy.dataCy('form-select-table-company')
+            .find('.q-radio.disabled')
+            .should('have.length', allOrganizations.length - 1);
         });
       });
     });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2078,27 +2078,30 @@ Cypress.Commands.add(
 /**
  * Select paying company
  */
-Cypress.Commands.add('selectRegisterChallengePayingOrganization', () => {
-  cy.fixture('formFieldCompany').then((formFieldCompany) => {
-    cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-      waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-      cy.dataCy('form-field-company').find('.q-field__append').click();
-      // select option
-      cy.get('.q-item__label')
-        .should('be.visible')
-        .and((opts) => {
-          expect(
-            opts.length,
-            formFieldCompany.results.length +
-              formFieldCompanyNext.results.length,
-          );
-        })
-        .first()
-        .click();
-      cy.get('.q-menu').should('not.exist');
+Cypress.Commands.add(
+  'selectRegisterChallengePayingOrganization',
+  (index = 0) => {
+    cy.fixture('formFieldCompany').then((formFieldCompany) => {
+      cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
+        waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
+        cy.dataCy('form-field-company').find('.q-field__append').click();
+        // select option
+        cy.get('.q-item__label')
+          .should('be.visible')
+          .and((opts) => {
+            expect(
+              opts.length,
+              formFieldCompany.results.length +
+                formFieldCompanyNext.results.length,
+            );
+          })
+          .eq(index)
+          .click();
+        cy.get('.q-menu').should('not.exist');
+      });
     });
-  });
-});
+  },
+);
 
 /**
  * Intercept IP address GET API call

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -411,6 +411,11 @@ export const interceptOrganizationsApi = (
         statusCode: httpSuccessfullStatus,
         body: formFieldCompanyNextResponse,
       }).as('getOrganizationsNextPage');
+      // alias all organizations
+      cy.wrap([
+        ...formFieldCompanyResponse.results,
+        ...formFieldCompanyNextResponse.results,
+      ]).as('allOrganizations');
     });
   });
   // intercept create organization API call (before mounting component)


### PR DESCRIPTION
Issue:
When option "My company pays for me" is selected, step 4 "Company" still allows to choose different company to ride for.

Steps to reproduce:
- Login to app.
- Go to `register-challenge`.
- Fill in personal details and go to next step.
- Select "My company pays for me" and select organization.
- Go to step 3 and click continue.
- Step 4 shows organizations -> you can now select any organization (this does not update organization in step 2 select).

Solution:
- If `payment_subject = company / school`, disable all organization options apart from the selected one (similar to step 3).
- If `payment_subject = company / school`, disable add new organization button.
- Ensure clearing values `subsidiaryId` and `teamId` when organization is changed in step 2 "Payment".
- Ensure clearing Select widget value when `subsidiaryId` (modelValue) changes in `FormFieldCompanyAddress`.
- Add E2E test to verify desired behaviour.