### PR TITLE
src/components: add ability to submit forms by pressing enter

### DIFF
--- a/src/components/form/FormFieldCompanyAddress.vue
+++ b/src/components/form/FormFieldCompanyAddress.vue
@@ -366,11 +366,13 @@ export default defineComponent({
       {{ titleDialogAddress }}
     </template>
     <template #content>
-      <q-form ref="formRef">
+      <q-form ref="formRef" @submit.prevent="onSubmit">
         <p data-cy="add-subsidiary-text">
           {{ $t('form.company.textSubsidiaryAddress') }}
         </p>
         <form-add-subsidiary v-model="addressNew" />
+        <!-- Hidden submit button enables Enter key to submit -->
+        <q-btn type="submit" class="hidden" />
       </q-form>
       <!-- Action buttons -->
       <div class="flex justify-end q-mt-sm">

--- a/src/components/form/FormFieldSelectTable.vue
+++ b/src/components/form/FormFieldSelectTable.vue
@@ -605,7 +605,7 @@ export default defineComponent({
             {{ titleDialog }}
           </template>
           <template #content>
-            <q-form ref="formRef">
+            <q-form ref="formRef" @submit.prevent="onSubmit">
               <form-add-company
                 v-if="organizationLevel === OrganizationLevel.organization"
                 v-model="organizationNew"
@@ -618,6 +618,8 @@ export default defineComponent({
                 :form-values="teamNew"
                 @update:form-values="teamNew = $event"
               ></form-add-team>
+              <!-- Hidden submit button enables Enter key to submit -->
+              <q-btn type="submit" class="hidden" />
             </q-form>
             <!-- Action buttons -->
             <div class="flex justify-end q-mt-sm">

--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -183,34 +183,32 @@ export default defineComponent({
         />
       </template>
     </q-banner>
-    <div
-      v-else
-      class="row items-center q-col-gutter-md"
-      data-cy="voucher-widget"
-    >
-      <div class="col">
-        <!-- Input: Voucher -->
-        <form-field-text-required
-          v-model="code"
-          name="voucher"
-          label="form.labelVoucher"
-          data-cy="form-field-voucher-input"
-          ref="formFieldTextRequiredRef"
-        />
+    <q-form v-else @submit.prevent="onSubmitVoucher">
+      <div class="row items-center q-col-gutter-md" data-cy="voucher-widget">
+        <div class="col">
+          <!-- Input: Voucher -->
+          <form-field-text-required
+            v-model="code"
+            name="voucher"
+            label="form.labelVoucher"
+            data-cy="form-field-voucher-input"
+            ref="formFieldTextRequiredRef"
+          />
+        </div>
+        <div class="col-auto">
+          <!-- Button: Submit -->
+          <q-btn
+            rounded
+            unelevated
+            type="submit"
+            color="primary"
+            class="q-mt-sm"
+            :label="$t('form.buttonVoucherSubmit')"
+            :loading="isLoading"
+            data-cy="form-field-voucher-submit"
+          />
+        </div>
       </div>
-      <div class="col-auto">
-        <!-- Button: Submit -->
-        <q-btn
-          rounded
-          unelevated
-          color="primary"
-          :label="$t('form.buttonVoucherSubmit')"
-          :loading="isLoading"
-          @click="onSubmitVoucher"
-          class="q-mt-sm"
-          data-cy="form-field-voucher-submit"
-        />
-      </div>
-    </div>
+    </q-form>
   </div>
 </template>

--- a/src/components/global/FormFieldCompany.vue
+++ b/src/components/global/FormFieldCompany.vue
@@ -354,12 +354,14 @@ export default defineComponent({
         {{ addNewOrganizationDialogTitle }}
       </template>
       <template #content>
-        <q-form ref="formRef">
+        <q-form ref="formRef" @submit.prevent="onSubmit">
           <form-add-company
             v-model="companyNew"
             :variant="FormAddCompanyVariantProp.simple"
             :organization-type="organizationType"
           ></form-add-company>
+          <!-- Hidden submit button enables Enter key to submit -->
+          <q-btn type="submit" class="hidden" />
         </q-form>
         <!-- Action buttons -->
         <div class="flex justify-end q-mt-sm">

--- a/src/components/register/FormRegisterCoordinator.vue
+++ b/src/components/register/FormRegisterCoordinator.vue
@@ -140,7 +140,7 @@ export default defineComponent({
     <!-- Form: register coordinator -->
     <q-form
       autofocus
-      @submit="onSubmit"
+      @submit.prevent="onSubmit"
       @reset="onReset"
       class="q-gutter-md text-grey-10"
     >


### PR DESCRIPTION
Add ability to submit forms by pressing enter.

* Add `@submit.prevent` handler to forms.
* Where needed add hidden submit button to forms as form submission is "[tethered to submit button](https://quasar.dev/vue-components/form#qform-api)".
* Add `q-form` element to voucher section of step 2 "Payment" to enable local submit.
* Add E2E test for the submit-with-enter behaviour.
* Fix `FormFieldSelectTable` component test (related to adding input mask in earlier commit).