### PR TITLE
test/cypress/e2e: fix issue in register_coordinator e2e test missing an intercept

### DIFF
--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -131,19 +131,21 @@ describe('Login page', () => {
                     null,
                     { has_user_verified_email_address: true },
                   );
-                  cy.fillAndSubmitLoginForm(config, win.i18n);
-                  cy.wait([
-                    '@loginRequest',
-                    '@refreshAuthTokenRequest',
-                    '@verifyEmailRequest',
-                    '@thisCampaignRequest',
-                  ]);
                   interceptRegisterCoordinatorApi(config, win.i18n);
                   interceptOrganizationsApi(
                     config,
                     win.i18n,
                     OrganizationType.company,
                   );
+                  cy.interceptIsUserOrganizationAdminGetApi(config, win.i18n);
+                  cy.fillAndSubmitLoginForm(config, win.i18n);
+                  cy.wait([
+                    '@loginRequest',
+                    '@refreshAuthTokenRequest',
+                    '@verifyEmailRequest',
+                    '@thisCampaignRequest',
+                    '@getIsUserOrganizationAdmin',
+                  ]);
                   cy.visit('#' + routesConf['register_coordinator']['path']);
                 },
               );


### PR DESCRIPTION
PR #871 test fails on `register_coordinator` e2e test:
`"fills in the form, submits it, and redirects to homepage on success"`

Add missing API request intercept for `isUserOrganizationAdmin` after login and wait for response.