### PR TITLE
src/stores: update processing voucher on load and registration-complete condition

### DIFF
--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -248,22 +248,20 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       ].includes(this.getPaymentState);
       const isPaymentCategoryDonation =
         this.getPaymentCategory === PaymentCategory.donation;
-      const isPaymentSubjectVoucher =
-        this.getPaymentSubject === PaymentSubject.voucher;
+      const isVoucherFullDiscount =
+        this.getPaymentSubject === PaymentSubject.voucher &&
+        this.getVoucher?.discount === 100;
+
+      // complete - voucher full discount (set from API response)
+      if (isVoucherFullDiscount) {
+        return true;
+      }
       // payment not successful
-      if (!isPaymentStateSuccess) {
+      else if (!isPaymentStateSuccess) {
         return false;
       }
       // complete - successful payment of entry fee
       else if (isPaymentStateSuccess && !isPaymentCategoryDonation) {
-        return true;
-      }
-      // complete - status = voucher (100% discount) + successful donation
-      else if (
-        isPaymentStateSuccess &&
-        isPaymentCategoryDonation &&
-        isPaymentSubjectVoucher
-      ) {
         return true;
       }
       return false;
@@ -425,6 +423,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
        */
       const isVoucherFullDiscount =
         parsedResponse.voucher &&
+        parsedResponse.paymentSubject === PaymentSubject.voucher &&
         (!parsedResponse.paymentAmount ||
           parsedResponse.paymentCategory === PaymentCategory.donation);
       if (isVoucherFullDiscount) {


### PR DESCRIPTION
Fixes issue where changing `payment_subject` from `company` to voucher and applying voucher 100% discount does not allow to complete registration.

Steps to reproduce:
- Login to app and start registration to challenge.
- Fill in personal details and go to step 2 "Payment".
- Select organization and continue to step 3 "Participation".
- Continue to select organization, subsidiary and team.
- Return back to step 2 "Payment".
- Select payment_subject `voucher`.
- Apply voucher 100% discount and continue.
- Complete registration to step 7 "Summary".
- User cannot complete registration.

Solution:
- Update getter `getIsPaymentComplete` (lines 244-268) to pass if 100% discount voucher is applied
- Update reading data from API on GET `/register-challenge` to only initiate 100% discount voucher in local state if `paymentSubject` is `voucher`. This prevents loading saved voucher if user switches **from** 100% discount voucher to another payment type (voucher/discount_coupon value cannot be erased in current API).