### PR TITLE
src/component: override form fields validation error color with custom color

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -10,6 +10,7 @@ colorGrayMiddle = "#DCE1ED"
 colorWhite = "#FFFFFF"
 colorBlack = "#000000"
 colorRed = "#F15857"
+colorCustomFormFieldValidationErr = "#A0D7C4"
 colorSecondaryBackgroundOpacity = 0.4
 colorWhiteBackgroundOpacity = 0.2
 

--- a/src/boot/global_vars.ts
+++ b/src/boot/global_vars.ts
@@ -16,6 +16,10 @@ const initVars = (): void => {
   setCssVar('secondary', rideToWorkByBikeConfig.colorSecondary);
   setCssVar('info', rideToWorkByBikeConfig.colorGrayLight);
   setCssVar('red', rideToWorkByBikeConfig.colorRed);
+  setCssVar(
+    'custom-form-field-validation-err',
+    rideToWorkByBikeConfig.colorCustomFormFieldValidationErr,
+  );
 };
 
 export { rideToWorkByBikeConfig, initVars };

--- a/src/components/__tests__/FormFieldEmail.cy.js
+++ b/src/components/__tests__/FormFieldEmail.cy.js
@@ -1,5 +1,16 @@
+import { colors, getCssVar } from 'quasar';
+
 import FormFieldTestWrapper from 'components/global/FormFieldTestWrapper.vue';
 import { i18n } from '../../boot/i18n';
+
+const { getPaletteColor } = colors;
+
+const customFormFieldValidationErrColor = getCssVar(
+  'custom-form-field-validation-err',
+);
+const negative = getPaletteColor('negative');
+
+const selectorFormFieldEmail = 'form-email';
 
 describe('<FormFieldEmail>', () => {
   it('has translation for all strings', () => {
@@ -18,6 +29,28 @@ describe('<FormFieldEmail>', () => {
         },
       });
       cy.viewport('macbook-16');
+    });
+
+    it('check default form field validation error color', () => {
+      cy.viewport('macbook-16');
+      [selectorFormFieldEmail].forEach((formField) => {
+        cy.checkFormFieldValidationErrColor(formField, negative);
+      });
+    });
+
+    it('check custom form field validation error color', () => {
+      cy.mount(FormFieldTestWrapper, {
+        props: {
+          component: 'FormFieldEmail',
+          useFormFieldValidationErrorCssClass: true,
+        },
+      });
+      [selectorFormFieldEmail].forEach((formField) => {
+        cy.checkFormFieldValidationErrColor(
+          formField,
+          customFormFieldValidationErrColor,
+        );
+      });
     });
 
     it('validates email correctly', () => {

--- a/src/components/__tests__/FormLogin.cy.js
+++ b/src/components/__tests__/FormLogin.cy.js
@@ -1,4 +1,4 @@
-import { colors } from 'quasar';
+import { colors, getCssVar } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 
 import { useLoginStore } from 'src/stores/login';
@@ -20,6 +20,10 @@ const { getPaletteColor, changeAlpha } = colors;
 const white = getPaletteColor('white');
 const primary = getPaletteColor('primary');
 const secondary = getPaletteColor('secondary');
+const customFormFieldValidationErrColor = getCssVar(
+  'custom-form-field-validation-err',
+);
+const negative = getPaletteColor('negative');
 const whiteOpacity = changeAlpha(
   white,
   rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
@@ -30,6 +34,9 @@ const classSelectorQNotificationMessage = '.q-notification__message';
 const selectorLoginPromptNoAccount = 'login-prompt-no-account';
 const selectorLoginLinkRegister = 'login-link-register';
 const selectorFormLoginSeparator = 'form-login-separator';
+const selectorFormLoginEmail = 'form-login-email';
+const selectorFormLoginPassword = 'form-login-password';
+const selectorFormPasswordReset = 'form-password-reset';
 
 // variables
 const {
@@ -84,7 +91,7 @@ describe('<FormLogin>', () => {
   context('desktop', () => {
     beforeEach(() => {
       cy.mount(FormLogin, {
-        props: {},
+        props: { useFormFieldValidationErrorCssClass: true },
       });
       cy.viewport('macbook-16');
       // get API base URL
@@ -117,20 +124,20 @@ describe('<FormLogin>', () => {
     });
 
     it('renders email field', () => {
-      cy.dataCy('form-login-email').should('be.visible');
-      cy.dataCy('form-login-email')
+      cy.dataCy(selectorFormLoginEmail).should('be.visible');
+      cy.dataCy(selectorFormLoginEmail)
         .find('.q-field__control')
         .should('be.visible')
         .and('have.css', 'border-radius', '8px');
     });
 
     it('renders password field', () => {
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .should('be.visible')
         .find('label[for="form-login-password"]')
         .should('be.visible')
         .and('have.text', i18n.global.t('login.form.labelPassword'));
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .find('.q-field__control')
         .should('be.visible')
         .and('have.css', 'border-radius', '8px');
@@ -149,15 +156,15 @@ describe('<FormLogin>', () => {
     });
 
     it('should allow user to reveal and hide password', () => {
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .find('input')
         .should('have.attr', 'type', 'password');
       cy.dataCy('form-login-password-icon').click();
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .find('input')
         .should('have.attr', 'type', 'text');
       cy.dataCy('form-login-password-icon').click();
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .find('input')
         .should('have.attr', 'type', 'password');
     });
@@ -166,6 +173,37 @@ describe('<FormLogin>', () => {
       cy.dataCy(selectorFormLoginSeparator)
         .should('be.visible')
         .and('have.backgroundColor', whiteOpacity);
+    });
+
+    it('check default form field validation error color', () => {
+      cy.mount(FormLogin, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+      [selectorFormLoginEmail, selectorFormLoginPassword].forEach(
+        (formField) => {
+          cy.checkFormFieldValidationErrColor(formField, negative);
+        },
+      );
+    });
+
+    it('check custom form field validation error color', () => {
+      [selectorFormLoginEmail, selectorFormLoginPassword].forEach(
+        (formField) => {
+          cy.checkFormFieldValidationErrColor(
+            formField,
+            customFormFieldValidationErrColor,
+          );
+        },
+      );
+      cy.dataCy('form-login-forgotten-password').should('be.visible').click();
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
+      [selectorFormPasswordReset].forEach((formField) => {
+        cy.checkFormFieldValidationErrColor(
+          formField,
+          customFormFieldValidationErrColor,
+        );
+      });
     });
 
     it('renders forgotten password link', () => {
@@ -220,14 +258,14 @@ describe('<FormLogin>', () => {
 
     it('allows to navigate between states', () => {
       cy.dataCy('form-login-forgotten-password').should('be.visible').click();
-      cy.dataCy('form-password-reset').should('be.visible');
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
       cy.dataCy('form-password-reset-button-back').should('be.visible').click();
       cy.dataCy('form-login').should('be.visible');
     });
 
     it('renders password reset form title', () => {
       cy.dataCy('form-login-forgotten-password').should('be.visible').click();
-      cy.dataCy('form-password-reset').should('be.visible');
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
       cy.dataCy('form-password-reset-title')
         .should('be.visible')
         .and('have.color', white)
@@ -238,7 +276,7 @@ describe('<FormLogin>', () => {
 
     it('renders password reset form description', () => {
       cy.dataCy('form-login-forgotten-password').should('be.visible').click();
-      cy.dataCy('form-password-reset').should('be.visible');
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
       cy.dataCy('form-password-reset-description')
         .should('be.visible')
         .and('have.color', white)
@@ -249,12 +287,12 @@ describe('<FormLogin>', () => {
 
     it('renders password reset form email input', () => {
       cy.dataCy('form-login-forgotten-password').should('be.visible').click();
-      cy.dataCy('form-password-reset').should('be.visible');
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
     });
 
     it('renders password reset form submit button', () => {
       cy.dataCy('form-login-forgotten-password').should('be.visible').click();
-      cy.dataCy('form-password-reset').should('be.visible');
+      cy.dataCy(selectorFormPasswordReset).should('be.visible');
       cy.dataCy('form-password-reset-submit')
         .should('be.visible')
         .and('have.color', primary)
@@ -367,9 +405,9 @@ describe('<FormLogin>', () => {
       cy.dataCy('form-login-submit-login').should('be.visible').click();
       // validate password required
       // first make email pass
-      cy.dataCy('form-login-email').find('input').type('test@example.com');
+      cy.dataCy(selectorFormLoginEmail).find('input').type('test@example.com');
       cy.dataCy('form-login-submit-login').should('be.visible').click();
-      cy.dataCy('form-login-password')
+      cy.dataCy(selectorFormLoginPassword)
         .find('.q-field__messages')
         .should('be.visible')
         .and('contain', i18n.global.t('login.form.messagePasswordRequired'));

--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -1,5 +1,5 @@
 import { computed } from 'vue';
-import { colors } from 'quasar';
+import { colors, getCssVar } from 'quasar';
 import { createPinia, setActivePinia } from 'pinia';
 import FormRegister from '../register/FormRegister.vue';
 import { i18n } from '../../boot/i18n';
@@ -29,6 +29,10 @@ const whiteOpacity = changeAlpha(
   white,
   rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
+const customFormFieldValidationErrColor = getCssVar(
+  'custom-form-field-validation-err',
+);
+const negative = getPaletteColor('negative');
 
 // selectors
 const selectorFormRegisterTitle = 'form-register-title';
@@ -101,7 +105,7 @@ describe('<FormRegister>', () => {
       cy.interceptThisCampaignGetApi(rideToWorkByBikeConfig, i18n);
       setActivePinia(createPinia());
       cy.mount(FormRegister, {
-        props: {},
+        props: { useFormFieldValidationErrorCssClass: true },
       });
       cy.viewport('macbook-16');
     });
@@ -170,6 +174,33 @@ describe('<FormRegister>', () => {
       cy.dataCy(selectorFormRegisterSeparator)
         .should('be.visible')
         .and('have.backgroundColor', whiteOpacity);
+    });
+
+    it('check default form field validation error color', () => {
+      cy.mount(FormRegister, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+      [
+        selectorFormRegisterEmail,
+        selectorFormRegisterPassword,
+        selectorFormRegisterPasswordConfirm,
+      ].forEach((formField) => {
+        cy.checkFormFieldValidationErrColor(formField, negative);
+      });
+    });
+
+    it('check custom form field validation error color', () => {
+      [
+        selectorFormRegisterEmail,
+        selectorFormRegisterPassword,
+        selectorFormRegisterPasswordConfirm,
+      ].forEach((formField) => {
+        cy.checkFormFieldValidationErrColor(
+          formField,
+          customFormFieldValidationErrColor,
+        );
+      });
     });
 
     testPasswordInputReveal(selectorFormRegisterPassword);

--- a/src/components/__tests__/ResetPassword.cy.js
+++ b/src/components/__tests__/ResetPassword.cy.js
@@ -1,4 +1,4 @@
-import { colors } from 'quasar';
+import { colors, getCssVar } from 'quasar';
 import ResetPassword from 'components/register/ResetPassword.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -11,6 +11,10 @@ const whiteOpacity = changeAlpha(
   white,
   rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
 );
+const customFormFieldValidationErrColor = getCssVar(
+  'custom-form-field-validation-err',
+);
+const negative = getPaletteColor('negative');
 
 // selectors
 const selectorResetPassword = 'reset-password';
@@ -61,7 +65,7 @@ describe('<ResetPassword>', () => {
     beforeEach(() => {
       cy.viewport('macbook-16');
       cy.mount(ResetPassword, {
-        props: {},
+        props: { useFormFieldValidationErrorCssClass: true },
       });
     });
 
@@ -72,7 +76,7 @@ describe('<ResetPassword>', () => {
     beforeEach(() => {
       cy.viewport('iphone-6');
       cy.mount(ResetPassword, {
-        props: {},
+        props: { useFormFieldValidationErrorCssClass: true },
       });
     });
 
@@ -144,6 +148,29 @@ function coreTests() {
     cy.dataCy(selectorFormResetPasswordConfirmIcon)
       .invoke('width')
       .should('be.equal', passwordIconSize);
+  });
+
+  it('check default form field validation error color', () => {
+    cy.mount(ResetPassword, {
+      props: {},
+    });
+    cy.viewport('macbook-16');
+    [selectorFormResetPassword, selectorFormResetPasswordConfirm].forEach(
+      (formField) => {
+        cy.checkFormFieldValidationErrColor(formField, negative);
+      },
+    );
+  });
+
+  it('check custom form field validation error color', () => {
+    [selectorFormResetPassword, selectorFormResetPasswordConfirm].forEach(
+      (formField) => {
+        cy.checkFormFieldValidationErrColor(
+          formField,
+          customFormFieldValidationErrColor,
+        );
+      },
+    );
   });
 
   it('validates password correctly', () => {

--- a/src/components/global/FormFieldEmail.vue
+++ b/src/components/global/FormFieldEmail.vue
@@ -19,6 +19,9 @@
  *    Defaults to `false`.
  * - `testing` (boolean, optional): Wheter this is a testing environment.
  *    Defaults to `false`.
+ * - `useFormFieldValidationErrorCssClass` (boolean, optional): Use custom email form field
+ *                                                              validation error CSS class
+ *                                                              Defaults to `false`.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
@@ -34,6 +37,8 @@ import { computed, defineComponent } from 'vue';
 
 // composables
 import { useValidation } from 'src/composables/useValidation';
+
+import { formFieldCustomValidationErrCssClass } from '../../utils';
 
 export default defineComponent({
   name: 'FormFieldEmail',
@@ -58,6 +63,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    useFormFieldValidationErrorCssClass: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
@@ -69,6 +79,11 @@ export default defineComponent({
         emit('update:modelValue', value);
       },
     });
+    const emailFormFieldCssClasses = {
+      'q-mt-sm': true,
+    };
+    if (props.useFormFieldValidationErrorCssClass)
+      emailFormFieldCssClasses[formFieldCustomValidationErrCssClass] = true;
 
     const { isEmail, isFilled } = useValidation();
 
@@ -76,11 +91,11 @@ export default defineComponent({
       email,
       isFilled,
       isEmail,
+      emailFormFieldCssClasses,
     };
   },
 });
 </script>
-
 <template>
   <div class="col-12 col-sm-6" data-cy="form-email">
     <!-- Label -->
@@ -104,7 +119,7 @@ export default defineComponent({
           }),
         (val) => isEmail(val) || $t('form.messageEmailInvalid'),
       ]"
-      class="q-mt-sm"
+      :class="emailFormFieldCssClasses"
       id="form-email"
       name="email"
       data-cy="form-email-input"

--- a/src/components/global/FormFieldTestWrapper.vue
+++ b/src/components/global/FormFieldTestWrapper.vue
@@ -123,6 +123,11 @@ export default defineComponent({
       type: [Number, String, Boolean, Array, Object] as PropType<DefaultValue>,
       default: '',
     },
+    useFormFieldValidationErrorCssClass: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props) {
     const inputValue = ref(props.defaultValue);
@@ -144,6 +149,7 @@ export default defineComponent({
     :options="options"
     :required="required"
     :validation-message="validationMessage"
+    :useFormFieldValidationErrorCssClass="useFormFieldValidationErrorCssClass"
   >
     <slot />
   </component>

--- a/src/components/login/FormLogin.vue
+++ b/src/components/login/FormLogin.vue
@@ -7,6 +7,10 @@
  * @description * Use this component to render login form.
  * Login form contains password reset.
  *
+ * @props
+ * - `useFormFieldValidationErrorCssClass` (boolean, optional): Use custom email form field
+ *                                                              validation error CSS class
+ *                                                              Defaults to `false`.
  * @events
  * - `formSubmit`: Emitted on form submit.
  *
@@ -42,15 +46,24 @@ import { useLoginStore } from '../../stores/login';
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
+import { formFieldCustomValidationErrCssClass } from '../../utils';
+
 export default defineComponent({
   name: 'FormLogin',
+  props: {
+    useFormFieldValidationErrorCssClass: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
   components: {
     BannerAppButtons,
     FormFieldEmail,
     LoginRegisterButtons,
   },
   emits: ['formSubmit'],
-  setup() {
+  setup(props) {
     const loginStore = useLoginStore();
     const formLogin = reactive({
       username: '',
@@ -91,6 +104,12 @@ export default defineComponent({
       rideToWorkByBikeConfig.colorWhiteBackgroundOpacity,
     );
 
+    const passwordFormFieldCssClasses = {
+      'q-mt-sm': true,
+    };
+    if (props.useFormFieldValidationErrorCssClass)
+      passwordFormFieldCssClasses[formFieldCustomValidationErrCssClass] = true;
+
     return {
       contactEmail,
       formPasswordReset,
@@ -104,6 +123,8 @@ export default defineComponent({
       isFilled,
       onSubmitLogin,
       onSubmitPasswordReset,
+      passwordFormFieldCssClasses,
+      props,
       setFormState,
     };
   },
@@ -131,6 +152,9 @@ export default defineComponent({
         bg-color="transparent"
         v-model="formLogin.username"
         data-cy="form-login-email"
+        :useFormFieldValidationErrorCssClass="
+          props.useFormFieldValidationErrorCssClass
+        "
       />
       <!-- Input: password -->
       <div data-cy="form-login-password">
@@ -152,7 +176,7 @@ export default defineComponent({
           :rules="[
             (val) => isFilled(val) || $t('login.form.messagePasswordRequired'),
           ]"
-          class="q-mt-sm"
+          :class="passwordFormFieldCssClasses"
           data-cy="form-login-password-input"
         >
           <!-- Icon: show password -->
@@ -259,6 +283,7 @@ export default defineComponent({
         color="white"
         bg-color="transparent"
         data-cy="form-password-reset-email"
+        useFormFieldValidationErrorCssClass
       />
       <!-- Button: submit -->
       <q-btn

--- a/src/components/register/FormRegister.vue
+++ b/src/components/register/FormRegister.vue
@@ -9,6 +9,10 @@
  *
  * Note: This component is commonly used in `LoginPage`.
  *
+ * @props
+ * - `useFormFieldValidationErrorCssClass` (boolean, optional): Use custom email form field
+ *                                                              validation error CSS class
+ *                                                              Defaults to `false`.
  * @events
  * - `formSubmit`: Emitted on form submit.
  *
@@ -45,15 +49,24 @@ import { PhaseType } from '../types/Challenge';
 import { useChallengeStore } from '../../stores/challenge';
 import { useRegisterStore } from '../../stores/register';
 
+import { formFieldCustomValidationErrCssClass } from '../../utils';
+
 export default defineComponent({
   name: 'FormRegister',
+  props: {
+    useFormFieldValidationErrorCssClass: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
   components: {
     FormFieldEmail,
     LoginRegisterButtons,
     ShowCurrentDatetime,
   },
   emits: ['formSubmit'],
-  setup() {
+  setup(props) {
     const defaultFormRegisterValue = '';
     const formRegister = reactive({
       email: defaultFormRegisterValue,
@@ -98,6 +111,12 @@ export default defineComponent({
       challengeStore.loadPhaseSet();
     });
 
+    const passwordFormFieldCssClasses = {
+      'q-mt-sm': true,
+    };
+    if (props.useFormFieldValidationErrorCssClass)
+      passwordFormFieldCssClasses[formFieldCustomValidationErrCssClass] = true;
+
     return {
       whiteOpacity,
       formRegister,
@@ -112,6 +131,8 @@ export default defineComponent({
       isStrongPassword,
       onSubmitRegister,
       onReset,
+      passwordFormFieldCssClasses,
+      props,
       urlAppDataPrivacyPolicy,
     };
   },
@@ -146,6 +167,9 @@ export default defineComponent({
         bg-color="transparent"
         color="white"
         data-cy="form-register-email"
+        :useFormFieldValidationErrorCssClass="
+          props.useFormFieldValidationErrorCssClass
+        "
       />
       <!-- Input: password -->
       <div data-cy="form-register-password">
@@ -173,7 +197,7 @@ export default defineComponent({
               $t('register.form.messagePasswordStrong'),
           ]"
           lazy-rules
-          class="q-mt-sm"
+          :class="passwordFormFieldCssClasses"
           data-cy="form-register-password-input"
         >
           <!-- Icon: show password -->
@@ -218,7 +242,7 @@ export default defineComponent({
               $t('register.form.messagePasswordConfirmNotMatch'),
           ]"
           lazy-rules
-          class="q-mt-sm"
+          :class="passwordFormFieldCssClasses"
           data-cy="form-register-password-confirm-input"
         >
           <!-- Icon: show password -->

--- a/src/components/register/ResetPassword.vue
+++ b/src/components/register/ResetPassword.vue
@@ -6,6 +6,10 @@
  * Renders a form that allows users to reset their password after clicking
  * the reset password link from their email.
  *
+ * @props
+ * - `useFormFieldValidationErrorCssClass` (boolean, optional): Use custom email form field
+ *                                                              validation error CSS class
+ *                                                              Defaults to `false`.
  * @example
  * <reset-password />
  */
@@ -33,10 +37,18 @@ import { useLoginStore } from '../../stores/login';
 // types
 import type { Logger } from '../types/Logger';
 
+import { formFieldCustomValidationErrCssClass } from '../../utils';
+
 export default defineComponent({
   name: 'ResetPassword',
-
-  setup() {
+  props: {
+    useFormFieldValidationErrorCssClass: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  setup(props) {
     const logger = inject('vuejs3-logger') as Logger | null;
     const loginStore = useLoginStore();
     const router = useRouter();
@@ -115,6 +127,12 @@ export default defineComponent({
       }
     };
 
+    const passwordFormFieldCssClasses = {
+      'q-mt-sm': true,
+    };
+    if (props.useFormFieldValidationErrorCssClass)
+      passwordFormFieldCssClasses[formFieldCustomValidationErrCssClass] = true;
+
     return {
       isFilled,
       isIdentical,
@@ -126,6 +144,7 @@ export default defineComponent({
       whiteOpacity,
       onSubmitResetPassword,
       isLoading,
+      passwordFormFieldCssClasses,
     };
   },
 });
@@ -187,7 +206,7 @@ export default defineComponent({
               $t('register.form.messagePasswordStrong'),
           ]"
           lazy-rules
-          class="q-mt-sm"
+          :class="passwordFormFieldCssClasses"
           data-cy="form-reset-password-input"
         >
           <!-- Icon: show password -->
@@ -229,7 +248,7 @@ export default defineComponent({
               $t('register.form.messagePasswordConfirmNotMatch'),
           ]"
           lazy-rules
-          class="q-mt-sm"
+          :class="passwordFormFieldCssClasses"
           data-cy="form-reset-password-confirm-input"
         >
           <!-- Icon: show password -->

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -9,6 +9,7 @@ export interface ConfigGlobal {
   colorWhite: string;
   colorBlack: string;
   colorRed: string;
+  colorCustomFormFieldValidationErr: string;
   colorSecondaryBackgroundOpacity: number;
   colorWhiteBackgroundOpacity: number;
   image: string;

--- a/src/css/form.scss
+++ b/src/css/form.scss
@@ -8,3 +8,9 @@
 .q-checkbox .q-checkbox__svg {
   padding: 3px;
 }
+.form-field-validation-err.q-field--error .q-field__bottom {
+  color: var(--q-custom-form-field-validation-err);
+}
+.form-field-validation-err .text-negative {
+  color: var(--q-custom-form-field-validation-err) !important;
+}

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -26,3 +26,5 @@ $positive: #21ba45;
 $negative: #c10015;
 $info: #31ccec;
 $warning: #f2c037;
+
+$custom-form-field-validation-err: $negative;

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -46,7 +46,7 @@ export default defineComponent({
 
       <div class="row">
         <div class="col-12 col-md-4">
-          <form-login />
+          <form-login useFormFieldValidationErrorCssClass />
         </div>
       </div>
     </div>

--- a/src/pages/RegisterPage.vue
+++ b/src/pages/RegisterPage.vue
@@ -46,7 +46,7 @@ export default defineComponent({
 
       <div class="row q-mt-xl">
         <div class="col-12 col-md-4">
-          <form-register />
+          <form-register useFormFieldValidationErrorCssClass />
         </div>
       </div>
     </div>

--- a/src/pages/ResetPasswordPage.vue
+++ b/src/pages/ResetPasswordPage.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 
       <div class="row q-mt-xl">
         <div class="col-12 col-md-4">
-          <reset-password />
+          <reset-password useFormFieldValidationErrorCssClass />
         </div>
       </div>
     </div>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -75,10 +75,14 @@ const requestTokenHeader = {
  * e.g. rgba(255, 255, 255, 0.2)
  *
  * @param {rgbai} rgba: RGBA object returned from hexToRgb() function
+ * @param {boolean} getRgb: if true return RGB string intead of RGBA
  *
  * @return {string}: RGBA string e.g. rgba(255, 255, 255, 0.2)
+ *                   RGB string e.g. rgba(255, 255, 255) accroding
+ *                   usage of `getRgb` param val
  */
-const rgbaColorObjectToString = (rgba: RgbaI): string => {
+const rgbaColorObjectToString = (rgba: RgbaI, getRgb: boolean): string => {
+  if (getRgb) return `rgb(${rgba['r']}, ${rgba['g']}, ${rgba['b']})`;
   return `rgba(${rgba['r']}, ${rgba['g']}, ${rgba['b']}, ${rgba['a'] / 100.0})`;
 };
 
@@ -116,10 +120,14 @@ const calculateCountdownIntervals = (timeDifferenceMs: number): Countdown => {
   };
 };
 
+// Custom form field validation error CSS class
+const formFieldCustomValidationErrCssClass = 'form-field-validation-err';
+
 export {
   calculateCountdownIntervals,
   bearerTokeAuth,
   deepObjectWithSimplePropsCopy,
+  formFieldCustomValidationErrCssClass,
   requestDefaultHeader,
   requestTokenHeader,
   rgbaColorObjectToString,

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -1,3 +1,6 @@
+import { colors } from 'quasar';
+
+import { rgbaColorObjectToString } from 'src/utils';
 import {
   testLanguageSwitcher,
   testBackgroundImage,
@@ -7,6 +10,11 @@ import {
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 import { httpSuccessfullStatus } from '../support/commonTests';
+
+const { hexToRgb } = colors;
+const selectorFormLoginEmail = 'form-login-email';
+const selectorFormLoginPassword = 'form-login-password';
+const selectorFormPasswordReset = 'form-password-reset';
 
 describe('Login page', () => {
   context('desktop', () => {
@@ -30,6 +38,31 @@ describe('Login page', () => {
 
     it('renders page header', () => {
       cy.dataCy('login-register-header').should('be.visible');
+    });
+
+    it('check custom form field validation error color', () => {
+      cy.task('getAppConfig', process).then((config) => {
+        const customFormFieldValidationErrColor = rgbaColorObjectToString(
+          hexToRgb(config.colorCustomFormFieldValidationErr),
+          true,
+        );
+        [selectorFormLoginEmail, selectorFormLoginPassword].forEach(
+          (formField) => {
+            cy.checkFormFieldValidationErrColor(
+              formField,
+              customFormFieldValidationErrColor,
+            );
+          },
+        );
+        cy.dataCy('form-login-forgotten-password').should('be.visible').click();
+        cy.dataCy(selectorFormPasswordReset).should('be.visible');
+        [selectorFormPasswordReset].forEach((formField) => {
+          cy.checkFormFieldValidationErrColor(
+            formField,
+            customFormFieldValidationErrColor,
+          );
+        });
+      });
     });
 
     it('allows user to display and submit contact form', () => {

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -1,3 +1,4 @@
+import { colors } from 'quasar';
 import {
   testLanguageSwitcher,
   testBackgroundImage,
@@ -7,6 +8,7 @@ import {
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 
+import { rgbaColorObjectToString } from 'src/utils';
 /**
  * Required for localization REST API URL during e2e tests for
  * intercepting API before visiting app URL page when i18n locale
@@ -14,11 +16,15 @@ import { routesConf } from '../../../src/router/routes_conf';
  */
 import { defLocale } from '../../../src/i18n/def_locale';
 
+const { hexToRgb } = colors;
 // selectors
 const selectorLogoutButton = 'logout-button';
 const selectorEmailVerificationRegisterLink =
   'email-verification-register-link';
 const selectorChallengeInactiveInfo = 'challenge-inactive-info';
+const selectorFormRegisterEmail = 'form-register-email';
+const selectorFormRegisterPassword = 'form-register-password';
+const selectorFormRegisterPasswordConfirm = 'form-register-password-confirm';
 
 describe('Register page', () => {
   context('desktop', () => {
@@ -69,6 +75,25 @@ describe('Register page', () => {
         .should('be.visible')
         .invoke('attr', 'href')
         .should('contain', routesConf['login']['path']);
+    });
+
+    it('check custom form field validation error color', () => {
+      cy.task('getAppConfig', process).then((config) => {
+        const customFormFieldValidationErrColor = rgbaColorObjectToString(
+          hexToRgb(config.colorCustomFormFieldValidationErr),
+          true,
+        );
+        [
+          selectorFormRegisterEmail,
+          selectorFormRegisterPassword,
+          selectorFormRegisterPasswordConfirm,
+        ].forEach((formField) => {
+          cy.checkFormFieldValidationErrColor(
+            formField,
+            customFormFieldValidationErrColor,
+          );
+        });
+      });
     });
   });
 

--- a/test/cypress/e2e/reset_password.spec.cy.js
+++ b/test/cypress/e2e/reset_password.spec.cy.js
@@ -1,13 +1,22 @@
+import { colors } from 'quasar';
+
 import { testBackgroundImage } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 import { HttpStatusCode } from 'axios';
 
+import { rgbaColorObjectToString } from 'src/utils';
+
+const { hexToRgb } = colors;
+
 const selectorResetPassword = 'reset-password';
 const selectorResetPasswordTitle = 'reset-password-title';
 const selectorResetPasswordText = 'reset-password-text';
-const selectorFormResetPassword = 'form-reset-password-input';
-const selectorFormResetPasswordConfirm = 'form-reset-password-confirm-input';
+const selectorFormResetPasswordInput = 'form-reset-password-input';
+const selectorFormResetPasswordConfirmInput =
+  'form-reset-password-confirm-input';
 const selectorFormResetPasswordSubmit = 'form-reset-password-submit';
+const selectorFormResetPassword = 'form-reset-password';
+const selectorFormResetPasswordConfirm = 'form-reset-password-confirm';
 
 describe('Reset Password', () => {
   context('desktop', () => {
@@ -71,23 +80,44 @@ describe('Reset Password', () => {
     });
 
     it('renders password input fields and submit button', () => {
-      cy.dataCy(selectorFormResetPassword).should('be.visible');
-      cy.dataCy(selectorFormResetPasswordConfirm).should('be.visible');
+      cy.dataCy(selectorFormResetPasswordInput).should('be.visible');
+      cy.dataCy(selectorFormResetPasswordConfirmInput).should('be.visible');
       cy.dataCy(selectorFormResetPasswordSubmit).should('be.visible');
     });
 
+    it('check custom form field validation error color', () => {
+      cy.task('getAppConfig', process).then((config) => {
+        const customFormFieldValidationErrColor = rgbaColorObjectToString(
+          hexToRgb(config.colorCustomFormFieldValidationErr),
+          true,
+        );
+        [selectorFormResetPassword, selectorFormResetPasswordConfirm].forEach(
+          (formField) => {
+            cy.checkFormFieldValidationErrColor(
+              formField,
+              customFormFieldValidationErrColor,
+            );
+          },
+        );
+      });
+    });
     it('submits form successfully and redirects to login', () => {
       cy.fixture('apiPostResetPasswordConfirmRequest').then((request) => {
         // fill in the form
-        cy.dataCy(selectorFormResetPassword).type(request.new_password1);
-        cy.dataCy(selectorFormResetPasswordConfirm).type(request.new_password2);
+        cy.dataCy(selectorFormResetPasswordInput).type(request.new_password1);
+        cy.dataCy(selectorFormResetPasswordConfirmInput).type(
+          request.new_password2,
+        );
         // submit form
         cy.dataCy(selectorFormResetPasswordSubmit).click();
         // wait for API call and verify request
         cy.waitForResetPasswordConfirmApi();
         // verify form is cleared
-        cy.dataCy(selectorFormResetPassword).should('have.value', '');
-        cy.dataCy(selectorFormResetPasswordConfirm).should('have.value', '');
+        cy.dataCy(selectorFormResetPasswordInput).should('have.value', '');
+        cy.dataCy(selectorFormResetPasswordConfirmInput).should(
+          'have.value',
+          '',
+        );
         // verify success notification
         cy.fixture('apiPostResetPasswordConfirmResponseSuccess.json').then(
           (responseBody) => {
@@ -110,8 +140,10 @@ describe('Reset Password', () => {
           );
           cy.fixture('apiPostResetPasswordConfirmRequest').then((request) => {
             // fill in the form
-            cy.dataCy(selectorFormResetPassword).type(request.new_password1);
-            cy.dataCy(selectorFormResetPasswordConfirm).type(
+            cy.dataCy(selectorFormResetPasswordInput).type(
+              request.new_password1,
+            );
+            cy.dataCy(selectorFormResetPasswordConfirmInput).type(
               request.new_password2,
             );
             // submit form

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2546,3 +2546,27 @@ Cypress.Commands.add(
     );
   },
 );
+
+/**
+ * Check form field validation error color
+ * @param {String} formField - Form field Cypress selector
+ * @param {String} validationErrorColor - Form field validation error color RGB string
+ *                                        e.g. 'rgb(160, 215, 196)'
+ */
+
+Cypress.Commands.add(
+  'checkFormFieldValidationErrColor',
+  (formField, validationErrorColor) => {
+    // Activate form field validation
+    cy.dataCy(formField).should('be.visible').find('.q-field__control').focus();
+    cy.focused().blur();
+    // Form field
+    cy.dataCy(formField)
+      .find('.q-field__control')
+      .should('have.color', validationErrorColor);
+    // Validation error message
+    cy.dataCy(formField)
+      .find('.q-field__messages')
+      .should('have.color', validationErrorColor);
+  },
+);

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2553,7 +2553,6 @@ Cypress.Commands.add(
  * @param {String} validationErrorColor - Form field validation error color RGB string
  *                                        e.g. 'rgb(160, 215, 196)'
  */
-
 Cypress.Commands.add(
   'checkFormFieldValidationErrColor',
   (formField, validationErrorColor) => {


### PR DESCRIPTION
On the registration, login, forgotten and reset password URI page. Custom color is define in app global config as `colorCustomFormFieldValidationErr` var.