### PR TITLE
src/components/__tests__: fix checking subsidiary form field street address

### DIFF
--- a/src/components/__tests__/FormSelectOrganization.cy.js
+++ b/src/components/__tests__/FormSelectOrganization.cy.js
@@ -150,10 +150,12 @@ describe('<FormSelectOrganization>', () => {
                             .its('value')
                             .should('equal', apiPostSubsidiaryResponse.id);
                           // check that the subsidary (address) input has correct value
-                          cy.dataCy('form-company-address').should(
-                            'contain',
-                            apiPostSubsidiaryRequest.address.street,
-                          );
+                          cy.dataCy('form-company-address-input')
+                            .invoke('val')
+                            .should(
+                              'contain',
+                              apiPostSubsidiaryRequest.address.street,
+                            );
                         });
                       },
                     );


### PR DESCRIPTION
Fix `FormSelectOrganization` component 'allows to create a new organization and subsidiary' test.