### PR TITLE
src/stores: update call point for checkOrganizationHasCoordinator func to remove unnecessary API request

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -16,6 +16,7 @@ module.exports = defineConfig({
   screenshotsFolder: 'test/cypress/screenshots',
   videosFolder: 'test/cypress/videos',
   video: true,
+  requestTimeout: 12000,
   e2e: {
     setupNodeEvents(on, config) {
       addMatchImageSnapshotPlugin(on, config);

--- a/src/components/__tests__/RegisterChallengePayment.cy.js
+++ b/src/components/__tests__/RegisterChallengePayment.cy.js
@@ -828,6 +828,10 @@ function coreTests() {
     cy.get('.q-menu').within(() => {
       cy.get('.q-item').first().click();
     });
+    // wait for API coordinator status check
+    cy.fixture('apiGetHasOrganizationAdminResponseTrue').then((response) => {
+      cy.waitForHasOrganizationAdminApi(response);
+    });
     // checkbox become coordinator should not be visible
     cy.dataCy(selectorCoordinatorCheckbox).should('not.exist');
     // open organization select
@@ -838,6 +842,10 @@ function coreTests() {
     // select second organization
     cy.get('.q-menu').within(() => {
       cy.get('.q-item').eq(1).click();
+    });
+    // wait for API coordinator status check
+    cy.fixture('apiGetHasOrganizationAdminResponseFalse').then((response) => {
+      cy.waitForHasOrganizationAdminApi(response);
     });
     // checkbox become coordinator should be visible
     cy.dataCy(selectorCoordinatorCheckbox)

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -208,6 +208,8 @@ export default defineComponent({
           registerChallengeStore.setOrganizationId(value);
           // refetch subsidiaries
           registerChallengeStore.loadSubsidiariesToStore(logger);
+          // check if organization has coordinator
+          registerChallengeStore.checkOrganizationHasCoordinator();
         }
       },
     });

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -309,7 +309,6 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     setOrganizationId(id: number | null): void {
       this.organizationId = id;
-      this.checkOrganizationHasCoordinator();
     },
     setSubsidiaryId(subsidiaryId: number | null) {
       this.subsidiaryId = subsidiaryId;

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -2627,6 +2627,12 @@ describe('Register Challenge page', () => {
               .should('be.visible')
               .and('not.be.disabled')
               .click();
+            // wait for hasOrganizationAdmin API call
+            cy.fixture('apiGetHasOrganizationAdminResponseTrue').then(
+              (response) => {
+                cy.waitForHasOrganizationAdminApi(response);
+              },
+            );
             cy.testRegisterChallengeLoadedStepsThreeToFive(
               win.i18n,
               registerChallengeResponse,
@@ -2725,6 +2731,12 @@ describe('Register Challenge page', () => {
                 .should('be.visible')
                 .and('not.be.disabled')
                 .click();
+              // wait for hasOrganizationAdmin API call
+              cy.fixture('apiGetHasOrganizationAdminResponseFalse').then(
+                (response) => {
+                  cy.waitForHasOrganizationAdminApi(response);
+                },
+              );
               cy.testRegisterChallengeLoadedStepsThreeToFive(
                 win.i18n,
                 registerChallengeResponse,

--- a/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
+++ b/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
@@ -28,5 +28,5 @@
   "isPayuTransactionInitiated": false,
   "isSelectedRegisterCoordinator": false,
   "isUserOrganizationAdmin": false,
-  "hasOrganizationAdmin": true
+  "hasOrganizationAdmin": null
 }


### PR DESCRIPTION
Fixes [Bug 5](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=5).

Issue: `checkOrganizationHasCoordinator` is being called on every `organizationId` change in `registerChallenge` store. This results in unnecessary requests.

Solution: Call `checkOrganizationHasCoordinator` from `RegisterChallengePayment` (when `organizationId` changes)

This ensures correct loading of the data when necessary.
Data is used in Payment step and also in **notification banners** on step 7 "Summary" - we always pass "Payment" to get there, therefore the state will be always available.

* Includes update of test fixture which relates to Voucher registration, and therefore does not need coordinator info.