### PR TITLE
src/router: make routing use the registration phase interval instead of challenge phase interval

### DIFF
--- a/src/components/__tests__/FormRegister.cy.js
+++ b/src/components/__tests__/FormRegister.cy.js
@@ -17,7 +17,7 @@ import {
   httpTooManyRequestsStatusMessage,
   httpInternalServerErrorStatus,
   systemTimeChallengeActive,
-  systemTimeChallengeInactive,
+  systemTimeRegistrationPhaseInactive,
   userAgentHeader,
 } from '../../../test/cypress/support/commonTests';
 import { PhaseType } from '../types/Challenge';
@@ -434,7 +434,7 @@ describe('<FormRegister>', () => {
       cy.clock()
         .as('clock')
         .then((clock) => {
-          clock.setSystemTime(systemTimeChallengeInactive);
+          clock.setSystemTime(systemTimeRegistrationPhaseInactive);
         });
       cy.mount(FormRegister, {
         props: {},

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -68,17 +68,17 @@ export default route(function (/* { store, ssrContext } */) {
 
       logger?.debug(`Router path <${to.path}>.`);
       logger?.debug(`Router from path <${from.path}>.`);
-      logger?.debug(`Router is authenticated <${isAuthenticated}>.`);
-      logger?.debug(`Router is email verified <${isEmailVerified}>.`);
+      logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
+      logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
       logger?.debug(
-        `Router is registration active <${isRegistrationPhaseActive}>.`,
+        `Router registration phase is active <${isRegistrationPhaseActive}>.`,
       );
-      logger?.debug(`Router is challenge active <${isChallengeActive}>.`);
+      logger?.debug(`Router challenge phase is active <${isChallengeActive}>.`);
       logger?.debug(
-        `Router is registration complete <${isRegistrationComplete}>.`,
+        `Router registration is complete <${isRegistrationComplete}>.`,
       );
       logger?.debug(
-        `Router is user organization admin <${isUserOrganizationAdmin}>.`,
+        `Router user is organization admin <${isUserOrganizationAdmin}>.`,
       );
 
       if (

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -50,14 +50,17 @@ export default route(function (/* { store, ssrContext } */) {
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;
-      // const challengeStore = useChallengeStore();
+      const challengeStore = useChallengeStore();
       const loginStore = useLoginStore();
       const registerStore = useRegisterStore();
       const registerChallengeStore = useRegisterChallengeStore();
       const isAuthenticated: boolean = await loginStore.validateAccessToken();
       const isEmailVerified: boolean = registerStore.getIsEmailVerified;
-      const isChallengeActive: boolean =
-        useChallengeStore().getIsChallengeInPhase(PhaseType.competition);
+      const isRegistrationPhaseActive: boolean =
+        challengeStore.getIsChallengeInPhase(PhaseType.registration);
+      const isChallengeActive: boolean = challengeStore.getIsChallengeInPhase(
+        PhaseType.competition,
+      );
       const isRegistrationComplete: boolean =
         registerChallengeStore.getIsRegistrationComplete;
       const isUserOrganizationAdmin: boolean =
@@ -67,6 +70,9 @@ export default route(function (/* { store, ssrContext } */) {
       logger?.debug(`Router from path <${from.path}>.`);
       logger?.debug(`Router is authenticated <${isAuthenticated}>.`);
       logger?.debug(`Router is email verified <${isEmailVerified}>.`);
+      logger?.debug(
+        `Router is registration active <${isRegistrationPhaseActive}>.`,
+      );
       logger?.debug(`Router is challenge active <${isChallengeActive}>.`);
       logger?.debug(
         `Router is registration complete <${isRegistrationComplete}>.`,
@@ -106,11 +112,11 @@ export default route(function (/* { store, ssrContext } */) {
       } else if (
         isAuthenticated &&
         isEmailVerified &&
-        isChallengeActive &&
+        isRegistrationPhaseActive &&
         isRegistrationComplete &&
         /**
          * These pages are not accessible when authenticated and verified,
-         * challenge is active and registration is complete.
+         * registration phase is active and registration is complete.
          */
         to.matched.some(
           (record) =>
@@ -125,6 +131,12 @@ export default route(function (/* { store, ssrContext } */) {
       ) {
         logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
         logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
+        logger?.debug(
+          `Router registration phase is active <${isRegistrationPhaseActive}>`,
+        );
+        logger?.debug(
+          `Router registration is complete <${isRegistrationComplete}>`,
+        );
         logger?.debug(
           `Router path <${routesConf['login']['path']}>,` +
             ` <${routesConf['register']['path']}>` +
@@ -144,7 +156,6 @@ export default route(function (/* { store, ssrContext } */) {
                 record.path === routesConf['register_coordinator']['path'],
             )}>.`,
         );
-        logger?.debug(`Router challenge is active <${isChallengeActive}>`);
         logger?.debug(
           `Router path redirect to page URL <${routesConf['home']['path']}>.`,
         );
@@ -153,18 +164,20 @@ export default route(function (/* { store, ssrContext } */) {
       } else if (
         isAuthenticated &&
         isEmailVerified &&
-        !isChallengeActive &&
+        !isRegistrationPhaseActive &&
         !to.matched.some(
           /**
            * Only these pages are accessible when authenticated, verified email
-           * and challenge is not active.
+           * and registration phase is not active.
            */
           (record) => record.path === routesConf['challenge_inactive']['path'],
         )
       ) {
         logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
         logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
-        logger?.debug(`Router challenge is not active <${!isChallengeActive}>`);
+        logger?.debug(
+          `Router registration phase is not active <${!isRegistrationPhaseActive}>`,
+        );
         logger?.debug(
           `Router path <${routesConf['challenge_inactive']['path']}>` +
             ` is not matched <${!to.matched.some(
@@ -180,12 +193,12 @@ export default route(function (/* { store, ssrContext } */) {
       } else if (
         isAuthenticated &&
         isEmailVerified &&
-        isChallengeActive &&
+        isRegistrationPhaseActive &&
         !isRegistrationComplete &&
         !isUserOrganizationAdmin &&
         /**
          * Only these pages are accessible when authenticated, verified email
-         * challenge is active, registration is not complete and user is not
+         * registration phase is active, registration is not complete and user is not
          * organization admin.
          */
         !to.matched.some(
@@ -196,7 +209,9 @@ export default route(function (/* { store, ssrContext } */) {
       ) {
         logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
         logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
-        logger?.debug(`Router challenge is active <${isChallengeActive}>.`);
+        logger?.debug(
+          `Router registration phase is active <${isRegistrationPhaseActive}>.`,
+        );
         logger?.debug(
           `Router registration is not complete <${!isRegistrationComplete}>.`,
         );
@@ -220,12 +235,12 @@ export default route(function (/* { store, ssrContext } */) {
       } else if (
         isAuthenticated &&
         isEmailVerified &&
-        isChallengeActive &&
+        isRegistrationPhaseActive &&
         !isRegistrationComplete &&
         isUserOrganizationAdmin &&
         /**
          * These pages are not accessible when authenticated and verified,
-         * challenge is active, registration is not complete and user is
+         * registration phase is active, registration is not complete and user is
          * organization admin.
          */
         to.matched.some(
@@ -240,6 +255,15 @@ export default route(function (/* { store, ssrContext } */) {
       ) {
         logger?.debug(`Router user is authenticated <${isAuthenticated}>.`);
         logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
+        logger?.debug(
+          `Router registration phase is active <${isRegistrationPhaseActive}>.`,
+        );
+        logger?.debug(
+          `Router registration is not complete <${!isRegistrationComplete}>.`,
+        );
+        logger?.debug(
+          `Router user is organization admin <${isUserOrganizationAdmin}>.`,
+        );
         logger?.debug(
           `Router path <${routesConf['login']['path']}>,` +
             ` <${routesConf['register']['path']}>` +
@@ -256,13 +280,6 @@ export default route(function (/* { store, ssrContext } */) {
                 record.path === routesConf['routes']['path'] ||
                 record.path === routesConf['register_coordinator']['path'],
             )}>.`,
-        );
-        logger?.debug(`Router challenge is active <${isChallengeActive}>`);
-        logger?.debug(
-          `Router registration is not complete <${!isRegistrationComplete}>.`,
-        );
-        logger?.debug(
-          `Router user is organization admin <${isUserOrganizationAdmin}>.`,
         );
         logger?.debug(
           `Router path redirect to page URL <${routesConf['home']['path']}>.`,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -58,9 +58,6 @@ export default route(function (/* { store, ssrContext } */) {
       const isEmailVerified: boolean = registerStore.getIsEmailVerified;
       const isRegistrationPhaseActive: boolean =
         challengeStore.getIsChallengeInPhase(PhaseType.registration);
-      const isChallengeActive: boolean = challengeStore.getIsChallengeInPhase(
-        PhaseType.competition,
-      );
       const isRegistrationComplete: boolean =
         registerChallengeStore.getIsRegistrationComplete;
       const isUserOrganizationAdmin: boolean =
@@ -73,7 +70,6 @@ export default route(function (/* { store, ssrContext } */) {
       logger?.debug(
         `Router registration phase is active <${isRegistrationPhaseActive}>.`,
       );
-      logger?.debug(`Router challenge phase is active <${isChallengeActive}>.`);
       logger?.debug(
         `Router registration is complete <${isRegistrationComplete}>.`,
       );

--- a/test/cypress/e2e/challenge_inactive.spec.cy.js
+++ b/test/cypress/e2e/challenge_inactive.spec.cy.js
@@ -1,7 +1,7 @@
 import {
   testLanguageSwitcher,
   testBackgroundImage,
-  systemTimeChallengeInactive,
+  systemTimeRegistrationPhaseInactive,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 
@@ -23,7 +23,7 @@ const selectorSocialBar = 'social-bar';
 describe('Challenge Inactive page', () => {
   context('desktop', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive, ['Date']).then(() => {
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']).then(() => {
         cy.viewport('macbook-16');
         cy.task('getAppConfig', process).then((config) => {
           cy.interceptThisCampaignGetApi(config, defLocale);
@@ -54,7 +54,7 @@ describe('Challenge Inactive page', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive, ['Date']).then(() => {
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']).then(() => {
         cy.viewport('iphone-6');
         cy.task('getAppConfig', process).then((config) => {
           cy.interceptThisCampaignGetApi(config, defLocale);

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -1,5 +1,5 @@
 import {
-  systemTimeChallengeInactive,
+  systemTimeRegistrationPhaseInactive,
   testDesktopSidebar,
   testLanguageSwitcher,
   testMobileHeader,
@@ -341,7 +341,7 @@ describe('Home page', () => {
 
   context('before challenge', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive, ['Date']).then(() => {
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']).then(() => {
         // load config
         cy.task('getAppConfig', process).then((config) => {
           // alias config
@@ -411,7 +411,9 @@ describe('Home page', () => {
           (phase) => phase.phase_type === 'competition',
         );
         const competitionStart = new Date(competitionPhase.date_from).getTime();
-        const currentDate = new Date(systemTimeChallengeInactive).getTime();
+        const currentDate = new Date(
+          systemTimeRegistrationPhaseInactive,
+        ).getTime();
         // calculate time difference in milliseconds
         const timeDifference = competitionStart - currentDate;
 

--- a/test/cypress/e2e/register.spec.cy.js
+++ b/test/cypress/e2e/register.spec.cy.js
@@ -3,7 +3,7 @@ import {
   testBackgroundImage,
   httpInternalServerErrorStatus,
   systemTimeChallengeActive,
-  systemTimeChallengeInactive,
+  systemTimeRegistrationPhaseInactive,
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 
@@ -74,7 +74,7 @@ describe('Register page', () => {
 
   context('inactive challenge', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive, ['Date']).then(() => {
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']).then(() => {
         cy.viewport('macbook-16');
         cy.task('getAppConfig', process).then((config) => {
           /**

--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -5,7 +5,7 @@ import {
   interceptOrganizationsApi,
   interceptRegisterCoordinatorApi,
   systemTimeChallengeActive,
-  systemTimeChallengeInactive,
+  systemTimeRegistrationPhaseInactive,
   waitForOrganizationsApi,
 } from '../support/commonTests';
 import { OrganizationType } from '../../../src/components/types/Organization';
@@ -13,7 +13,7 @@ import { OrganizationType } from '../../../src/components/types/Organization';
 describe('Router rules', () => {
   context('challenge inactive', () => {
     beforeEach(() => {
-      cy.clock(systemTimeChallengeInactive, ['Date']);
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']);
       cy.viewport('macbook-16');
       cy.visit('#' + routesConf['login']['path']);
 

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -604,9 +604,19 @@ export const timeUntilExpiration = timeUntilRefresh * 2;
 // 2 min before JWT expires
 export const systemTimeLoggedIn =
   fixtureTokenExpirationTime - timeUntilExpiration;
-// time before challenge starts
+/**
+ * Time before `registration` phase starts
+ * Registration phase allows users to register for challenge
+ * even when `challenge` phase is not yet active.
+ * The `challenge` phase overlaps is typically contained within
+ * the `registration` phase.
+ * @see apiGetThisCampaign.json fixture for example
+ */
 export const systemTimeRegistrationPhaseInactive = new Date(
   '2024-07-14T23:59:00.000Z',
 );
-// time after challenge starts
+/**
+ * Time after `challenge` phase starts
+ * @see apiGetThisCampaign.json fixture for example
+ */
 export const systemTimeChallengeActive = new Date('2024-09-16T00:01:00.000Z');

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -378,7 +378,7 @@ export const setupApiChallengeInactive = (
     body: { has_user_verified_email_address: verifiedEmail },
   }).as('verifyEmail');
   // set system time to "before challenge"
-  cy.clock(systemTimeChallengeInactive, ['Date']);
+  cy.clock(systemTimeRegistrationPhaseInactive, ['Date']);
 };
 
 /**
@@ -605,6 +605,8 @@ export const timeUntilExpiration = timeUntilRefresh * 2;
 export const systemTimeLoggedIn =
   fixtureTokenExpirationTime - timeUntilExpiration;
 // time before challenge starts
-export const systemTimeChallengeInactive = new Date('2024-08-14T23:59:00.000Z');
+export const systemTimeRegistrationPhaseInactive = new Date(
+  '2024-07-14T23:59:00.000Z',
+);
 // time after challenge starts
 export const systemTimeChallengeActive = new Date('2024-09-16T00:01:00.000Z');


### PR DESCRIPTION
Make routing use the registration phase interval instead of challenge phase interval.

* Use correct interval `registration` for allowing users to register instaed of going to `challenge-inactive` page.
* Update test variable.