### PR TITLE
src/adapters: allow to submit empty newsletter field to register challenge POST API

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -81,10 +81,14 @@ export const registerChallengeAdapter = {
       if (storePersonalDetails.gender !== undefined) {
         payload.sex = storePersonalDetails.gender as Gender;
       }
-      if (storePersonalDetails.newsletter?.length) {
-        payload.newsletter = newsletterAdapter.combineNewsletterValues(
-          storePersonalDetails.newsletter,
-        );
+      if (storePersonalDetails.newsletter !== undefined) {
+        if (storePersonalDetails.newsletter?.length) {
+          payload.newsletter = newsletterAdapter.combineNewsletterValues(
+            storePersonalDetails.newsletter,
+          );
+        } else {
+          payload.newsletter = '';
+        }
       }
       if (storePersonalDetails.terms !== undefined) {
         payload.personal_data_opt_in = storePersonalDetails.terms;

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1769,6 +1769,65 @@ describe('Register Challenge page', () => {
       );
     });
 
+    it('submits personal details with empty newsletter', () => {
+      cy.fixture('apiPostRegisterChallengePersonalDetailsRequest').then(
+        (personalDetailsRequest) => {
+          // fill in name and nickname
+          cy.dataCy('form-firstName-input').type(
+            personalDetailsRequest.first_name,
+          );
+          cy.dataCy('form-lastName-input').type(
+            personalDetailsRequest.last_name,
+          );
+          cy.dataCy('form-nickname-input').type(
+            personalDetailsRequest.nickname,
+          );
+          // select first newsletter option
+          cy.dataCy('newsletter-option').first().click();
+          // select gender
+          cy.dataCy('form-personal-details-gender')
+            .find('.q-radio__label')
+            .first()
+            .click();
+          // agree with terms
+          cy.dataCy('form-personal-details-terms')
+            .find('.q-checkbox__inner')
+            .first()
+            .click();
+          // continue to step 2
+          cy.dataCy('step-1-continue').should('be.visible').click();
+          cy.dataCy('step-1-continue').find('.q-spinner').should('be.visible');
+          // test API POST request
+          cy.fixture(
+            'apiPostRegisterChallengePersonalDetailsChallengeNewsletter.json',
+          ).then((request) => {
+            cy.waitForRegisterChallengePostApi(request);
+          });
+          // on step 2
+          cy.dataCy('step-2')
+            .find('.q-stepper__step-content')
+            .should('be.visible');
+          // go back
+          cy.dataCy('step-2-back').should('be.visible').click();
+          // on step 1
+          cy.dataCy('step-1')
+            .find('.q-stepper__step-content')
+            .should('be.visible');
+          // deselect newsletter option
+          cy.dataCy('newsletter-option').first().click();
+          // continue to step 2
+          cy.dataCy('step-1-continue').should('be.visible').click();
+          cy.dataCy('step-1-continue').find('.q-spinner').should('be.visible');
+          // test API POST request
+          cy.fixture(
+            'apiPostRegisterChallengePersonalDetailsNoNewsletter.json',
+          ).then((request) => {
+            cy.waitForRegisterChallengePostApi(request);
+          });
+        },
+      );
+    });
+
     it('displays correct nav buttons on payment step based on payment configuration', () => {
       cy.get('@config').then((config) => {
         cy.get('@i18n').then((i18n) => {

--- a/test/cypress/fixtures/apiPostRegisterChallengePersonalDetailsChallengeNewsletter.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengePersonalDetailsChallengeNewsletter.json
@@ -1,0 +1,9 @@
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "nickname": "JD",
+  "sex": "male",
+  "newsletter": "challenge",
+  "personal_data_opt_in": true,
+  "language": "cs"
+}

--- a/test/cypress/fixtures/apiPostRegisterChallengePersonalDetailsNoNewsletter.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengePersonalDetailsNoNewsletter.json
@@ -1,0 +1,9 @@
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "nickname": "JD",
+  "sex": "male",
+  "newsletter": "",
+  "personal_data_opt_in": true,
+  "language": "cs"
+}


### PR DESCRIPTION
Fixes [Bug 76](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=76).

Issue: The `newsletter` value was not being saved when unselecting all options because empty fields are discarded by default.

Solution: Allow sending empty `newsletter` field so that user can clear the value by unchecking all options.