### PR TITLE
src/stores: clear voucher on step change if payment subject is not voucher

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -53,7 +53,7 @@ export const registerChallengeAdapter = {
       telephone: apiData.personal_details.telephone,
       telephoneOptIn: apiData.personal_details.telephone_opt_in,
       language: apiData.personal_details.language,
-      voucher: apiData.personal_details.discount_coupon || '',
+      voucher: apiData.personal_details.discount_coupon,
     };
   },
 

--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -53,7 +53,7 @@ export const registerChallengeAdapter = {
       telephone: apiData.personal_details.telephone,
       telephoneOptIn: apiData.personal_details.telephone_opt_in,
       language: apiData.personal_details.language,
-      voucher: apiData.personal_details.discount_coupon,
+      voucher: apiData.personal_details.discount_coupon || '',
     };
   },
 
@@ -117,6 +117,10 @@ export const registerChallengeAdapter = {
     }
     if (storeState.voucher) {
       payload.discount_coupon = storeState.voucher?.name;
+    }
+    // if voucher is empty make sure it is reset
+    if (storeState.voucher === null) {
+      payload.discount_coupon = '';
     }
     if (storeState.teamId !== undefined) {
       payload.team_id = storeState.teamId;

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -17,7 +17,7 @@ export type CorePersonalDetails = {
   age_group: number | null;
   newsletter: string;
   personal_data_opt_in: boolean;
-  discount_coupon: string | null;
+  discount_coupon: string;
   payment_subject: string;
   payment_amount: number | null;
 };

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -17,7 +17,7 @@ export type CorePersonalDetails = {
   age_group: number | null;
   newsletter: string;
   personal_data_opt_in: boolean;
-  discount_coupon: string;
+  discount_coupon: string | null;
   payment_subject: string;
   payment_amount: number | null;
 };

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -524,6 +524,10 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     async submitStep(
       step: RegisterChallengeStep,
     ): Promise<RegisterChallengePostResponse | null | true> {
+      // clear voucher on step change if payment subject is not voucher
+      if (this.voucher && this.paymentSubject !== PaymentSubject.voucher) {
+        this.setVoucher(null);
+      }
       // payload map defines what data is sent to the API for each step
       const isPaymentOrganization = this.getIsPaymentSubjectOrganization;
       /**

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1588,6 +1588,50 @@ describe('Register Challenge page', () => {
       });
     });
 
+    it('when voucher FULL and payment subject is changed to organization, voucher is reset', () => {
+      cy.get('@config').then((config) => {
+        cy.get('@i18n').then((i18n) => {
+          cy.passToStep2();
+          // wait for personal details POST request
+          cy.fixture(
+            'apiPostRegisterChallengePersonalDetailsRequest.json',
+          ).then((request) => {
+            cy.waitForRegisterChallengePostApi(request);
+          });
+          // select voucher payment
+          cy.dataCy(getRadioOption(PaymentSubject.voucher))
+            .should('be.visible')
+            .click();
+          // apply voucher FULL
+          cy.applyFullVoucher(config, i18n);
+          // go to next step
+          cy.dataCy('step-2-continue').should('be.visible').click();
+          // wait for payment POST request
+          cy.fixture('apiPostRegisterChallengeVoucherFullRequest.json').then(
+            (request) => {
+              cy.waitForRegisterChallengePostApi(request);
+            },
+          );
+          // go back
+          cy.dataCy('step-2-back').should('be.visible').click();
+          // select company pays
+          cy.dataCy(getRadioOption(PaymentSubject.company))
+            .should('be.visible')
+            .click();
+          // select paying company (required)
+          cy.selectRegisterChallengePayingOrganization();
+          // go to next step
+          cy.dataCy('step-2-continue').should('be.visible').click();
+          // voucher is reset
+          cy.fixture('apiPostRegisterChallengeVoucherNoneRequest.json').then(
+            (request) => {
+              cy.waitForRegisterChallengePostApi(request);
+            },
+          );
+        });
+      });
+    });
+
     it('submits form state on 1st 2nd, 5th and 6th step (voucher payment)', () => {
       cy.window().should('have.property', 'i18n');
       cy.get('@i18n').then((i18n) => {
@@ -1714,6 +1758,12 @@ describe('Register Challenge page', () => {
       });
       // go to next step
       cy.dataCy('step-2-continue').should('be.visible').click();
+      // test API post request (empty voucher)
+      cy.fixture('apiPostRegisterChallengeVoucherNoneRequest.json').then(
+        (request) => {
+          cy.waitForRegisterChallengePostApi(request);
+        },
+      );
       // participation is preselected - continue
       cy.dataCy('step-3-continue').should('be.visible').click();
       // organization is preselected - select address

--- a/test/cypress/fixtures/apiPostRegisterChallengeVoucherNoneRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeVoucherNoneRequest.json
@@ -1,0 +1,3 @@
+{
+  "discount_coupon": ""
+}


### PR DESCRIPTION
Clear voucher (both from local state and via API request) if `payment_subject` is not `voucher`.
This results in more accurate model of registration state.