### PR TITLE
src/components: make privacy policy link in RegisterChallengePayment coordinator form clickable

### DIFF
--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -599,6 +599,9 @@ export default defineComponent({
       () => registerChallengeStore.getSelectedOrganizationLabel,
     );
 
+    const urlAppDataPrivacyPolicy =
+      rideToWorkByBikeConfig.urlAppDataPrivacyPolicy;
+
     return {
       borderRadius,
       computedCurrentValue,
@@ -618,6 +621,7 @@ export default defineComponent({
       selectedPaymentAmount,
       selectedPaymentAmountCustom,
       selectedPaymentSubject,
+      urlAppDataPrivacyPolicy,
       Currency,
       formatPriceCurrency,
       onUpdateDonation,
@@ -829,10 +833,14 @@ export default defineComponent({
               <span>
                 {{ $t('register.coordinator.form.labelPrivacyConsent') }}
                 <!-- Link: terms -->
-                <!-- TODO: Link to terms page -->
-                <a href="#" target="_blank" class="text-primary">{{
-                  $t('register.coordinator.form.linkPrivacyConsent')
-                }}</a
+                <a
+                  :href="urlAppDataPrivacyPolicy"
+                  target="_blank"
+                  class="text-primary"
+                  @click.stop
+                  data-cy="form-terms-link"
+                >
+                  {{ $t('register.coordinator.form.linkPrivacyConsent') }} </a
                 >.
               </span>
             </q-checkbox>


### PR DESCRIPTION
Fixes [Bug 74](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=74).
Make privacy policy link in `RegisterChallengePayment` coordinator form clickable.
Use `@click.stop` to stop propagation of the event to the checkbox label.
Add test which confirms the behaviour.