### PR TITLE
src/components: save language on selection in LanguageSwitcher component

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -82,6 +82,9 @@ export const registerChallengeAdapter = {
       if (storePersonalDetails.gender !== undefined) {
         payload.sex = storePersonalDetails.gender as Gender;
       }
+      if (storePersonalDetails.language !== undefined) {
+        payload.language = storePersonalDetails.language;
+      }
       if (storePersonalDetails.newsletter !== undefined) {
         if (storePersonalDetails.newsletter?.length) {
           payload.newsletter = newsletterAdapter.combineNewsletterValues(

--- a/src/components/__tests__/LanguageSwitcher.cy.js
+++ b/src/components/__tests__/LanguageSwitcher.cy.js
@@ -4,6 +4,7 @@ import LanguageSwitcher from '../global/LanguageSwitcher.vue';
 import { i18n } from '../../boot/i18n';
 import { defaultLocale } from 'src/i18n/def_locale';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 
 const { getPaletteColor } = colors;
 const white = getPaletteColor('white');
@@ -183,8 +184,13 @@ describe('<LanguageSwitcher>', () => {
                   (requestPostEn) => {
                     cy.fixture('apiPostRegisterChallengeLanguageSk.json').then(
                       (requestPostSk) => {
+                        // set manually as data will be loaded by other components
+                        cy.wrap(useRegisterChallengeStore()).then((store) => {
+                          store.setRegisterChallengeFromApi(
+                            response.results[0],
+                          );
+                        });
                         // wait for initial GET request
-                        cy.waitForRegisterChallengeGetApi(response);
                         const personalDetails =
                           response.results[0].personal_details;
                         // switch to English

--- a/src/components/__tests__/LanguageSwitcher.cy.js
+++ b/src/components/__tests__/LanguageSwitcher.cy.js
@@ -130,7 +130,9 @@ describe('<LanguageSwitcher>', () => {
   context('mobile', () => {
     beforeEach(() => {
       cy.mount(LanguageSwitcher, {
-        props: {},
+        props: {
+          variant: 'light',
+        },
       });
       cy.viewport('iphone-6');
     });
@@ -170,7 +172,9 @@ describe('<LanguageSwitcher>', () => {
         );
       });
       cy.mount(LanguageSwitcher, {
-        props: {},
+        props: {
+          variant: 'light',
+        },
       });
     });
 

--- a/src/components/global/LanguageSwitcher.vue
+++ b/src/components/global/LanguageSwitcher.vue
@@ -57,9 +57,6 @@ export default defineComponent({
     });
 
     onMounted(async () => {
-      if (!registrationId.value) {
-        await registerChallengeStore.loadRegisterChallengeToStore();
-      }
       if (registerChallengeStore.getLanguage) {
         i18n.global.locale = registerChallengeStore.getLanguage;
       } else {
@@ -103,6 +100,11 @@ export default defineComponent({
     const onSetLanguage = async (item: string) => {
       i18n.global.locale = item;
       registerChallengeStore.setLanguage(item);
+      /**
+       * Registraion ID may not be available (if user is not logged in)
+       * or registred. In this case, the settings will be saved in local
+       * storage.
+       */
       if (registrationId.value) {
         const payload = registerChallengeAdapter.toApiPayload({
           personalDetails: {

--- a/src/components/global/LanguageSwitcher.vue
+++ b/src/components/global/LanguageSwitcher.vue
@@ -57,6 +57,10 @@ export default defineComponent({
     });
 
     onMounted(async () => {
+      if (!registrationId.value) {
+        registerChallengeStore.loadRegisterChallengeToStore();
+        return;
+      }
       if (registerChallengeStore.getLanguage) {
         i18n.global.locale = registerChallengeStore.getLanguage;
       } else {

--- a/src/components/global/LanguageSwitcher.vue
+++ b/src/components/global/LanguageSwitcher.vue
@@ -57,10 +57,6 @@ export default defineComponent({
     });
 
     onMounted(async () => {
-      if (!registrationId.value) {
-        registerChallengeStore.loadRegisterChallengeToStore();
-        return;
-      }
       if (registerChallengeStore.getLanguage) {
         i18n.global.locale = registerChallengeStore.getLanguage;
       } else {

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfileLanguageEn.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfileLanguageEn.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "id": 123,
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "en",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "done",
+        "payment_amount": 390
+      },
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 133
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfileLanguageSk.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfileLanguageSk.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "id": 123,
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "sk",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "done",
+        "payment_amount": 390
+      },
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 133
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiPostRegisterChallengeLanguageEn.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeLanguageEn.json
@@ -1,0 +1,3 @@
+{
+  "language": "en"
+}

--- a/test/cypress/fixtures/apiPostRegisterChallengeLanguageSk.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeLanguageSk.json
@@ -1,0 +1,3 @@
+{
+  "language": "sk"
+}


### PR DESCRIPTION
Issue: Currently, language is saved only on registration (step personal details), but UI does not allow to update it later (when selecting from language-switcher).

Solution: Add register-challenge PUT method to the `LanguageSwitcher` component.

---

Blocked by: Backend currently returns message "sk" is not a valid language option.