### PR TITLE
src/components/form: fix removing space from the typed discount coupon string

### DIFF
--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -62,6 +62,7 @@ export default defineComponent({
     const registerChallengeStore = useRegisterChallengeStore();
 
     const code = ref('');
+    const codeFormatted = computed(() => code.value.replace(/\s/g, ''));
     const voucher = computed<ValidatedCoupon | null>({
       get: (): ValidatedCoupon | null => registerChallengeStore.getVoucher,
       set: (voucher: ValidatedCoupon | null) => {
@@ -79,7 +80,7 @@ export default defineComponent({
     const onSubmitVoucher = async (): Promise<void> => {
       if (formFieldTextRequiredRef.value.inputRef.validate()) {
         const validatedCoupon: ValidatedCoupon = await validateCoupon(
-          code.value,
+          codeFormatted.value,
         );
 
         if (validatedCoupon.valid) {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1457,7 +1457,7 @@ Cypress.Commands.add('applyFullVoucher', (config, i18n) => {
  * @param {I18n} i18n - i18n instance
  */
 Cypress.Commands.add('applyInvalidVoucher', (config, i18n) => {
-  const invalid = 'INVALID';
+  const invalid = 'INVALID TOKEN WITH SPACES';
   cy.fixture('apiGetDiscountCouponResponseEmpty').then((responseEmpty) => {
     // intercept coupon endpoint
     cy.interceptDiscountCouponGetApi(config, i18n, invalid, responseEmpty);


### PR DESCRIPTION
Before send it to the REST API validation, to prevent get unexpected error message.

Fixes following [bug](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=78).