### PR TITLE
src/components: update CountdownEvent component title to correctly show challenge month

### DIFF
--- a/src/components/__tests__/CountdownEvent.cy.js
+++ b/src/components/__tests__/CountdownEvent.cy.js
@@ -29,7 +29,15 @@ describe('<CountdownEvent>', () => {
 
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
-      ['title', 'days', 'hours', 'minutes', 'seconds'],
+      [
+        'title.may',
+        'title.october',
+        'title.september',
+        'days',
+        'hours',
+        'minutes',
+        'seconds',
+      ],
       'index.countdown',
       i18n,
     );

--- a/src/components/homepage/CountdownEvent.vue
+++ b/src/components/homepage/CountdownEvent.vue
@@ -41,6 +41,7 @@ export default defineComponent({
   setup(props) {
     const fontSize = '48px';
 
+    const { challengeMonth } = rideToWorkByBikeConfig;
     const { countdown } = useCountdown(computed(() => props.releaseDate));
 
     // colors
@@ -66,6 +67,7 @@ export default defineComponent({
     }
 
     return {
+      challengeMonth,
       borderRadius,
       secondaryOpacity,
       countdown,
@@ -93,7 +95,7 @@ export default defineComponent({
         data-cy="title"
       >
         {{
-          $t('index.countdown.title', {
+          $t(`index.countdown.title.${challengeMonth}`, {
             date: releaseDateComputed
               ? $d(releaseDateComputed, 'monthDay')
               : releaseDateComputed,

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -473,7 +473,9 @@ emailRequired = "Prosím, zadejte e-mailovou adresu"
 submit = "Odeslat"
 
 [index.countdown]
-title = "Říjnová výzva začíná {date}, to je za"
+title.may = "Květnová výzva začíná {date}, to je za"
+title.october = "Říjnová výzva začíná {date}, to je za"
+title.september = "Záříjová výzva začíná {date}, to je za"
 days = "dní"
 hours = "hodin"
 minutes = "minut"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -471,7 +471,9 @@ emailRequired = "Please, fill in your email"
 submit = "Submit"
 
 [index.countdown]
-title = "October challenge starts {date}, that is in"
+title.may = "May challenge starts on {date}, that's in"
+title.october = "October challenge starts on {date}, that's in"
+title.september = "September challenge starts on {date}, that's in"
 days = "days"
 hours = "hours"
 minutes = "minutes"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -471,7 +471,9 @@ emailRequired = "Zadajte svoju e-mailovú adresu"
 submit = "Odoslať"
 
 [index.countdown]
-title = "Októbrová výzva začína {date}, to je pre"
+title.may = "Májová výzva začína {date}, to je za"
+title.october = "Októbrová výzva začína {date}, to je za"
+title.september = "Septembrová výzva začína {date}, to je za"
 days = "dní"
 hours = "hodin"
 minutes = "minút"

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -16,7 +16,7 @@ import { calculateCountdownIntervals } from '../../../src/utils';
 const failTestTitle = 'allows user to scroll to top using the footer button';
 const fontFamily = 'Poppins';
 const bottomPanelItemsIncludingMenu = 4;
-const bottomPanelDialogItems = 2;
+const bottomPanelDialogItems = 3;
 
 describe('Home page', () => {
   Cypress.on('fail', (err, runnable) => {


### PR DESCRIPTION
Fixes [Bug 83](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=83).
Update `CountdownEvent` component title to correctly show challenge month.

* Update translation key to depend on `challengeMonth` config var.
* Add translation strings for different options.

Additional change: Fix `home.spec` E2E test by updating the number of expected items in bottom panel.