### PR TITLE
src/adapters: add missing rounding function for coupon discount calculation

### DIFF
--- a/src/adapters/payuAdapter.ts
+++ b/src/adapters/payuAdapter.ts
@@ -43,9 +43,10 @@ export const payuAdapter = {
       defaultPaymentAmountMinComputed(priceLevels);
     let defaultPaymentAmountCoupon = defaultPaymentAmountBasic;
     if (voucher?.valid && voucher.discount) {
-      defaultPaymentAmountCoupon =
+      defaultPaymentAmountCoupon = Math.round(
         defaultPaymentAmountBasic -
-        (defaultPaymentAmountBasic * voucher.discount) / 100;
+          (defaultPaymentAmountBasic * voucher.discount) / 100,
+      );
     }
 
     const products: PayuProduct[] = [];

--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -311,8 +311,9 @@ export default defineComponent({
       ) {
         const discountAmount: number =
           (defaultPaymentAmountMin.value * activeVoucher.value?.discount) / 100;
-        const discountedAmount: number =
-          defaultPaymentAmountMin.value - discountAmount;
+        const discountedAmount: number = Math.round(
+          defaultPaymentAmountMin.value - discountAmount,
+        );
         logger?.debug(
           `Selected payment subject <${selectedPaymentSubject.value}>,` +
             ` is voucher valid <${isVoucherValid.value}>,` +

--- a/test/cypress/fixtures/apiGetDiscountCouponResponse95.json
+++ b/test/cypress/fixtures/apiGetDiscountCouponResponse95.json
@@ -1,0 +1,12 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "name": "TS-KM4NP9",
+      "discount": 95,
+      "available": true
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetThisCampaignMay.json
+++ b/test/cypress/fixtures/apiGetThisCampaignMay.json
@@ -1,0 +1,110 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "phase_set": [
+        {
+          "phase_type": "registration",
+          "date_from": "2025-01-28",
+          "date_to": "2025-06-01"
+        },
+        {
+          "phase_type": "competition",
+          "date_from": "2025-05-01",
+          "date_to": "2025-05-31"
+        },
+        {
+          "phase_type": "entry_enabled",
+          "date_from": "2025-05-01",
+          "date_to": "2025-06-03"
+        },
+        {
+          "phase_type": "payment",
+          "date_from": "2025-01-28",
+          "date_to": "2025-06-01"
+        },
+        {
+          "phase_type": "invoices",
+          "date_from": "2025-02-01",
+          "date_to": "2025-06-04"
+        },
+        {
+          "phase_type": "results",
+          "date_from": "2025-05-01",
+          "date_to": "2025-06-30"
+        },
+        {
+          "phase_type": "admissions",
+          "date_from": "2025-02-01",
+          "date_to": "2025-06-03"
+        }
+      ],
+      "days_active": 15,
+      "max_team_members": 5,
+      "price_level": [
+        {
+          "name": "2. vlna registrace",
+          "price": 500,
+          "category": "basic",
+          "takes_effect_on": "2025-03-01"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 500,
+          "category": "company",
+          "takes_effect_on": "2025-03-01"
+        },
+        {
+          "name": "3. vlna registrace",
+          "price": 550,
+          "category": "basic",
+          "takes_effect_on": "2025-04-03"
+        },
+        {
+          "name": "3. vlna registrace",
+          "price": 550,
+          "category": "company",
+          "takes_effect_on": "2025-04-03"
+        },
+        {
+          "name": "4. vlna registrace",
+          "price": 600,
+          "category": "basic",
+          "takes_effect_on": "2025-04-17"
+        },
+        {
+          "name": "4. vlna registrace",
+          "price": 600,
+          "category": "company",
+          "takes_effect_on": "2025-04-17"
+        },
+        {
+          "name": "1. vlna registrace",
+          "price": 470,
+          "category": "basic",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
+          "name": "1. vlna registrace",
+          "price": 470,
+          "category": "company",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
+          "name": "5. vlna registrace",
+          "price": 650,
+          "category": "basic",
+          "takes_effect_on": "2025-05-01"
+        },
+        {
+          "name": "5. vlna registrace",
+          "price": 650,
+          "category": "company",
+          "takes_effect_on": "2025-05-01"
+        }
+      ]
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiPostPayuCreateOrderRequestVoucher95NoDonation.json
+++ b/test/cypress/fixtures/apiPostPayuCreateOrderRequestVoucher95NoDonation.json
@@ -1,0 +1,13 @@
+{
+  "amount": 24,
+  "client_ip": "185.250.215.37",
+  "payment_subject": "voucher",
+  "payment_category": "entry_fee",
+  "products": [
+    {
+      "name": "RTWBB challenge entry fee",
+      "unitPrice": 24,
+      "quantity": 1
+    }
+  ]
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -553,7 +553,7 @@ Cypress.Commands.add(
  * Wait for `@thisCampaignRequest` intercept
  * @param {object} thisCampaignResponse - Get this campaign API data response
  */
-Cypress.Commands.add('waitForThisCampaignApi', () => {
+Cypress.Commands.add('waitForThisCampaignApi', (responseBody = null) => {
   cy.fixture('apiGetThisCampaign').then((thisCampaignResponse) => {
     cy.wait('@thisCampaignRequest').then((thisCampaignRequest) => {
       if (thisCampaignRequest.response) {
@@ -561,7 +561,7 @@ Cypress.Commands.add('waitForThisCampaignApi', () => {
           httpSuccessfullStatus,
         );
         expect(thisCampaignRequest.response.body).to.deep.equal(
-          thisCampaignResponse,
+          responseBody ? responseBody : thisCampaignResponse,
         );
       }
     });

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -631,3 +631,11 @@ export const systemTimeRegistrationPhaseInactive = new Date(
  * @see apiGetThisCampaign.json fixture for example
  */
 export const systemTimeChallengeActive = new Date('2024-09-16T00:01:00.000Z');
+/**
+ * Time after `registration` phase starts for May campaign
+ * 1st registration phase starts on 28th January 2025
+ * @see apiGetThisCampaignMay.json fixture for example
+ */
+export const systemTimeRegistrationPhase1May = new Date(
+  '2025-01-28T00:01:00.000Z',
+);


### PR DESCRIPTION
Fixes [Bug 85](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=85).

Issue: When discount amount is calculated as a decimal number (to be rounded up, e.g `23.5Kč`), some parts of code do not correctly calculate rounded amount (`24Kč`). This results in incorrect `if` statement result in `payuAdapter.ts:76`, and that in turn prevents user to send payment order.

Solution: Add missing rounding functions in `payuAdapter.ts` and `RegisterChallengePayment.vue`.

Add E2E test which tests specific case with decimal voucher discount. Add new fixtures and timestamp for this test.