### PR TITLE
src/stores: load coupon on register challenge refresh in registerChallenge store

### DIFF
--- a/src/components/register/RegisterChallengePayment.vue
+++ b/src/components/register/RegisterChallengePayment.vue
@@ -373,62 +373,66 @@ export default defineComponent({
       return opts;
     });
 
-    watch(optionsPaymentAmountComputed, (options) => {
-      const optsVals = options.map((option) => option.value);
-      logger?.debug(
-        `Computed payment subject option change to <${selectedPaymentSubject.value}>` +
-          ` for <${i18n.global.t('register.challenge.labelPaymentSubject')}> radio element` +
-          ` and amount options changed to <${optsVals}> for` +
-          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
-          ' radio button element.',
-      );
-      // New payment options include currently selected amount
-      const newPaymentOptionsIncludeSelectedAmount = optsVals.includes(
-        selectedPaymentAmount.value,
-      );
-      // Selected payment amount is custom
-      const isSelectedAmountCustom =
-        selectedPaymentAmount.value === PaymentAmount.custom;
+    watch(
+      optionsPaymentAmountComputed,
+      (options) => {
+        const optsVals = options.map((option) => option.value);
+        logger?.debug(
+          `Computed payment subject option change to <${selectedPaymentSubject.value}>` +
+            ` for <${i18n.global.t('register.challenge.labelPaymentSubject')}> radio element` +
+            ` and amount options changed to <${optsVals}> for` +
+            ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+            ' radio button element.',
+        );
+        // New payment options include currently selected amount
+        const newPaymentOptionsIncludeSelectedAmount = optsVals.includes(
+          selectedPaymentAmount.value,
+        );
+        // Selected payment amount is custom
+        const isSelectedAmountCustom =
+          selectedPaymentAmount.value === PaymentAmount.custom;
 
-      // Reset custom payment amount to first option to update slider min value
-      if (isSelectedAmountCustom && optsVals.length > 0) {
+        // Reset custom payment amount to first option to update slider min value
+        if (isSelectedAmountCustom && optsVals.length > 0) {
+          logger?.debug(
+            `Selected payment amount is <${selectedPaymentAmountCustom.value}>,` +
+              ` reset it to the first option <${optsVals[0]}>.`,
+          );
+          selectedPaymentAmount.value = String(optsVals[0]);
+        }
+        // New payment options include selected amount
+        else if (newPaymentOptionsIncludeSelectedAmount) {
+          logger?.debug(
+            'New payment options include selected payment amount' +
+              ` <${selectedPaymentAmount.value}>, selected payment` +
+              ` amount is the same <${selectedPaymentAmount.value}>.`,
+          );
+        }
+        // New payment options do not include selected amount
+        else if (!newPaymentOptionsIncludeSelectedAmount) {
+          selectedPaymentAmount.value = String(optsVals[0]);
+          logger?.debug(
+            'New payment options do not include selected payment amount' +
+              ` <${selectedPaymentAmount.value}>, set new selected payment` +
+              ` amount to <${selectedPaymentAmount.value}>.`,
+          );
+        }
+        // No payment options, clear selected amount value
+        else if (optsVals.length === 0) {
+          selectedPaymentAmount.value = '';
+          logger?.debug(
+            'No payment options for payment amount, set selected amount to' +
+              ` <${selectedPaymentAmount.value}>.`,
+          );
+        }
         logger?.debug(
-          `Selected payment amount is <${selectedPaymentAmountCustom.value}>,` +
-            ` reset it to the first option <${optsVals[0]}>.`,
+          `New selected payment amount <${selectedPaymentAmount.value}> for` +
+            ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+            ' radio button element.',
         );
-        selectedPaymentAmount.value = String(optsVals[0]);
-      }
-      // New payment options include selected amount
-      else if (newPaymentOptionsIncludeSelectedAmount) {
-        logger?.debug(
-          'New payment options include selected payment amount' +
-            ` <${selectedPaymentAmount.value}>, selected payment` +
-            ` amount is the same <${selectedPaymentAmount.value}>.`,
-        );
-      }
-      // New payment options do not include selected amount
-      else if (!newPaymentOptionsIncludeSelectedAmount) {
-        selectedPaymentAmount.value = String(optsVals[0]);
-        logger?.debug(
-          'New payment options do not include selected payment amount' +
-            ` <${selectedPaymentAmount.value}>, set new selected payment` +
-            ` amount to <${selectedPaymentAmount.value}>.`,
-        );
-      }
-      // No payment options, clear selected amount value
-      else if (optsVals.length === 0) {
-        selectedPaymentAmount.value = '';
-        logger?.debug(
-          'No payment options for payment amount, set selected amount to' +
-            ` <${selectedPaymentAmount.value}>.`,
-        );
-      }
-      logger?.debug(
-        `New selected payment amount <${selectedPaymentAmount.value}> for` +
-          ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
-          ' radio button element.',
-      );
-    });
+      },
+      { immediate: true },
+    );
 
     /**
      * Set selected custom payment amount model value
@@ -447,22 +451,26 @@ export default defineComponent({
      * After selecting a payment amount from the given options,
      * set it as the default value for custom payment amount.
      */
-    watch(selectedPaymentAmount, (newVal, oldVal) => {
-      logger?.debug(
-        `Selected payment amount option changed from <${oldVal}>` +
-          ` to <${newVal}> for <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
-          ' radio button element.',
-      );
-      if (newVal !== PaymentAmount.custom) {
-        setSelectedPaymentAmountCustomVal(selectedPaymentAmount.value);
+    watch(
+      selectedPaymentAmount,
+      (newVal, oldVal) => {
         logger?.debug(
-          `Set new value <${selectedPaymentAmountCustom.value}> with` +
-            ` type <${typeof selectedPaymentAmountCustom.value}> for` +
-            ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
-            ' radio button element custom option slider element.',
+          `Selected payment amount option changed from <${oldVal}>` +
+            ` to <${newVal}> for <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+            ' radio button element.',
         );
-      }
-    });
+        if (newVal !== PaymentAmount.custom) {
+          setSelectedPaymentAmountCustomVal(selectedPaymentAmount.value);
+          logger?.debug(
+            `Set new value <${selectedPaymentAmountCustom.value}> with` +
+              ` type <${typeof selectedPaymentAmountCustom.value}> for` +
+              ` <${i18n.global.t('register.challenge.labelPaymentAmount')}>` +
+              ' radio button element custom option slider element.',
+          );
+        }
+      },
+      { immediate: true },
+    );
 
     /**
      * Compute current value based on selected payment subject, amount option and donation

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -23,6 +23,7 @@ import { useApiGetIpAddress } from '../composables/useApiGetIpAddress';
 import { useApiPostPayuCreateOrder } from '../composables/useApiPostPayuCreateOrder';
 import { useApiGetHasOrganizationAdmin } from '../composables/useApiGetHasOrganizationAdmin';
 import { useApiIsUserOrganizationAdmin } from '../composables/useApiIsUserOrganizationAdmin';
+import { useApiGetDiscountCoupon } from '../composables/useApiGetDiscountCoupon';
 
 // enums
 import { Gender } from '../components/types/Profile';
@@ -389,7 +390,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       this.isLoadingRegisterChallenge = true;
       await loadRegistrations();
       if (registrations.value.length > 0) {
-        this.setRegisterChallengeFromApi(registrations.value[0]);
+        await this.setRegisterChallengeFromApi(registrations.value[0]);
       } else {
         this.$log?.info(
           'No registration challenge data available to set store state.',
@@ -401,7 +402,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
      * Set store state from API registration data
      * @param registration - Registration data from API
      */
-    setRegisterChallengeFromApi(registration: RegisterChallengeResult): void {
+    async setRegisterChallengeFromApi(
+      registration: RegisterChallengeResult,
+    ): Promise<void> {
       this.$log?.debug(
         `Setting store state from registration challenge data <${JSON.stringify(
           registration,
@@ -417,29 +420,27 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       );
       /**
        * The paymentAmount value is sent for subject = 'company' or 'school'.
-       * TODO: It is sent to the API after the TEAM step is completed.
+       * !It is sent to the API after the TEAM step is completed.
        * If sent earlier, we cannot determine the right coordinator.
        * paymentAmount indicates what was the price for which the user
        * registered. We store the amount because the price changes.
        */
       /**
-       * The paymentVoucher value is sent when discounted payment is made.
-       * We do not need the name value (unless for information purposes)
-       * as the payment must be made immediately.
-       * If voucher is saved and paymentAmount is null, we set the voucher
-       * as a full discount voucher.
+       * Re-validate `voucher` value over API every time registration is loaded
+       * to prevent incorrect voucher value from being set.
        */
-      const isVoucherFullDiscount =
-        parsedResponse.voucher &&
-        parsedResponse.paymentSubject === PaymentSubject.voucher &&
-        (!parsedResponse.paymentAmount ||
-          parsedResponse.paymentCategory === PaymentCategory.donation);
-      if (isVoucherFullDiscount) {
-        this.setVoucher({
-          valid: true,
-          discount: 100,
-          name: parsedResponse.voucher,
-        });
+      if (parsedResponse.voucher) {
+        const { validateCoupon } = useApiGetDiscountCoupon(null);
+        const validatedCoupon = await validateCoupon(parsedResponse.voucher);
+        if (validatedCoupon.valid) {
+          this.setVoucher(validatedCoupon);
+        } else {
+          Notify.create({
+            type: 'negative',
+            message: i18n.global.t('notify.voucherApplyError'),
+          });
+          this.setVoucher(null);
+        }
       }
       /**
        * Update payment subject to API response value if not exception case

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -430,7 +430,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
        * to prevent incorrect voucher value from being set.
        */
       if (parsedResponse.voucher) {
-        const { validateCoupon } = useApiGetDiscountCoupon(null);
+        const { validateCoupon } = useApiGetDiscountCoupon(this.$log);
         const validatedCoupon = await validateCoupon(parsedResponse.voucher);
         if (validatedCoupon.valid) {
           this.setVoucher(validatedCoupon);

--- a/test/cypress/fixtures/apiGetRegisterChallengeVoucher95NotApplied.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeVoucher95NotApplied.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "TS-KM4NP9",
+        "payment_subject": "voucher",
+        "payment_type": "",
+        "payment_status": "none",
+        "payment_amount": null,
+        "payment_category": ""
+      },
+      "organization_type": "school",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes [Bug 86](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=86).
Load coupon on register challenge refresh in `registerChallenge` store.

Issue: When registration is loaded the logic incorrectly assumes 100% discount from saved coupon.

Solution:
* Recheck voucher via API on load.
* Add `{ immediate: true }` to `RegisterChallengePayment` watchers to display voucher data in Payment step on load.
* Add E2E test with a new fixture for given case.