### PR TITLE
test/cypress/e2e: fix Cypress company_coordinator e2e 'displays company coordinator disabled text' test

### DIFF
--- a/test/cypress/e2e/company_coordinator.spec.cy.js
+++ b/test/cypress/e2e/company_coordinator.spec.cy.js
@@ -70,10 +70,10 @@ describe('Company Coordinator Page', () => {
           cy.dataCy(selectorCompanyCoordinatorDisabledText)
             .find('a')
             .should('have.attr', 'href')
-            .and('eq', config.urlRideToWorkByBikeOldSystem);
+            .and('eq', config.urlRideToWorkByBikeOldFrontendDjangoApp);
           // check if the link is accessible
           cy.request({
-            url: config.urlRideToWorkByBikeOldSystem,
+            url: config.urlRideToWorkByBikeOldFrontendDjangoApp,
             failOnStatusCode: failOnStatusCode,
             headers: { ...userAgentHeader },
           }).then((resp) => {


### PR DESCRIPTION
Fix Cypress company_coordinator e2e 'displays company coordinator disabled text' test.

Error message:

```
1) Company Coordinator Page
       general
         displays company coordinator disabled text:
     AssertionError: Timed out retrying after 60000ms: expected 'https://dpnk.dopracenakole.net/' to equal undefined
```