### PR TITLE
src/mocks: update newsletter items list to computed value to show dynamically translated labels

### DIFF
--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -3,7 +3,7 @@ import { colors } from 'quasar';
 import NewsletterItem from '../homepage/NewsletterItem.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
-import { newsletterItems as newsletterItemsFixture } from '../../mocks/homepage';
+import { newsletterItems } from '../../mocks/homepage';
 import { vModelAdapter } from '../../../test/cypress/utils';
 
 // colors
@@ -28,7 +28,7 @@ const colorPrimaryOpacity = changeAlpha(
   rideToWorkByBikeConfig.colorPrimaryOpacity,
 );
 
-const model = ref([newsletterItemsFixture[0].id]);
+const model = ref([newsletterItems.value[0].id]);
 const modelEmpty = ref([]);
 
 describe('<NewsletterItem>', () => {
@@ -36,7 +36,7 @@ describe('<NewsletterItem>', () => {
     beforeEach(() => {
       cy.mount(NewsletterItem, {
         props: {
-          item: newsletterItemsFixture[0],
+          item: newsletterItems.value[0],
           ...vModelAdapter(model),
         },
       });
@@ -84,7 +84,7 @@ describe('<NewsletterItem>', () => {
     beforeEach(() => {
       cy.mount(NewsletterItem, {
         props: {
-          item: newsletterItemsFixture[0],
+          item: newsletterItems.value[0],
           ...vModelAdapter(model),
         },
       });
@@ -134,7 +134,7 @@ describe('<NewsletterItem>', () => {
     beforeEach(() => {
       cy.mount(NewsletterItem, {
         props: {
-          item: newsletterItemsFixture[0],
+          item: newsletterItems.value[0],
           ...vModelAdapter(modelEmpty),
         },
       });
@@ -162,9 +162,9 @@ describe('<NewsletterItem>', () => {
           .should('have.css', 'font-size', '14px')
           .and('have.css', 'font-weight', '400')
           .and('have.color', grey10)
-          .and('contain', newsletterItemsFixture[0].title)
+          .and('contain', newsletterItems.value[0].title)
           .then(($title) => {
-            expect($title.text()).to.equal(newsletterItemsFixture[0].title);
+            expect($title.text()).to.equal(newsletterItems.value[0].title);
           });
       });
     });

--- a/src/components/__tests__/NewsletterItem.cy.js
+++ b/src/components/__tests__/NewsletterItem.cy.js
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { colors } from 'quasar';
 import NewsletterItem from '../homepage/NewsletterItem.vue';
 import { i18n } from '../../boot/i18n';
+import { defaultLocale } from '../../i18n/def_locale';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { newsletterItems } from '../../mocks/homepage';
 import { vModelAdapter } from '../../../test/cypress/utils';
@@ -76,6 +77,44 @@ describe('<NewsletterItem>', () => {
         cy.dataCy(newsletterItemFollowIcon)
           .invoke('width')
           .should('be.eq', iconSize);
+      });
+    });
+  });
+
+  context('desktop - change default lang to the en lang', () => {
+    beforeEach(() => {
+      i18n.global.locale = 'en';
+      cy.mount(NewsletterItem, {
+        props: {
+          item: newsletterItems.value[0],
+          ...vModelAdapter(model),
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+    afterEach(() => {
+      i18n.global.locale = defaultLocale;
+    });
+
+    it('renders title', () => {
+      cy.window().then(() => {
+        cy.dataCy(newsletterItemTitle)
+          .should('have.css', 'font-size', '14px')
+          .and('have.css', 'font-weight', '400')
+          .and('have.color', grey10)
+          .and(
+            'contain',
+            i18n.global.t('index.newsletterFeature.aboutChallenges', {
+              locale: i18n.global.locale,
+            }),
+          )
+          .then(($title) => {
+            expect($title.text()).to.equal(
+              i18n.global.t('index.newsletterFeature.aboutChallenges', {
+                locale: i18n.global.locale,
+              }),
+            );
+          });
       });
     });
   });

--- a/src/components/homepage/NewsletterFeature.vue
+++ b/src/components/homepage/NewsletterFeature.vue
@@ -36,14 +36,14 @@ import { i18n } from '../../boot/i18n';
 import { useApiPutRegisterChallenge } from '../../composables/useApiPutRegisterChallenge';
 
 // mocks
-import { newsletterItems as newsletterItemsFixture } from '../../mocks/homepage';
+import { newsletterItems } from '../../mocks/homepage';
 
 // stores
 import { useLoginStore } from '../../stores/login';
 import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 
 // types
-import { NewsletterItem as NewsletterItemType, NewsletterType } from '../types';
+import { NewsletterType } from '../types';
 
 export default defineComponent({
   name: 'NewsletterFeature',
@@ -113,8 +113,6 @@ export default defineComponent({
             email: user?.email ? ` <b>${user.email}</b>` : '',
           });
     });
-
-    const newsletterItems = newsletterItemsFixture as NewsletterItemType[];
 
     const headingMaxWidth = Screen.sizes.sm;
 

--- a/src/components/types/Newsletter.ts
+++ b/src/components/types/Newsletter.ts
@@ -2,7 +2,6 @@ export interface NewsletterItem {
   id: NewsletterType;
   icon: string;
   title: string;
-  following: boolean;
 }
 
 export enum NewsletterType {

--- a/src/mocks/homepage.ts
+++ b/src/mocks/homepage.ts
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { i18n } from 'src/boot/i18n';
 
 // types
@@ -298,7 +299,7 @@ export const cardsProgress: CardProgress[] = [
   },
 ];
 
-export const newsletterItems: Partial<NewsletterItem>[] = [
+export const newsletterItems = computed<NewsletterItem[]>(() => [
   {
     id: NewsletterType.challenge,
     title: i18n.global.t('index.newsletterFeature.aboutChallenges'),
@@ -314,7 +315,7 @@ export const newsletterItems: Partial<NewsletterItem>[] = [
     title: i18n.global.t('index.newsletterFeature.aboutMobility'),
     icon: 'svguse:icons/newsletter_item/icons.svg#tabler-leaf',
   },
-];
+]);
 
 export const badgeList: ItemBadge[] = [
   {

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -207,6 +207,47 @@ describe('Home page', () => {
         });
     });
 
+    it('renders newsletter labels in correct language', () => {
+      cy.get('@i18n').then((i18n) => {
+        Object.keys(i18n.global.messages).forEach((key) => {
+          // set language to given locale
+          cy.dataCy(`switcher-button-${key}`).click();
+          // test newsletter labels for selected locale
+          cy.dataCy('newsletter-feature-item')
+            .should(
+              'contain',
+              i18n.global.t(
+                'index.newsletterFeature.aboutChallenges',
+                {},
+                {
+                  locale: key,
+                },
+              ),
+            )
+            .and(
+              'contain',
+              i18n.global.t(
+                'index.newsletterFeature.aboutEvents',
+                {},
+                {
+                  locale: key,
+                },
+              ),
+            )
+            .and(
+              'contain',
+              i18n.global.t(
+                'index.newsletterFeature.aboutMobility',
+                {},
+                {
+                  locale: key,
+                },
+              ),
+            );
+        });
+      });
+    });
+
     it(failTestTitle, () => {
       cy.dataCy('footer-top-button').should('be.visible').click();
       cy.window().its('scrollY').should('equal', 0);


### PR DESCRIPTION
Issue: When switching between languages on homepage, labels for different newsletter subscriptions do not change and only show in Czech language.

Solution: Change the newsletter items list to `computed` value to update on language change.

* Update the `NewsletterItem` type, which should no longer contain the `following` property.
* Simplify the `newsletterItems` import in `NewsletterFeature` component.
* Update `NewsletterItem.cy.js` component test to use the `.value` of the computed ref.
* Add E2E test which validates correct language of labels when given locale is selected.