### PR TITLE
src/components: allow updating user phone number in ProfileDetails component

### DIFF
--- a/src/components/__tests__/FormUpdatePhone.cy.js
+++ b/src/components/__tests__/FormUpdatePhone.cy.js
@@ -76,7 +76,7 @@ function coreTests() {
     cy.testElementsSideBySide(selectorFormButtonCancel, selectorFormButtonSave);
   });
 
-  it('validates form on submit and allows enter key submission', () => {
+  it('updates form validation messages on submit and input blur', () => {
     // save
     cy.dataCy(selectorFormButtonSave).should('be.visible').click();
     // validate phone required

--- a/src/components/__tests__/FormUpdatePhone.cy.js
+++ b/src/components/__tests__/FormUpdatePhone.cy.js
@@ -81,20 +81,23 @@ function coreTests() {
     cy.dataCy(selectorFormButtonSave).should('be.visible').click();
     // validate phone required
     cy.dataCy(selectorFormPhone)
-      .find('.q-field__messages')
       .should('be.visible')
+      .find('.q-field__messages')
+      .should('not.be.visible')
       .and(
-        'contain',
+        'not.contain',
         i18n.global.t('form.messageFieldRequired', {
           fieldName: i18n.global.t('form.labelPhone'),
         }),
       );
+
     // enter invalid phone
     cy.dataCy(selectorFormPhone).find('input').clear();
     cy.dataCy(selectorFormPhone).find('input').type(invalidPhone);
     cy.dataCy(selectorFormPhone).find('input').blur();
     // invalid phone message is visible
     cy.dataCy(selectorFormPhone)
+      .should('be.visible')
       .find('.q-field__messages')
       .should('be.visible')
       .and('contain', i18n.global.t('form.messagePhoneInvalid'));

--- a/src/components/__tests__/FormUpdatePhone.cy.js
+++ b/src/components/__tests__/FormUpdatePhone.cy.js
@@ -1,0 +1,110 @@
+import { ref } from 'vue';
+import FormUpdatePhone from 'components/form/FormUpdatePhone.vue';
+import { i18n } from '../../boot/i18n';
+import { vModelAdapter } from '../../../test/cypress/utils';
+
+// selectors
+const selectorFormUpdatePhone = 'form-update-phone';
+const selectorFormButtonSave = 'form-button-save';
+const selectorFormButtonCancel = 'form-button-cancel';
+const selectorFormPhone = 'form-phone';
+
+// variables
+const invalidPhone = '123';
+const validPhone = '+420777888999';
+
+const model = ref('');
+const setModelValue = (value) => {
+  model.value = value;
+};
+
+describe('<FormUpdatePhone>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['discardChanges', 'save'],
+      'navigation',
+      i18n,
+    );
+  });
+
+  context('desktop', () => {
+    beforeEach(() => {
+      cy.wrap(setModelValue(''));
+      cy.mount(FormUpdatePhone, {
+        props: {
+          ...vModelAdapter(model),
+          onClose: () => {},
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+  });
+
+  context('mobile', () => {
+    beforeEach(() => {
+      cy.wrap(setModelValue(''));
+      cy.mount(FormUpdatePhone, {
+        props: {
+          ...vModelAdapter(model),
+          onClose: () => {},
+        },
+      });
+      cy.viewport('iphone-6');
+    });
+
+    coreTests();
+  });
+});
+
+function coreTests() {
+  it('renders component', () => {
+    // component
+    cy.dataCy(selectorFormUpdatePhone).should('be.visible');
+    // button cancel
+    cy.dataCy(selectorFormButtonCancel)
+      .should('be.visible')
+      .and('contain', i18n.global.t('navigation.discardChanges'));
+    // button save
+    cy.dataCy(selectorFormButtonSave)
+      .should('be.visible')
+      .and('contain', i18n.global.t('navigation.save'));
+  });
+
+  it('renders buttons side by side', () => {
+    cy.testElementsSideBySide(selectorFormButtonCancel, selectorFormButtonSave);
+  });
+
+  it('validates form on submit and allows enter key submission', () => {
+    // save
+    cy.dataCy(selectorFormButtonSave).should('be.visible').click();
+    // validate phone required
+    cy.dataCy(selectorFormPhone)
+      .find('.q-field__messages')
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('form.messageFieldRequired', {
+          fieldName: i18n.global.t('form.labelPhone'),
+        }),
+      );
+    // enter invalid phone
+    cy.dataCy(selectorFormPhone).find('input').clear();
+    cy.dataCy(selectorFormPhone).find('input').type(invalidPhone);
+    cy.dataCy(selectorFormPhone).find('input').blur();
+    // invalid phone message is visible
+    cy.dataCy(selectorFormPhone)
+      .find('.q-field__messages')
+      .should('be.visible')
+      .and('contain', i18n.global.t('form.messagePhoneInvalid'));
+    // enter valid phone
+    cy.dataCy(selectorFormPhone).find('input').clear();
+    cy.dataCy(selectorFormPhone).find('input').type(validPhone);
+    cy.dataCy(selectorFormPhone).find('input').blur();
+    // error message is not visible
+    cy.dataCy(selectorFormPhone)
+      .find('.q-field__messages')
+      .should('not.contain', i18n.global.t('form.messagePhoneInvalid'));
+  });
+}

--- a/src/components/__tests__/ProfileDetails.cy.js
+++ b/src/components/__tests__/ProfileDetails.cy.js
@@ -934,6 +934,120 @@ function coreTests() {
     });
   });
 
+  it('allows to edit telephone', () => {
+    cy.fixture('apiGetRegisterChallengeProfile.json').then((response) => {
+      cy.fixture('apiGetRegisterChallengeProfileUpdatedTelephone.json').then(
+        (responseNew) => {
+          // wait for GET request
+          cy.waitForRegisterChallengeGetApi(response);
+          const personalDetails = response.results[0].personal_details;
+          const personalDetailsNew = responseNew.results[0].personal_details;
+          // get initial phone value
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorValue)
+            .should('be.visible')
+            .and('have.text', personalDetails.telephone);
+          // click edit phone button
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorEdit)
+            .should('be.visible')
+            .click();
+          // verify phone edit form
+          cy.dataCy('profile-details-form-phone').should('be.visible');
+          // intercept POST request
+          cy.interceptRegisterChallengePutApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            personalDetails.id,
+            responseNew,
+          );
+          // override intercept GET request
+          cy.interceptRegisterChallengeGetApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            responseNew,
+          );
+          // change phone to new value
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .should('be.visible')
+            .clear();
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .type(personalDetailsNew.telephone);
+          // cancel
+          cy.dataCy('profile-details-form-phone')
+            .find(dataSelectorButtonCancel)
+            .click();
+          // phone stays the same
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorValue)
+            .should('be.visible')
+            .and('have.text', personalDetails.telephone);
+          // click edit phone button
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorEdit)
+            .should('be.visible')
+            .click();
+          // verify phone edit form
+          cy.dataCy('profile-details-form-phone').should('be.visible');
+          // change phone to new value
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .should('be.visible')
+            .clear();
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .type(personalDetailsNew.telephone);
+          // save
+          cy.dataCy('profile-details-form-phone')
+            .find(dataSelectorButtonSave)
+            .click();
+          // phone is different
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorValue)
+            .should('be.visible')
+            .and('have.text', personalDetailsNew.telephone);
+          // click edit phone button
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorEdit)
+            .should('be.visible')
+            .click();
+          // verify phone edit form
+          cy.dataCy('profile-details-form-phone').should('be.visible');
+          // change phone to old value
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .should('be.visible')
+            .clear();
+          cy.dataCy('profile-details-form-phone')
+            .find('input')
+            .type(personalDetails.telephone);
+          // intercept POST request
+          cy.interceptRegisterChallengePutApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            personalDetails.id,
+            response,
+          );
+          // override intercept GET request
+          cy.interceptRegisterChallengeGetApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            response,
+          );
+          // save (enter)
+          cy.dataCy('profile-details-form-phone').find('input').type('{enter}');
+          // phone is original value
+          cy.dataCy(selectorPhone)
+            .find(dataSelectorValue)
+            .should('be.visible')
+            .and('have.text', personalDetails.telephone);
+        },
+      );
+    });
+  });
+
   it('allows to edit telephone opt-in setting', () => {
     cy.fixture('apiGetRegisterChallengeProfile.json').then((response) => {
       cy.fixture(

--- a/src/components/form/FormUpdatePhone.vue
+++ b/src/components/form/FormUpdatePhone.vue
@@ -17,7 +17,7 @@
  * - `FormFieldPhone` - Component to render phone number field.
  *
  * @example
- * <form-update-phone :value="phone" @update:value="onUpdatePhone">
+ * <form-update-phone :value="phone" :loading="isLoading" :on-close="close" @update:value="onUpdatePhone">
  *
  */
 

--- a/src/components/form/FormUpdatePhone.vue
+++ b/src/components/form/FormUpdatePhone.vue
@@ -1,0 +1,102 @@
+<script lang="ts">
+/**
+ * FormUpdatePhone Component
+ *
+ * @description * Use this component to render a form for updating phone number.
+ * Note: Used in `DetailsItem` component on `ProfilePage`.
+ *
+ * @props
+ * - `value` (string, required): Phone number value.
+ * - `onClose` (function, required): Function to close the dialog.
+ * - `loading` (boolean, optional): Loading state.
+ *
+ * @events
+ * - `update:value`: Emitted when value successfully changes.
+ *
+ * @components
+ * - `FormFieldPhone` - Component to render phone number field.
+ *
+ * @example
+ * <form-update-phone :value="phone" @update:value="onUpdatePhone">
+ *
+ */
+
+// libraries
+import { defineComponent, onMounted, ref } from 'vue';
+
+// components
+import FormFieldPhone from '../global/FormFieldPhone.vue';
+
+export default defineComponent({
+  name: 'FormUpdatePhone',
+  components: {
+    FormFieldPhone,
+  },
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+    onClose: {
+      type: Function,
+      required: true,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:value', 'close'],
+  setup(props, { emit }) {
+    const inputValue = ref<string>('');
+
+    onMounted(() => {
+      inputValue.value = props.value;
+    });
+
+    const closeDialog = (): void => {
+      props.onClose();
+    };
+
+    const onUpdatePhone = (): void => {
+      emit('update:value', inputValue.value);
+      props.onClose();
+    };
+
+    return {
+      inputValue,
+      closeDialog,
+      onUpdatePhone,
+    };
+  },
+});
+</script>
+
+<template>
+  <q-form @submit.prevent="onUpdatePhone" data-cy="form-update-phone">
+    <!-- Input: Phone -->
+    <form-field-phone v-model="inputValue" data-cy="form-phone" />
+    <div class="q-mt-xl flex justify-end gap-8">
+      <!-- Button: Cancel -->
+      <q-btn
+        rounded
+        unelevated
+        outline
+        color="primary"
+        :label="$t('navigation.discardChanges')"
+        @click.prevent="closeDialog"
+        data-cy="form-button-cancel"
+      />
+      <!-- Button: Save -->
+      <q-btn
+        rounded
+        unelevated
+        type="submit"
+        color="primary"
+        :label="$t('navigation.save')"
+        :loading="loading"
+        data-cy="form-button-save"
+      />
+    </div>
+  </q-form>
+</template>

--- a/src/components/form/FormUpdatePhone.vue
+++ b/src/components/form/FormUpdatePhone.vue
@@ -75,7 +75,11 @@ export default defineComponent({
 <template>
   <q-form @submit.prevent="onUpdatePhone" data-cy="form-update-phone">
     <!-- Input: Phone -->
-    <form-field-phone v-model="inputValue" data-cy="form-phone" />
+    <form-field-phone
+      v-model="inputValue"
+      :required="false"
+      data-cy="form-phone"
+    />
     <div class="q-mt-xl flex justify-end gap-8">
       <!-- Button: Cancel -->
       <q-btn

--- a/src/components/profile/ProfileDetails.vue
+++ b/src/components/profile/ProfileDetails.vue
@@ -473,7 +473,7 @@ export default defineComponent({
             <!-- Form: Update phone number -->
             <form-update-phone
               :on-close="close"
-              :value="profile.phone"
+              :value="phone"
               :loading="isLoading"
               @update:value="
                 onUpdateRegisterChallengeDetails({

--- a/src/components/profile/ProfileDetails.vue
+++ b/src/components/profile/ProfileDetails.vue
@@ -33,6 +33,7 @@ import { subsidiaryAdapter } from '../../adapters/subsidiaryAdapter';
 import DetailsItem from '../profile/DetailsItem.vue';
 import FormUpdateGender from '../form/FormUpdateGender.vue';
 import FormUpdateNickname from '../form/FormUpdateNickname.vue';
+import FormUpdatePhone from '../form/FormUpdatePhone.vue';
 import LanguageSwitcher from '../global/LanguageSwitcher.vue';
 import ProfileCoordinatorContact from './ProfileCoordinatorContact.vue';
 import SectionHeading from '../global/SectionHeading.vue';
@@ -67,6 +68,7 @@ export default defineComponent({
     DetailsItem,
     FormUpdateGender,
     FormUpdateNickname,
+    FormUpdatePhone,
     LanguageSwitcher,
     ProfileCoordinatorContact,
     SectionHeading,
@@ -460,11 +462,28 @@ export default defineComponent({
         />
         <!-- Phone number -->
         <details-item
+          editable
           :label="$t('profile.labelPhone')"
+          :dialog-title="$t('profile.titleUpdatePhone')"
           :value="phone"
           class="col-12 col-sm-6"
           data-cy="profile-details-phone"
-        />
+        >
+          <template #form="{ close }">
+            <!-- Form: Update phone number -->
+            <form-update-phone
+              :on-close="close"
+              :value="profile.phone"
+              :loading="isLoading"
+              @update:value="
+                onUpdateRegisterChallengeDetails({
+                  telephone: $event,
+                })
+              "
+              data-cy="profile-details-form-phone"
+            />
+          </template>
+        </details-item>
       </div>
     </div>
 

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -711,6 +711,7 @@ titleStarterPackage = "Soutěžní balíček"
 titleUpdateEmail = "Upravit e-mail"
 titleUpdateGender = "Upravit výkonnostní kategorii"
 titleUpdateNickname = "Upravit přezdívku"
+titleUpdatePhone = "Upravit telefonní číslo"
 
 [putRegisterChallenge]
 apiMessageError = "Chyba při aktualizaci profilu."

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -707,6 +707,7 @@ titleStarterPackage = "Starter Package"
 titleUpdateEmail = "Edit e-mail"
 titleUpdateGender = "Edit performance category"
 titleUpdateNickname = "Edit nickname"
+titleUpdatePhone = "Edit phone number"
 
 [putRegisterChallenge]
 apiMessageError = "Error updating profile."

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -707,6 +707,7 @@ titleStarterPackage = "Súťažný balíček"
 titleUpdateEmail = "Upraviť e-mail"
 titleUpdateGender = "Upraviť kategóriu výkonu"
 titleUpdateNickname = "Upraviť prezývku"
+titleUpdatePhone = "Upraviť telefónne číslo"
 
 [putRegisterChallenge]
 apiMessageError = "Chyba pri aktualizácii profilu."

--- a/test/cypress/e2e/profile.spec.cy.js
+++ b/test/cypress/e2e/profile.spec.cy.js
@@ -15,6 +15,7 @@ const selectorGender = 'profile-details-gender';
 const selectorFormNickname = 'profile-details-form-nickname';
 // const selectorFormEmail = 'profile-details-form-email';
 const selectorFormGender = 'profile-details-form-gender';
+const selectorTelephone = 'profile-details-phone';
 const selectorTelephoneOptIn = 'profile-details-telephone-opt-in';
 const dataSelectorEdit = '[data-cy="details-item-edit"]';
 const dataSelectorInput = '[data-cy="form-input"]';
@@ -103,7 +104,7 @@ function coreTests() {
     });
   });
 
-  it('allows user to change nickname, and gender', () => {
+  it('allows user to change nickname, gender and telephone opt-in', () => {
     cy.fixture('apiGetRegisterChallengeProfile.json').then((response) => {
       cy.fixture('apiGetRegisterChallengeProfileUpdatedNickname.json').then(
         (responseNickname) => {
@@ -209,6 +210,60 @@ function coreTests() {
               });
             },
           );
+        },
+      );
+    });
+  });
+
+  it('allows user to change telephone', () => {
+    cy.fixture('apiGetRegisterChallengeProfile.json').then((response) => {
+      cy.fixture('apiGetRegisterChallengeProfileUpdatedTelephone.json').then(
+        (responseTelephone) => {
+          cy.get('@config').then((config) => {
+            cy.get('@i18n').then((i18n) => {
+              // wait for GET request
+              cy.waitForRegisterChallengeGetApi(response);
+              const personalDetails = response.results[0].personal_details;
+              const newTelephone =
+                responseTelephone.results[0].personal_details.telephone;
+              // telephone value
+              cy.dataCy(selectorTelephone)
+                .find(dataSelectorValue)
+                .should('have.text', personalDetails.telephone);
+              // telephone edit button
+              cy.dataCy(selectorTelephone).find(dataSelectorEdit).click();
+              // telephone edit form
+              cy.dataCy('profile-details-form-phone').should('be.visible');
+              // intercept POST request
+              cy.interceptRegisterChallengePutApi(
+                config,
+                i18n,
+                personalDetails.id,
+                responseTelephone,
+              );
+              // override intercept GET request
+              cy.interceptRegisterChallengeGetApi(
+                config,
+                i18n,
+                responseTelephone,
+              );
+              // change telephone
+              cy.dataCy('profile-details-form-phone').find('input').clear();
+              cy.dataCy('profile-details-form-phone')
+                .find('input')
+                .type(newTelephone);
+              // save
+              cy.dataCy('profile-details-form-phone')
+                .find(dataSelectorButtonSave)
+                .click();
+              // wait for GET request
+              cy.waitForRegisterChallengeGetApi(responseTelephone);
+              // telephone value
+              cy.dataCy(selectorTelephone)
+                .find(dataSelectorValue)
+                .should('have.text', newTelephone);
+            });
+          });
         },
       );
     });

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfileUpdatedTelephone.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfileUpdatedTelephone.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "id": 123,
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736987654",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "done",
+        "payment_amount": 390
+      },
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 133
+    }
+  ]
+}


### PR DESCRIPTION
Allow updating user phone in `ProfileDetails` component.

* Add `FormUpdatePhone` component for the form UI inside modal.
* Use the new form component to allow updating phone number.
* Add fixture for testing updated phone number.
* Add component tests for `FormUpdatePhone` and `ProfileDetails` components
* Add E2E test in `profile.spec` file.

Additional change: Update E2E test name in `profile.spec.cy.js:107` to correctly list tested values updates.