### PR TITLE
src/components: add required prop to FormFieldEmail component

### DIFF
--- a/src/components/__tests__/FormFieldEmail.cy.js
+++ b/src/components/__tests__/FormFieldEmail.cy.js
@@ -1,7 +1,8 @@
+import { ref } from 'vue';
 import { colors, getCssVar } from 'quasar';
-
-import FormFieldTestWrapper from 'components/global/FormFieldTestWrapper.vue';
+import FormFieldEmail from '../global/FormFieldEmail.vue';
 import { i18n } from '../../boot/i18n';
+import { vModelAdapter } from '../../../test/cypress/utils';
 
 const { getPaletteColor } = colors;
 
@@ -11,6 +12,10 @@ const customFormFieldValidationErrColor = getCssVar(
 const negative = getPaletteColor('negative');
 
 const selectorFormFieldEmail = 'form-email';
+const model = ref('');
+const setModelValue = (value) => {
+  model.value = value;
+};
 
 describe('<FormFieldEmail>', () => {
   it('has translation for all strings', () => {
@@ -23,13 +28,16 @@ describe('<FormFieldEmail>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.mount(FormFieldTestWrapper, {
+      cy.wrap(setModelValue(''));
+      cy.mount(FormFieldEmail, {
         props: {
-          component: 'FormFieldEmail',
+          ...vModelAdapter(model),
         },
       });
       cy.viewport('macbook-16');
     });
+
+    coreTests();
 
     it('check default form field validation error color', () => {
       cy.viewport('macbook-16');
@@ -39,9 +47,9 @@ describe('<FormFieldEmail>', () => {
     });
 
     it('check custom form field validation error color', () => {
-      cy.mount(FormFieldTestWrapper, {
+      cy.mount(FormFieldEmail, {
         props: {
-          component: 'FormFieldEmail',
+          ...vModelAdapter(model),
           useFormFieldValidationErrorCssClass: true,
         },
       });
@@ -52,116 +60,157 @@ describe('<FormFieldEmail>', () => {
         );
       });
     });
+  });
 
-    it('validates email correctly', () => {
-      // invalid email
-      cy.dataCy('form-email-input').type('qw123@qw');
-      // first blur triggers validation
+  context('desktop (optional)', () => {
+    beforeEach(() => {
+      cy.wrap(setModelValue(''));
+      cy.mount(FormFieldEmail, {
+        props: {
+          ...vModelAdapter(model),
+          required: false,
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+
+    it('validates email correctly (optional)', () => {
+      // enter invalid email to show messages
+      cy.dataCy('form-email-input').type('invalidemail');
       cy.dataCy('form-email-input').blur();
       cy.dataCy('form-email')
         .find('.q-field__messages')
         .should('be.visible')
         .and('contain', i18n.global.t('form.messageEmailInvalid'));
+      // clear input
       cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('abc.example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('a@b@c@example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('a"b(c)d,e:f;g<h>i[jk]l@example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('just"not"right@example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('this is"notallowed@example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type('this still"not\\allowed@example.com');
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type(
-        '1234567890123456789012345678901234567890123456789012345678901234+x@example.com',
+      cy.dataCy('form-email-input').blur();
+      // no validation error is shown
+      cy.get('.q-field__messages').should(
+        'not.contain',
+        i18n.global.t('form.messageEmailInvalid'),
       );
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // invalid email
-      cy.dataCy('form-email-input').type(
-        'i.like.underscores@but_they_are_not_allowed_in_this_part',
+      cy.get('.q-field__messages').should(
+        'not.contain',
+        i18n.global.t('form.messageFieldRequired', {
+          fieldName: i18n.global.t('form.labelEmail'),
+        }),
       );
-      cy.dataCy('form-email')
-        .find('.q-field__messages')
-        .and('contain', i18n.global.t('form.messageEmailInvalid'));
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('simple@example.com');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('very.common@example.com');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('x@example.com');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type(
-        'long.email-address-with-hyphens@and.subdomains.example.com',
-      );
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('user.name+tag+sorting@example.com');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('name/surname@example.com');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('mailhost!username@example.org');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('user%example.com@example.org');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
-      // valid email
-      cy.dataCy('form-email-input').type('user-@example.org');
-      cy.dataCy('form-email-input').blur();
-      cy.get('.q-field__messages').should('be.empty');
-      cy.dataCy('form-email-input').clear();
     });
   });
 });
+
+function coreTests() {
+  it('validates email correctly', () => {
+    // invalid email
+    cy.dataCy('form-email-input').type('qw123@qw');
+    // first blur triggers validation
+    cy.dataCy('form-email-input').blur();
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .should('be.visible')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('abc.example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('a@b@c@example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('a"b(c)d,e:f;g<h>i[jk]l@example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('just"not"right@example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('this is"notallowed@example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type('this still"not\\allowed@example.com');
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type(
+      '1234567890123456789012345678901234567890123456789012345678901234+x@example.com',
+    );
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // invalid email
+    cy.dataCy('form-email-input').type(
+      'i.like.underscores@but_they_are_not_allowed_in_this_part',
+    );
+    cy.dataCy('form-email')
+      .find('.q-field__messages')
+      .and('contain', i18n.global.t('form.messageEmailInvalid'));
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('simple@example.com');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('very.common@example.com');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('x@example.com');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type(
+      'long.email-address-with-hyphens@and.subdomains.example.com',
+    );
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('user.name+tag+sorting@example.com');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('name/surname@example.com');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('mailhost!username@example.org');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('user%example.com@example.org');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email
+    cy.dataCy('form-email-input').type('user-@example.org');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+  });
+}

--- a/src/components/global/FormFieldEmail.vue
+++ b/src/components/global/FormFieldEmail.vue
@@ -124,7 +124,7 @@ export default defineComponent({
           $t('form.messageFieldRequired', {
             fieldName: $t('form.labelEmail'),
           }),
-        (val) => isEmail(val) || $t('form.messageEmailInvalid'),
+        (val) => !val || isEmail(val) || $t('form.messageEmailInvalid'),
       ]"
       :class="emailFormFieldCssClasses"
       id="form-email"

--- a/src/components/global/FormFieldEmail.vue
+++ b/src/components/global/FormFieldEmail.vue
@@ -17,6 +17,8 @@
  *    Defaults to `transparent`.
  * - `dark` (boolean, optional): Whether the input should be dark.
  *    Defaults to `false`.
+ * - `required` (boolean, default: true): Whether the input is required.
+ *    Defaults to `true`.
  * - `testing` (boolean, optional): Wheter this is a testing environment.
  *    Defaults to `false`.
  * - `useFormFieldValidationErrorCssClass` (boolean, optional): Use custom email form field
@@ -58,6 +60,10 @@ export default defineComponent({
     bgColor: {
       type: String as () => 'white' | 'transparent',
       default: 'transparent',
+    },
+    required: {
+      type: Boolean,
+      default: true,
     },
     testing: {
       type: Boolean,
@@ -113,6 +119,7 @@ export default defineComponent({
       :lazy-rules="!testing"
       :rules="[
         (val) =>
+          !required ||
           isFilled(val) ||
           $t('form.messageFieldRequired', {
             fieldName: $t('form.labelEmail'),

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -1,5 +1,9 @@
 export const useValidation = () => {
   const isEmail = (value: string): boolean => {
+    // if empty, pass - required check is separate from regex validation
+    if (!value) {
+      return true;
+    }
     /**
      * Match 99% of valid email addresses and will not pass validation
      * for email addresses that have, for instance

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -26,7 +26,7 @@ export const useValidation = () => {
     const emails = value.split(',');
     // remove whitespace
     const trimmedEmails = emails.map((email) => email.trim());
-    return trimmedEmails.every((email) => isEmail(email));
+    return trimmedEmails.every((email) => !!email && isEmail(email));
   };
 
   const isPhone = (value: string): boolean => {

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -1,9 +1,5 @@
 export const useValidation = () => {
   const isEmail = (value: string): boolean => {
-    // if empty, pass - required check is separate from regex validation
-    if (!value) {
-      return true;
-    }
     /**
      * Match 99% of valid email addresses and will not pass validation
      * for email addresses that have, for instance
@@ -26,7 +22,7 @@ export const useValidation = () => {
     const emails = value.split(',');
     // remove whitespace
     const trimmedEmails = emails.map((email) => email.trim());
-    return trimmedEmails.every((email) => !!email && isEmail(email));
+    return trimmedEmails.every((email) => isEmail(email));
   };
 
   const isPhone = (value: string): boolean => {


### PR DESCRIPTION
Add `required` prop to `FormFieldEmail` component.
This will be used in Profile page edit form.

* Add `required` prop and use it in validation
* Update validation for email to pass if value is empty
* Update component tests, removing the unnecessary wrapper component and adding test for optional variant.
* Update `isEmailList` validation condition to keep requiring values.