### PR TITLE
src/composables: fix email form field validation letter case insensitive rule

### DIFF
--- a/src/components/__tests__/FormFieldEmail.cy.js
+++ b/src/components/__tests__/FormFieldEmail.cy.js
@@ -212,5 +212,15 @@ function coreTests() {
     cy.dataCy('form-email-input').blur();
     cy.get('.q-field__messages').should('be.empty');
     cy.dataCy('form-email-input').clear();
+    // valid email (uppercase)
+    cy.dataCy('form-email-input').type('USER@EXAMPLE.ORG');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
+    // valid email (uppercase)
+    cy.dataCy('form-email-input').type('uSeR@Example.OrG');
+    cy.dataCy('form-email-input').blur();
+    cy.get('.q-field__messages').should('be.empty');
+    cy.dataCy('form-email-input').clear();
   });
 }

--- a/src/composables/useValidation.ts
+++ b/src/composables/useValidation.ts
@@ -10,7 +10,7 @@ export const useValidation = () => {
      * https://uibakery.io/regex-library/email
      */
     const regex =
-      /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+      /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
     return regex.test(value);
   };
 


### PR DESCRIPTION
Fixes [Bug 98](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=98).

* Allow uppercase letters for email input in `useValidation` composable.
* Add test for validating emails with uppercase letters.

Backend functionality tested by logging in with active account details in uppercase form.
