### PR TITLE
src/composables: add Django admin menu link item into home page menu

### DIFF
--- a/public/icons/drawer_menu/icons.svg
+++ b/public/icons/drawer_menu/icons.svg
@@ -26,4 +26,7 @@
   <symbol id="lucide-gift" viewBox="0 0 24 24">
     <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="18" height="4" x="3" y="8" rx="1"/><path d="M12 8v13m7-9v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7m2.5-4a2.5 2.5 0 0 1 0-5A4.8 8 0 0 1 12 8a4.8 8 0 0 1 4.5-5a2.5 2.5 0 0 1 0 5"/></g>
   </symbol>
+  <symbol id="lucide:settings-2" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M20 7h-9m3 10H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></g>
+  </symbol>
 </svg>

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -49,7 +49,6 @@ urlBaseBackend = "https://test.dopracenakole.cz/"
 
 # EXTERNAL URLS
 
-urlAppAdmin = "https://dpnk.dopracenakole.net/admin"
 urlAppStore = "https://apps.apple.com/cz/app/do-pr%C3%A1ce-na-kole/id1564442780"
 urlAutoMat = "https://auto-mat.cz"
 urlBlog = "https://dopracenakole.cz/novinky-do-prace-na-kole"
@@ -63,6 +62,7 @@ urlInstagram = "https://www.instagram.com/spolekautomat"
 urlAppDataPrivacyPolicy = "https://auto-mat.cz/zasady"
 urlAppDataTermsOfService = "https://dopracenakole.cz/obchodni-podminky"
 urlRideToWorkByBikeOldFrontendDjangoApp = "https://dpnk.dopracenakole.net"
+urlRideToWorkByBikeOldFrontendDjangoAppAdmin = "admin/"
 urlTwitter = "https://twitter.com/spolekautomat"
 urlVideoLoggingRoutes = "https://www.youtube.com/embed/ItfTtrEutgo?rel=0"
 urlVideoOnboarding = "https://www.youtube.com/embed/ItfTtrEutgo?rel=0"

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -49,6 +49,7 @@ urlBaseBackend = "https://test.dopracenakole.cz/"
 
 # EXTERNAL URLS
 
+urlAppAdmin = "https://dpnk.dopracenakole.net/admin"
 urlAppStore = "https://apps.apple.com/cz/app/do-pr%C3%A1ce-na-kole/id1564442780"
 urlAutoMat = "https://auto-mat.cz"
 urlBlog = "https://dopracenakole.cz/novinky-do-prace-na-kole"

--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -29,6 +29,7 @@ export const registerChallengeAdapter = {
       firstName: apiData.personal_details.first_name,
       lastName: apiData.personal_details.last_name,
       id: apiData.personal_details.id,
+      isStaff: apiData.personal_details.is_staff,
       nickname: apiData.personal_details.nickname,
       gender: apiData.personal_details.sex as Gender,
       newsletter: newsletterAdapter.parseNewsletterValues(

--- a/src/components/__tests__/DrawerMenu.cy.js
+++ b/src/components/__tests__/DrawerMenu.cy.js
@@ -27,6 +27,12 @@ const selectorDrawerMenuItemIcon = 'drawer-menu-item-icon';
 const iconSize = 18;
 const fontSize = '16px';
 
+const {
+  urlRideToWorkByBikeOldFrontendDjangoApp,
+  urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
+} = rideToWorkByBikeConfig;
+const rtwbbOldFrontendDjangoAdminUrl = `${urlRideToWorkByBikeOldFrontendDjangoApp}/${urlRideToWorkByBikeOldFrontendDjangoAppAdmin}`;
+
 const { getMenuBottom, getMenuTop } = useMenu();
 
 describe('DrawerMenu', () => {
@@ -36,7 +42,7 @@ describe('DrawerMenu', () => {
         getMenuTop({
           isUserOrganizationAdmin: false,
           isUserStaff: false,
-          urlAdmin: rideToWorkByBikeConfig.urlAppAdmin,
+          urlAdmin: rtwbbOldFrontendDjangoAdminUrl,
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -73,7 +79,7 @@ describe('DrawerMenu', () => {
         getMenuTop({
           isUserOrganizationAdmin: true,
           isUserStaff: false,
-          urlAdmin: rideToWorkByBikeConfig.urlAppAdmin,
+          urlAdmin: rtwbbOldFrontendDjangoAdminUrl,
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -108,7 +114,7 @@ describe('DrawerMenu', () => {
     beforeEach(() => {
       const urlAdmin = getApiBaseUrlWithLang(
         null,
-        rideToWorkByBikeConfig.urlAppAdmin,
+        rtwbbOldFrontendDjangoAdminUrl,
         defaultLocale,
         i18n,
       );
@@ -149,7 +155,7 @@ describe('DrawerMenu', () => {
           'href',
           getApiBaseUrlWithLang(
             null,
-            rideToWorkByBikeConfig.urlAppAdmin,
+            rtwbbOldFrontendDjangoAdminUrl,
             defaultLocale,
             i18n,
           ),

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -46,14 +46,25 @@ export default defineComponent({
     const isUserOrganizationAdmin = computed(
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
+    const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
     const { getMenuTop, getMenuBottom } = useMenu();
 
     const { mobileBottomPanelVisibleItems } = rideToWorkByBikeConfig;
     const logger = inject('vuejs3-logger') as Logger | null;
 
+    const urlAdmin = computed(() => {
+      return getApiBaseUrlWithLang(
+        logger,
+        rideToWorkByBikeConfig.urlAppAdmin,
+        defaultLocale,
+        i18n,
+      );
+    });
     const menuTop = computed((): Link[] => {
       return getMenuTop({
         isUserOrganizationAdmin: isUserOrganizationAdmin,
+        isUserStaff,
+        urlAdmin,
       });
     });
     const menuPanel = computed((): Link[] => {

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -52,10 +52,16 @@ export default defineComponent({
     const { mobileBottomPanelVisibleItems } = rideToWorkByBikeConfig;
     const logger = inject('vuejs3-logger') as Logger | null;
 
+    const {
+      urlRideToWorkByBikeOldFrontendDjangoApp,
+      urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
+    } = rideToWorkByBikeConfig;
+    const rtwbbOldFrontendDjangoAdminUrl = `${urlRideToWorkByBikeOldFrontendDjangoApp}/${urlRideToWorkByBikeOldFrontendDjangoAppAdmin}`;
+
     const urlAdmin = computed(() => {
       return getApiBaseUrlWithLang(
         logger,
-        rideToWorkByBikeConfig.urlAppAdmin,
+        rtwbbOldFrontendDjangoAdminUrl,
         defaultLocale,
         i18n,
       );

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -8,6 +8,7 @@ export type CorePersonalDetails = {
   first_name: string;
   last_name: string;
   id: number;
+  is_staff: boolean;
   nickname: string;
   sex: string;
   telephone: string;

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -22,6 +22,7 @@ export interface ConfigGlobal {
   borderRadiusButtonSmall: string;
   maxWidthBanner: string;
   contactEmail: string;
+  urlAppAdmin: string;
   urlAutoMat: string;
   urlAppStore: string;
   urlBlog: string;

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -22,7 +22,6 @@ export interface ConfigGlobal {
   borderRadiusButtonSmall: string;
   maxWidthBanner: string;
   contactEmail: string;
-  urlAppAdmin: string;
   urlAutoMat: string;
   urlAppStore: string;
   urlBlog: string;
@@ -33,6 +32,7 @@ export interface ConfigGlobal {
   urlInstagram: string;
   urlProjectSourceCode: string;
   urlRideToWorkByBikeOldFrontendDjangoApp: string;
+  urlRideToWorkByBikeOldFrontendDjangoAppAdmin: string;
   urlTwitter: string;
   urlVideoLoggingRoutes: string;
   urlVideoOnboarding: string;

--- a/src/components/types/RegisterChallenge.ts
+++ b/src/components/types/RegisterChallenge.ts
@@ -32,6 +32,7 @@ export interface RegisterChallengePersonalDetailsForm
   firstName: string;
   gender: Gender | null;
   id: number | null;
+  isStaff: boolean;
   lastName: string;
   newsletter: NewsletterType[];
 }

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -13,6 +13,10 @@ export const useMenu = () => {
    * Get the top menu items
    * @param {ComputedRef<boolean | null> | boolean | null}
    *   isUserOrganizationAdmin - Whether the user is an organization admin
+   * @param {ComputedRef<boolean | null> | boolean | null}
+   *   isUserStaff - Whether the user is staff member
+   * @param {ComputedRef<string> | string } urlAdmin - RTWBB old Django frontend
+   *                                                   app admin URL
    * @returns {Link[]} - Array of top menu items
    */
   const getMenuTop = ({

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -17,8 +17,12 @@ export const useMenu = () => {
    */
   const getMenuTop = ({
     isUserOrganizationAdmin,
+    isUserStaff,
+    urlAdmin,
   }: {
     isUserOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
+    isUserStaff: ComputedRef<boolean | null> | boolean | null;
+    urlAdmin: ComputedRef<string> | string;
   }): Link[] => {
     let menuTop: Link[] = [
       {
@@ -64,6 +68,19 @@ export const useMenu = () => {
         title: 'profile',
       },
     ];
+
+    if (unref(isUserStaff)) {
+      menuTop = [
+        ...menuTop,
+        {
+          url: '',
+          icon: 'svguse:icons/drawer_menu/icons.svg#lucide:settings-2',
+          name: 'admin',
+          title: 'admin',
+          href: unref(urlAdmin),
+        },
+      ];
+    }
 
     return menuTop;
   };

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -49,6 +49,7 @@ apiMessageErrorWithMessage = "Vytvoření pobočky selhalo. Chyba: {error}"
 apiMessageSuccess = "Pobočka byla úspěšně vytvořena."
 
 [drawerMenu]
+admin = "Administrace"
 buttonParticipation = "Účast"
 buttonCityAdministration = "Správa města"
 community = "Komunita"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -49,6 +49,7 @@ apiMessageErrorWithMessage = "Subsidiary creation failed. Error: {error}"
 apiMessageSuccess = "Subsidiary was successfully created."
 
 [drawerMenu]
+admin = "Administration"
 buttonParticipation = "Participation"
 buttonCityAdministration = "City administration"
 community = "Community"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -49,6 +49,7 @@ apiMessageErrorWithMessage = "Vytvorenie pobočky zlyhalo. Chyba: {error}"
 apiMessageSuccess = "Pobočka bola úspešne vytvorená."
 
 [drawerMenu]
+admin = "Administrácia"
 buttonParticipation = "Účasť"
 buttonCityAdministration = "Správa mesta"
 community = "Komunita"

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -84,10 +84,17 @@ export default defineComponent({
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
     const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
+
+    const {
+      urlRideToWorkByBikeOldFrontendDjangoApp,
+      urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
+    } = rideToWorkByBikeConfig;
+    const rtwbbOldFrontendDjangoAdminUrl = `${urlRideToWorkByBikeOldFrontendDjangoApp}/${urlRideToWorkByBikeOldFrontendDjangoAppAdmin}`;
+
     const urlAdmin = computed(() => {
       return getApiBaseUrlWithLang(
         logger,
-        rideToWorkByBikeConfig.urlAppAdmin,
+        rtwbbOldFrontendDjangoAdminUrl,
         defaultLocale,
         i18n,
       );

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -83,9 +83,20 @@ export default defineComponent({
     const isUserOrganizationAdmin = computed(
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
+    const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
+    const urlAdmin = computed(() => {
+      return getApiBaseUrlWithLang(
+        logger,
+        rideToWorkByBikeConfig.urlAppAdmin,
+        defaultLocale,
+        i18n,
+      );
+    });
     const menuTop = computed((): Link[] => {
       return getMenuTop({
         isUserOrganizationAdmin,
+        isUserStaff,
+        urlAdmin,
       });
     });
 

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -303,6 +303,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       state.isUserOrganizationAdmin,
     getIsLoadingUserOrganizationAdmin: (state): boolean =>
       state.isLoadingUserOrganizationAdmin,
+    getIsUserStaff: (state): boolean | null => state.personalDetails.isStaff,
   },
 
   actions: {

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -19,6 +19,7 @@ export const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
   lastName: '',
   id: null,
+  isStaff: false,
   newsletter: [] as NewsletterType[],
   nickname: '',
   gender: null as Gender | null,

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -286,8 +286,17 @@ describe('Home page', () => {
     testMobileHeader();
 
     it('allows user to show and hide bottom panel on mobile', () => {
-      cy.get('@config').then((config) => {
-        cy.checkMobileBottomPanel(config, false);
+      cy.window().should('have.property', 'i18n');
+      cy.window().then((win) => {
+        cy.get('@config').then((config) => {
+          cy.checkMobileBottomPanel({
+            config,
+            i18n: win.i18n,
+            defLocale,
+            isUserOrganizationAdmin: false,
+            isUserStaff: false,
+          });
+        });
       });
     });
 
@@ -328,8 +337,17 @@ describe('Home page', () => {
     testMobileHeader();
 
     it('allows user to show and hide bottom panel on mobile', () => {
-      cy.get('@config').then((config) => {
-        cy.checkMobileBottomPanel(config, true);
+      cy.window().should('have.property', 'i18n');
+      cy.window().then((win) => {
+        cy.get('@config').then((config) => {
+          cy.checkMobileBottomPanel({
+            config,
+            i18n: win.i18n,
+            defLocale,
+            isUserOrganizationAdmin: true,
+            isUserStaff: false,
+          });
+        });
       });
     });
 
@@ -439,6 +457,40 @@ describe('Home page', () => {
 
     it(failTestTitle, () => {
       cy.window().its('scrollY').should('equal', 0);
+    });
+  });
+
+  context('mobile - user is staff', () => {
+    beforeEach(() => {
+      cy.task('getAppConfig', process).then((config) => {
+        cy.wrap(config).as('config');
+        // intercept register challenge API with staff user
+        cy.fixture('apiGetRegisterChallengeIndividualPaidCompleteStaff').then(
+          (response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          },
+        );
+      });
+      // visit index page
+      cy.visit(Cypress.config('baseUrl'));
+      // wait for API intercepts
+      cy.waitForThisCampaignApi();
+      cy.viewport('iphone-6');
+    });
+
+    it('allows user to show and hide bottom panel on mobile', () => {
+      cy.window().should('have.property', 'i18n');
+      cy.window().then((win) => {
+        cy.get('@config').then((config) => {
+          cy.checkMobileBottomPanel({
+            config,
+            i18n: win.i18n,
+            defLocale,
+            isUserOrganizationAdmin: false,
+            isUserStaff: true,
+          });
+        });
+      });
     });
   });
 

--- a/test/cypress/fixtures/apiGetRegisterChallengeIndividualPaidCompleteStaff.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeIndividualPaidCompleteStaff.json
@@ -1,0 +1,34 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "nickname": "FB",
+        "sex": "male",
+        "is_staff": true,
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "individual",
+        "payment_type": "CARD_TOKEN",
+        "payment_status": "done",
+        "payment_amount": 390,
+        "payment_category": "entry_fee"
+      },
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": null
+    }
+  ]
+}

--- a/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
+++ b/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
@@ -3,6 +3,7 @@
     "firstName": "John",
     "lastName": "Doe",
     "id": null,
+    "isStaff": false,
     "newsletter": ["challenge", "events", "mobility"],
     "nickname": "JD",
     "gender": "male",

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2640,11 +2640,37 @@ Cypress.Commands.add(
  */
 Cypress.Commands.add(
   'checkMobileBottomPanel',
-  (config, isUserOrganizationAdmin) => {
+  ({
+    config,
+    i18n,
+    defLocale,
+    isUserOrganizationAdmin = false,
+    isUserStaff = false,
+  }) => {
     const { getMenuTop, getMenuBottom } = useMenu();
 
-    cy.wrap(getMenuTop({ isUserOrganizationAdmin })).then((menuTop) => {
-      cy.wrap(getMenuBottom(config)).then((menuBottom) => {
+    // get localized URL for menu admin link
+    const urlAdmin = getApiBaseUrlWithLang(
+      null,
+      config.urlAppAdmin,
+      defLocale,
+      i18n,
+    );
+    // get localized URL for menu donate link
+    const urlDonate = getApiBaseUrlWithLang(
+      null,
+      config.urlDonate,
+      defLocale,
+      i18n,
+    );
+    cy.wrap(
+      getMenuTop({
+        isUserOrganizationAdmin,
+        isUserStaff,
+        urlAdmin,
+      }),
+    ).then((menuTop) => {
+      cy.wrap(getMenuBottom(urlDonate)).then((menuBottom) => {
         // Check footer panel menu
         cy.dataCy('footer-panel-menu').should('be.visible');
         cy.dataCy('footer-panel-menu')
@@ -2666,6 +2692,74 @@ Cypress.Commands.add(
               menuBottom.length -
               config.mobileBottomPanelVisibleItems,
           );
+        // check that menu contains donate link
+        cy.dataCy('footer-panel-menu-dialog').within(() => {
+          cy.get('.q-item')
+            .contains('.q-item', i18n.global.t('drawerMenu.donate'))
+            .should('be.visible')
+            .and('have.attr', 'href', urlDonate)
+            .should('have.attr', 'target', '_blank')
+            .invoke('attr', 'href')
+            .then((href) => {
+              cy.request({
+                url: href,
+                failOnStatusCode: failOnStatusCode,
+                headers: { ...userAgentHeader },
+              }).then((resp) => {
+                if (resp.status === httpTooManyRequestsStatus) {
+                  cy.log(httpTooManyRequestsStatusMessage);
+                  return;
+                }
+                expect(resp.status).to.eq(httpSuccessfullStatus);
+              });
+            });
+        });
+        if (isUserOrganizationAdmin) {
+          // user is coordinator - menu should contain coordinator item
+          cy.dataCy('footer-panel-menu-dialog').within(() => {
+            cy.get('.q-item')
+              .contains('.q-item', i18n.global.t('drawerMenu.coordinator'))
+              .should('be.visible');
+          });
+        } else {
+          // user is not coordinator - menu should not contain coordinator item
+          cy.dataCy('footer-panel-menu-dialog').within(() => {
+            cy.get('.q-item')
+              .contains('.q-item', i18n.global.t('drawerMenu.coordinator'))
+              .should('not.exist');
+          });
+        }
+        if (isUserStaff) {
+          // user is staff - menu should contain admin item
+          cy.dataCy('footer-panel-menu-dialog').within(() => {
+            cy.get('.q-item')
+              .contains('.q-item', i18n.global.t('drawerMenu.admin'))
+              .should('be.visible')
+              .and('have.attr', 'href', urlAdmin)
+              .should('have.attr', 'target', '_blank')
+              .invoke('attr', 'href')
+              .then((href) => {
+                cy.request({
+                  url: href,
+                  failOnStatusCode: failOnStatusCode,
+                  headers: { ...userAgentHeader },
+                }).then((resp) => {
+                  if (resp.status === httpTooManyRequestsStatus) {
+                    cy.log(httpTooManyRequestsStatusMessage);
+                    return;
+                  }
+                  expect(resp.status).to.eq(httpSuccessfullStatus);
+                });
+              });
+          });
+        } else {
+          // user is not staff - menu should not contain admin item
+          cy.dataCy('footer-panel-menu-dialog').within(() => {
+            cy.get('.q-item')
+              .contains('.q-item', i18n.global.t('drawerMenu.admin'))
+              .should('not.exist');
+          });
+        }
       });
     });
   },

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2648,11 +2648,16 @@ Cypress.Commands.add(
     isUserStaff = false,
   }) => {
     const { getMenuTop, getMenuBottom } = useMenu();
+    const {
+      urlRideToWorkByBikeOldFrontendDjangoApp,
+      urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
+    } = config;
+    const rtwbbOldFrontendDjangoAdminUrl = `${urlRideToWorkByBikeOldFrontendDjangoApp}/${urlRideToWorkByBikeOldFrontendDjangoAppAdmin}`;
 
     // get localized URL for menu admin link
     const urlAdmin = getApiBaseUrlWithLang(
       null,
-      config.urlAppAdmin,
+      rtwbbOldFrontendDjangoAdminUrl,
       defLocale,
       i18n,
     );

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -139,9 +139,15 @@ export const testDesktopSidebar = (): void => {
       cy.dataCy(selectorDrawer).should('be.visible');
       cy.dataCy(selectorDrawerHeader).should('be.visible');
       cy.dataCy(selectorUserSelectDesktop).should('be.visible');
+
+      const {
+        urlRideToWorkByBikeOldFrontendDjangoApp,
+        urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
+      } = config as ConfigGlobal;
+      const rtwbbOldFrontendDjangoAdminUrl = `${urlRideToWorkByBikeOldFrontendDjangoApp}/${urlRideToWorkByBikeOldFrontendDjangoAppAdmin}`;
       const urlAdmin = getApiBaseUrlWithLang(
         null,
-        (config as ConfigGlobal).urlAppAdmin,
+        rtwbbOldFrontendDjangoAdminUrl,
         defaultLocale,
         defaultLocale,
       );

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -139,9 +139,17 @@ export const testDesktopSidebar = (): void => {
       cy.dataCy(selectorDrawer).should('be.visible');
       cy.dataCy(selectorDrawerHeader).should('be.visible');
       cy.dataCy(selectorUserSelectDesktop).should('be.visible');
+      const urlAdmin = getApiBaseUrlWithLang(
+        null,
+        (config as ConfigGlobal).urlAppAdmin,
+        defaultLocale,
+        defaultLocale,
+      );
       if (
         getMenuTop({
           isUserOrganizationAdmin: false,
+          isUserStaff: false,
+          urlAdmin,
         }).length > 0
       ) {
         cy.dataCy(selectorDrawerMenuTop).should('be.visible');


### PR DESCRIPTION
Fixes [Bug 103](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=103).
Add staff menu link to app administration in `useMenu` composable.

* Use localized link to app admin (from global config).
* Update component test for `DrawerMenu` where composable is being used.
* Add more robust test for `MobileBottomPanel` where composable is being used.
* Add and update necessary fixtures.