### PR TITLE
test/cypress/e2e: remove URL test command from register_challenge.spec which tends to fail because of redirect

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1280,8 +1280,6 @@ describe('Register Challenge page', () => {
       // submit payment
       cy.dataCy('step-2-submit-payment').should('be.visible').click();
       cy.waitForPayuCreateOrderPostApi();
-      // window is redirected to given url
-      cy.url().should('not.include', routesConf['register_challenge']['path']);
     });
 
     it('when voucher payment - all participation options are enabled', () => {


### PR DESCRIPTION
Issue: E2E tests tend to fail with message:
```
  1) Register Challenge page
       desktop
         when individual payment - all participation options are enabled:
     CypressError: The command was expected to run against origin `http://localhost:9000` but the application is at origin `https://merch-prod.snd.payu.com`.

This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.
```

This is most likely caused by the redirection to the PayU gateway and running a check after that.

Solution:
To avoid this error, remove the final URL check.
We test `redirectUrl` as a part of API response check, so the final test command is not necessary.