### PR TITLE
src/adapters: update loaded properties of discount coupon to correctly load one-time coupons

### DIFF
--- a/src/adapters/couponAdapter.ts
+++ b/src/adapters/couponAdapter.ts
@@ -10,7 +10,7 @@ export const couponAdapter = {
    */
   toValidatedCoupon(response: DiscountCouponResponse | null): ValidatedCoupon {
     const coupon = response?.results?.[0];
-    if (coupon && coupon?.name) {
+    if (coupon && coupon.name) {
       return {
         valid: true,
         available: !!coupon.available || false,

--- a/src/adapters/couponAdapter.ts
+++ b/src/adapters/couponAdapter.ts
@@ -10,10 +10,20 @@ export const couponAdapter = {
    */
   toValidatedCoupon(response: DiscountCouponResponse | null): ValidatedCoupon {
     const coupon = response?.results?.[0];
-    return {
-      valid: !!coupon?.available,
-      discount: coupon?.discount || 0,
-      name: coupon?.name || '',
-    };
+    if (coupon && coupon?.name) {
+      return {
+        valid: true,
+        available: !!coupon.available || false,
+        discount: coupon.discount || 0,
+        name: coupon.name || '',
+      };
+    } else {
+      return {
+        valid: false,
+        available: !!coupon?.available || false,
+        discount: coupon?.discount || 0,
+        name: coupon?.name || '',
+      };
+    }
   },
 };

--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -85,6 +85,7 @@ export default defineComponent({
           codeFormatted.value,
         );
 
+        // when applying voucher, we need to check both validity and availability
         if (validatedCoupon.valid && validatedCoupon.available) {
           Notify.create({
             type: 'positive',

--- a/src/components/form/FormFieldVoucher.vue
+++ b/src/components/form/FormFieldVoucher.vue
@@ -51,7 +51,9 @@ export default defineComponent({
   },
   props: {},
   setup() {
-    const formFieldTextRequiredRef = ref(null);
+    const formFieldTextRequiredRef = ref<InstanceType<
+      typeof FormFieldTextRequired
+    > | null>(null);
     const challengeStore = useChallengeStore();
     const defaultPaymentAmountMin = computed(() => {
       return defaultPaymentAmountMinComputed(
@@ -78,12 +80,12 @@ export default defineComponent({
      * @returns {void}
      */
     const onSubmitVoucher = async (): Promise<void> => {
-      if (formFieldTextRequiredRef.value.inputRef.validate()) {
+      if (formFieldTextRequiredRef.value?.inputRef?.validate()) {
         const validatedCoupon: ValidatedCoupon = await validateCoupon(
           codeFormatted.value,
         );
 
-        if (validatedCoupon.valid) {
+        if (validatedCoupon.valid && validatedCoupon.available) {
           Notify.create({
             type: 'positive',
             message: i18n.global.t('notify.voucherApplySuccess'),

--- a/src/components/types/Coupon.ts
+++ b/src/components/types/Coupon.ts
@@ -19,6 +19,7 @@ export interface DiscountCoupon {
 
 export interface ValidatedCoupon {
   valid: boolean;
+  available: boolean;
   discount: number;
   name: string;
 }

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -430,6 +430,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       /**
        * Re-validate `voucher` value over API every time registration is loaded
        * to prevent incorrect voucher value from being set.
+       * We are only checking validity (existence of the coupon), not
+       * availability (possibility to use the coupon). This is because some
+       * coupons can only be used once, but need to be loaded every time.
        */
       if (parsedResponse.voucher) {
         const { validateCoupon } = useApiGetDiscountCoupon(this.$log);

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -2848,6 +2848,52 @@ describe('Register Challenge page', () => {
     });
   });
 
+  context('registration in progress, voucher payment FULL ONE-TIME', () => {
+    beforeEach(() => {
+      cy.task('getAppConfig', process).then((config) => {
+        cy.wrap(config).as('config');
+        cy.interceptThisCampaignGetApi(config, defLocale);
+        cy.visit('#' + routesConf['challenge_inactive']['path']);
+        cy.waitForThisCampaignApi();
+        cy.fixture('apiGetRegisterChallengeVoucherFull.json').then(
+          (response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          },
+        );
+        cy.fixture('apiGetDiscountCouponResponseOneTime.json').then(
+          (response) => {
+            cy.interceptDiscountCouponGetApi(
+              config,
+              defLocale,
+              response.results[0].name,
+              response,
+            );
+          },
+        );
+        // intercept common response (not currently used)
+        cy.interceptRegisterChallengePostApi(config, defLocale);
+        cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+      });
+      cy.visit('#' + routesConf['register_challenge']['path']);
+      cy.viewport('macbook-16');
+    });
+
+    it('loads payment page - voucher payment ONE-TIME (valid but not available)', () => {
+      cy.fixture('apiGetRegisterChallengeVoucherFull.json').then((response) => {
+        cy.fixture('apiGetDiscountCouponResponseOneTime.json').then(
+          (responseCoupon) => {
+            cy.waitForDiscountCouponApi(responseCoupon);
+          },
+        );
+        // show enabled voucher with voucher name
+        cy.dataCy('voucher-banner').should('be.visible');
+        cy.dataCy('voucher-banner-code')
+          .should('be.visible')
+          .and('contain', response.results[0].personal_details.discount_coupon);
+      });
+    });
+  });
+
   context('registration in progress, company payment "unknown"', () => {
     beforeEach(() => {
       cy.task('getAppConfig', process).then((config) => {

--- a/test/cypress/fixtures/apiGetDiscountCouponResponseOneTime.json
+++ b/test/cypress/fixtures/apiGetDiscountCouponResponseOneTime.json
@@ -1,0 +1,12 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "name": "ZD-CZBGSD",
+      "discount": 100,
+      "available": false
+    }
+  ]
+}

--- a/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
+++ b/test/cypress/fixtures/registerChallengeLocalStorageCompletedVoucherFull.json
@@ -18,7 +18,12 @@
   "subsidiaryId": 1358,
   "teamId": 2452,
   "merchId": 133,
-  "voucher": { "valid": true, "discount": 100, "name": "ZD-CZBGSD" },
+  "voucher": {
+    "valid": true,
+    "available": true,
+    "discount": 100,
+    "name": "ZD-CZBGSD"
+  },
   "formRegisterCoordinator": {
     "jobTitle": "",
     "phone": "",


### PR DESCRIPTION
Fixes [Bug 101](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=101).

Issue: One-time (single use) coupons can be used but any subsequent load shows error message. This is because adapter considers availability as equal to validity.

Solution: 
* Add a property `available` to the property `valid` to `ValidatedCoupon` object.
* Add the availability constraint to coupon application (but not to loading coupon info).
* Add test for loading already applied one-time coupon (the coupon should be shown in the Payment step).