### PR TITLE
src/router: fix bug where registration allows to skip saving merchId to database

### DIFF
--- a/src/components/debug/ShowOrganizationIds.vue
+++ b/src/components/debug/ShowOrganizationIds.vue
@@ -25,7 +25,7 @@ export default defineComponent({
     let teamId;
     let paymentState;
     let isPayuTransactionInitiated;
-
+    let isRegistrationInProgressLocalFlag;
     const showComponent = computed(() => !!window.Cypress);
 
     if (showComponent.value) {
@@ -38,6 +38,9 @@ export default defineComponent({
       isPayuTransactionInitiated = computed(
         () => registerChallengeStore.getIsPayuTransactionInitiated,
       );
+      isRegistrationInProgressLocalFlag = computed(
+        () => registerChallengeStore.getIsRegistrationInProgressLocalFlag,
+      );
     }
 
     return {
@@ -47,6 +50,7 @@ export default defineComponent({
       showComponent,
       paymentState,
       isPayuTransactionInitiated,
+      isRegistrationInProgressLocalFlag,
     };
   },
 });
@@ -74,6 +78,12 @@ export default defineComponent({
         DEBUG: is paid from UI
         <span data-cy="debug-is-paid-from-ui-value">{{
           isPayuTransactionInitiated
+        }}</span>
+      </div>
+      <div data-cy="debug-is-registration-in-progress-local-flag">
+        DEBUG: is registration in progress local flag
+        <span data-cy="debug-is-registration-in-progress-local-flag-value">{{
+          isRegistrationInProgressLocalFlag
         }}</span>
       </div>
     </div>

--- a/src/components/register/RegisterChallengeSummary.vue
+++ b/src/components/register/RegisterChallengeSummary.vue
@@ -56,14 +56,14 @@ export default defineComponent({
     onMounted(() => {
       if (
         registerChallengeStore.getIsRegistrationComplete &&
-        registerChallengeStore.getIsRegistrationInProgress
+        registerChallengeStore.getIsRegistrationInProgressLocalFlag
       ) {
         logger?.debug(
-          `Setting current isRegistrationInProgress state from <${registerChallengeStore.getIsRegistrationInProgress}> to <false>.`,
+          `Setting current isRegistrationInProgress state from <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}> to <false>.`,
         );
         registerChallengeStore.setIsRegistrationInProgress(false);
         logger?.debug(
-          `Current isRegistrationInProgress state set to <${registerChallengeStore.getIsRegistrationInProgress}>.`,
+          `Current isRegistrationInProgress state set to <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}>.`,
         );
       }
     });

--- a/src/components/register/RegisterChallengeSummary.vue
+++ b/src/components/register/RegisterChallengeSummary.vue
@@ -59,11 +59,11 @@ export default defineComponent({
         registerChallengeStore.getIsRegistrationInProgressLocalFlag
       ) {
         logger?.debug(
-          `Setting current isRegistrationInProgress state from <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}> to <false>.`,
+          `Setting current isRegistrationInProgressLocalFlag state from <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}> to <false>.`,
         );
-        registerChallengeStore.setIsRegistrationInProgress(false);
+        registerChallengeStore.setIsRegistrationInProgressLocalFlag(false);
         logger?.debug(
-          `Current isRegistrationInProgress state set to <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}>.`,
+          `Current isRegistrationInProgressLocalFlag state set to <${registerChallengeStore.getIsRegistrationInProgressLocalFlag}>.`,
         );
       }
     });

--- a/src/components/register/RegisterChallengeSummary.vue
+++ b/src/components/register/RegisterChallengeSummary.vue
@@ -13,7 +13,7 @@
  */
 
 // libraries
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, onMounted } from 'vue';
 
 // stores
 import { useRegisterChallengeStore } from '../../stores/registerChallenge';
@@ -47,6 +47,13 @@ export default defineComponent({
     const subsidiaryAddress = computed(
       () => registerChallengeStore.getSelectedSubsidiaryAddress,
     );
+
+    // confirm registration is complete by setting local flag
+    onMounted(() => {
+      if (registerChallengeStore.getIsRegistrationComplete) {
+        registerChallengeStore.setIsRegistrationInProgress(false);
+      }
+    });
 
     return {
       personalDetails,

--- a/src/components/register/RegisterChallengeSummary.vue
+++ b/src/components/register/RegisterChallengeSummary.vue
@@ -13,15 +13,19 @@
  */
 
 // libraries
-import { computed, defineComponent, onMounted } from 'vue';
+import { computed, defineComponent, inject, onMounted } from 'vue';
 
 // stores
 import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 import { useLoginStore } from '../../stores/login';
 
+// types
+import type { Logger } from '../types/Logger';
+
 export default defineComponent({
   name: 'RegisterChallengeSummary',
   setup() {
+    const logger = inject('vuejs3-logger') as Logger | null;
     const registerChallengeStore = useRegisterChallengeStore();
     const loginStore = useLoginStore();
 
@@ -50,8 +54,17 @@ export default defineComponent({
 
     // confirm registration is complete by setting local flag
     onMounted(() => {
-      if (registerChallengeStore.getIsRegistrationComplete) {
+      if (
+        registerChallengeStore.getIsRegistrationComplete &&
+        registerChallengeStore.getIsRegistrationInProgress
+      ) {
+        logger?.debug(
+          `Setting current isRegistrationInProgress state from <${registerChallengeStore.getIsRegistrationInProgress}> to <false>.`,
+        );
         registerChallengeStore.setIsRegistrationInProgress(false);
+        logger?.debug(
+          `Current isRegistrationInProgress state set to <${registerChallengeStore.getIsRegistrationInProgress}>.`,
+        );
       }
     });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -65,12 +65,12 @@ export default route(function (/* { store, ssrContext } */) {
        * Otherwise, data from local storage may take precedence over
        * data from API in enforcing router rules.
        */
-      const isRegistrationInProgress: boolean =
+      const isRegistrationInProgressLocalFlag: boolean =
         registerChallengeStore.getIsRegistrationInProgressLocalFlag;
       const isRegistrationCompleteInStore: boolean =
         registerChallengeStore.getIsRegistrationComplete;
       const isRegistrationComplete: boolean =
-        isRegistrationCompleteInStore && !isRegistrationInProgress;
+        isRegistrationCompleteInStore && !isRegistrationInProgressLocalFlag;
       const isUserOrganizationAdmin: boolean =
         registerChallengeStore.getIsUserOrganizationAdmin || false;
 
@@ -82,7 +82,7 @@ export default route(function (/* { store, ssrContext } */) {
         `Router registration phase is active <${isRegistrationPhaseActive}>.`,
       );
       logger?.debug(
-        `Router registration is in progress <${isRegistrationInProgress}>.`,
+        `Router registration is in progress local flag <${isRegistrationInProgressLocalFlag}>.`,
       );
       logger?.debug(
         `Router registration is complete in store <${isRegistrationCompleteInStore}>.`,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -59,8 +59,18 @@ export default route(function (/* { store, ssrContext } */) {
       const isEmailVerified: boolean = registerStore.getIsEmailVerified;
       const isRegistrationPhaseActive: boolean =
         challengeStore.getIsChallengeInPhase(PhaseType.registration);
-      const isRegistrationComplete: boolean =
+      /**
+       * Due to saving registration data in local storage,
+       * we need a local flag to confirm completing the registration.
+       * Otherwise, data from local storage may take precedence over
+       * data from API in enforcing router rules.
+       */
+      const isRegistrationInProgress: boolean =
+        registerChallengeStore.getIsRegistrationInProgress;
+      const isRegistrationCompleteInStore: boolean =
         registerChallengeStore.getIsRegistrationComplete;
+      const isRegistrationComplete: boolean =
+        isRegistrationCompleteInStore && !isRegistrationInProgress;
       const isUserOrganizationAdmin: boolean =
         registerChallengeStore.getIsUserOrganizationAdmin || false;
 
@@ -70,6 +80,12 @@ export default route(function (/* { store, ssrContext } */) {
       logger?.debug(`Router user email is verified <${isEmailVerified}>.`);
       logger?.debug(
         `Router registration phase is active <${isRegistrationPhaseActive}>.`,
+      );
+      logger?.debug(
+        `Router registration is in progress <${isRegistrationInProgress}>.`,
+      );
+      logger?.debug(
+        `Router registration is complete in store <${isRegistrationCompleteInStore}>.`,
       );
       logger?.debug(
         `Router registration is complete <${isRegistrationComplete}>.`,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,7 +46,8 @@ export default route(function (/* { store, ssrContext } */) {
   if (
     !window.Cypress ||
     window.Cypress.spec.name === 'register.spec.cy.js' ||
-    window.Cypress.spec.name === 'router_rules.cy.js'
+    window.Cypress.spec.name === 'router_rules.cy.js' ||
+    window.Cypress.spec.name === 'register_challenge_login.spec.cy.js'
   ) {
     Router.beforeEach(async (to, from, next) => {
       const logger = inject('vuejs3-logger') as Logger | null;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -66,7 +66,7 @@ export default route(function (/* { store, ssrContext } */) {
        * data from API in enforcing router rules.
        */
       const isRegistrationInProgress: boolean =
-        registerChallengeStore.getIsRegistrationInProgress;
+        registerChallengeStore.getIsRegistrationInProgressLocalFlag;
       const isRegistrationCompleteInStore: boolean =
         registerChallengeStore.getIsRegistrationComplete;
       const isRegistrationComplete: boolean =

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -294,7 +294,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getIsMerchIdComplete(): boolean {
       return this.getMerchId !== null;
     },
-    getIsRegistrationInProgress: (state): boolean =>
+    getIsRegistrationInProgressLocalFlag: (state): boolean =>
       state.isRegistrationInProgress,
     getIsRegistrationComplete(): boolean {
       return (
@@ -531,13 +531,16 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
       );
       // if registration is complete after setting data from API, set isRegistrationInProgress to false
-      if (this.getIsRegistrationComplete && this.getIsRegistrationInProgress) {
+      if (
+        this.getIsRegistrationComplete &&
+        this.getIsRegistrationInProgressLocalFlag
+      ) {
         this.$log?.debug(
-          `Setting current isRegistrationInProgress state from <${this.getIsRegistrationInProgress}> to <false>.`,
+          `Setting current isRegistrationInProgress state from <${this.getIsRegistrationInProgressLocalFlag}> to <false>.`,
         );
         this.setIsRegistrationInProgress(false);
         this.$log?.debug(
-          `Current isRegistrationInProgress state set to <${this.getIsRegistrationInProgress}>.`,
+          `Current isRegistrationInProgress state set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
         );
       }
       if (parsedResponse.language) {

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -116,7 +116,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     isSelectedRegisterCoordinator: false,
     hasOrganizationAdmin: null as boolean | null,
     isUserOrganizationAdmin: null as boolean | null,
-    isRegistrationInProgress: true as boolean,
+    isRegistrationInProgressLocalFlag: true as boolean,
   }),
 
   getters: {
@@ -295,7 +295,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       return this.getMerchId !== null;
     },
     getIsRegistrationInProgressLocalFlag: (state): boolean =>
-      state.isRegistrationInProgress,
+      state.isRegistrationInProgressLocalFlag,
     getIsRegistrationComplete(): boolean {
       return (
         this.getIsPersonalDetailsComplete &&
@@ -372,8 +372,11 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     setTelephoneOptIn(telephoneOptIn: boolean) {
       this.telephoneOptIn = telephoneOptIn;
     },
-    setIsRegistrationInProgress(isRegistrationInProgress: boolean) {
-      this.isRegistrationInProgress = isRegistrationInProgress;
+    setIsRegistrationInProgressLocalFlag(
+      isRegistrationInProgressLocalFlag: boolean,
+    ) {
+      this.isRegistrationInProgressLocalFlag =
+        isRegistrationInProgressLocalFlag;
     },
     setLanguage(language: string) {
       this.language = language;
@@ -530,17 +533,17 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       this.$log?.debug(
         `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
       );
-      // if registration is complete after setting data from API, set isRegistrationInProgress to false
+      // if registration is complete after setting data from API, set isRegistrationInProgressLocalFlag to false
       if (
         this.getIsRegistrationComplete &&
         this.getIsRegistrationInProgressLocalFlag
       ) {
         this.$log?.debug(
-          `Setting current isRegistrationInProgress state from <${this.getIsRegistrationInProgressLocalFlag}> to <false>.`,
+          `Setting current isRegistrationInProgressLocalFlag state from <${this.getIsRegistrationInProgressLocalFlag}> to <false>.`,
         );
-        this.setIsRegistrationInProgress(false);
+        this.setIsRegistrationInProgressLocalFlag(false);
         this.$log?.debug(
-          `Current isRegistrationInProgress state set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
+          `Current isRegistrationInProgressLocalFlag state set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
         );
       }
       if (parsedResponse.language) {

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -116,6 +116,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     isSelectedRegisterCoordinator: false,
     hasOrganizationAdmin: null as boolean | null,
     isUserOrganizationAdmin: null as boolean | null,
+    isRegistrationInProgress: true as boolean,
   }),
 
   getters: {
@@ -293,6 +294,8 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getIsMerchIdComplete(): boolean {
       return this.getMerchId !== null;
     },
+    getIsRegistrationInProgress: (state): boolean =>
+      state.isRegistrationInProgress,
     getIsRegistrationComplete(): boolean {
       return (
         this.getIsPersonalDetailsComplete &&
@@ -368,6 +371,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     setTelephoneOptIn(telephoneOptIn: boolean) {
       this.telephoneOptIn = telephoneOptIn;
+    },
+    setIsRegistrationInProgress(isRegistrationInProgress: boolean) {
+      this.isRegistrationInProgress = isRegistrationInProgress;
     },
     setLanguage(language: string) {
       this.language = language;
@@ -524,6 +530,10 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       this.$log?.debug(
         `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
       );
+      // if registration is complete after setting data from API, set isRegistrationInProgress to false
+      if (this.getIsRegistrationComplete) {
+        this.setIsRegistrationInProgress(false);
+      }
       if (parsedResponse.language) {
         this.setLanguage(parsedResponse.language);
         this.$log?.debug(`Language store updated to <${this.getLanguage}>.`);

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -531,8 +531,14 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
         `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
       );
       // if registration is complete after setting data from API, set isRegistrationInProgress to false
-      if (this.getIsRegistrationComplete) {
+      if (this.getIsRegistrationComplete && this.getIsRegistrationInProgress) {
+        this.$log?.debug(
+          `Setting current isRegistrationInProgress state from <${this.getIsRegistrationInProgress}> to <false>.`,
+        );
         this.setIsRegistrationInProgress(false);
+        this.$log?.debug(
+          `Current isRegistrationInProgress state set to <${this.getIsRegistrationInProgress}>.`,
+        );
       }
       if (parsedResponse.language) {
         this.setLanguage(parsedResponse.language);

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -533,19 +533,36 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       this.$log?.debug(
         `Telephone opt-in store updated to <${this.getTelephoneOptIn}>.`,
       );
-      // if registration is complete after setting data from API, set isRegistrationInProgressLocalFlag to false
+      /**
+       * If registration is complete after setting data from API, set
+       * isRegistrationInProgressLocalFlag to false.
+       * Otherwise, set isRegistrationInProgressLocalFlag to true.
+       * Flag ensures consistency between backend and frontend.
+       */
       if (
         this.getIsRegistrationComplete &&
         this.getIsRegistrationInProgressLocalFlag
       ) {
         this.$log?.debug(
-          `Setting current isRegistrationInProgressLocalFlag state from <${this.getIsRegistrationInProgressLocalFlag}> to <false>.`,
+          `Changing store variable isRegistrationInProgressLocalFlag from <${this.getIsRegistrationInProgressLocalFlag}> to <false>.`,
         );
         this.setIsRegistrationInProgressLocalFlag(false);
         this.$log?.debug(
-          `Current isRegistrationInProgressLocalFlag state set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
+          `Store variable isRegistrationInProgressLocalFlag set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
+        );
+      } else if (
+        !this.getIsRegistrationComplete &&
+        !this.getIsRegistrationInProgressLocalFlag
+      ) {
+        this.$log?.debug(
+          `Changing store variable isRegistrationInProgressLocalFlag from <${this.getIsRegistrationInProgressLocalFlag}> to <true>.`,
+        );
+        this.setIsRegistrationInProgressLocalFlag(true);
+        this.$log?.debug(
+          `Store variable isRegistrationInProgressLocalFlag set to <${this.getIsRegistrationInProgressLocalFlag}>.`,
         );
       }
+      // set language from API response
       if (parsedResponse.language) {
         this.setLanguage(parsedResponse.language);
         this.$log?.debug(`Language store updated to <${this.getLanguage}>.`);

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -61,5 +61,5 @@ export const getRegisterChallengeEmptyPersistentState = () => ({
   isUserOrganizationAdmin: null,
   hasOrganizationAdmin: null,
   paymentCategory: PaymentCategory.none,
-  isRegistrationInProgress: true,
+  isRegistrationInProgressLocalFlag: true,
 });

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -61,4 +61,5 @@ export const getRegisterChallengeEmptyPersistentState = () => ({
   isUserOrganizationAdmin: null,
   hasOrganizationAdmin: null,
   paymentCategory: PaymentCategory.none,
+  isRegistrationInProgress: true,
 });

--- a/test/cypress/e2e/register_challenge_login.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_login.spec.cy.js
@@ -4,6 +4,7 @@ import { defLocale } from '../../../src/i18n/def_locale';
 
 describe('Register Challenge registration with login', () => {
   beforeEach(() => {
+    cy.viewport('macbook-16');
     cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
       cy.task('getAppConfig', process).then((config) => {
         cy.wrap(config).as('config');
@@ -41,7 +42,20 @@ describe('Register Challenge registration with login', () => {
             );
           },
         );
+        cy.fixture('apiGetDiscountCouponResponseFull.json').then((response) => {
+          cy.interceptDiscountCouponGetApi(
+            config,
+            defLocale,
+            response.results[0].name,
+            response,
+          );
+        });
       });
+    });
+  });
+
+  context('login and registration', () => {
+    it('allows register from blank state and redirect to homepage', () => {
       // go to login page
       cy.visit('#' + routesConf['login']['children']['fullPath']);
       // alias i18n
@@ -56,21 +70,34 @@ describe('Register Challenge registration with login', () => {
         'include',
         routesConf['register_challenge']['children']['fullPath'],
       );
-    });
-  });
-
-  context('login and registration', () => {
-    it('allows register from blank state and redirect to homepage', () => {
+      // wait for register challenge GET API
       cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
         cy.waitForRegisterChallengeGetApi(response);
       });
+      // fill in register challenge form
       cy.passToStep7();
       cy.dataCy('step-7-continue').should('be.visible').click();
+      // get redirected to homepage
       cy.dataCy('index-title').should('be.visible');
     });
 
     it('should not be redirected to homepage after refreshing on step merch', () => {
       cy.get('@config').then((config) => {
+        // go to login page
+        cy.visit('#' + routesConf['login']['children']['fullPath']);
+        // alias i18n
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          cy.wrap(win.i18n).as('i18n');
+        });
+        // log in
+        cy.fillAndSubmitLoginForm();
+        // wait for register challenge page to load
+        cy.url().should(
+          'include',
+          routesConf['register_challenge']['children']['fullPath'],
+        );
+        // wait for register challenge GET API
         cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
           cy.waitForRegisterChallengeGetApi(response);
         });
@@ -90,13 +117,117 @@ describe('Register Challenge registration with login', () => {
         cy.dataCy('dialog-close').click();
         // verify dialog is closed
         cy.dataCy('dialog-merch').should('not.exist');
-        // refresh page
+        // add phone details
+        cy.fixture('apiPostRegisterChallengeMerchandiseRequest').then(
+          (request) => {
+            // fill phone number
+            cy.dataCy('form-merch-phone-input')
+              .should('be.visible')
+              .find('input')
+              .type(request.telephone);
+            // opt in to info phone calls
+            cy.dataCy('form-merch-phone-opt-in-input')
+              .should('be.visible')
+              .click();
+          },
+        );
+        // verify registration in progress local flag is true
+        cy.dataCy('debug-is-registration-in-progress-local-flag-value')
+          .should('be.visible')
+          .should('have.text', 'true');
+        // trigger router rules
         cy.visit('#' + routesConf['home']['children']['fullPath']);
-        // wait for register challenge page to load
+        // verify we are on register challenge page
         cy.url().should(
           'include',
           routesConf['register_challenge']['children']['fullPath'],
         );
+        // go to next step
+        cy.dataCy('step-6-continue').should('be.visible').click();
+        // verify registration in progress local flag is false
+        cy.dataCy('debug-is-registration-in-progress-local-flag-value')
+          .should('be.visible')
+          .should('have.text', 'false');
+      });
+    });
+
+    it('should redirect user to homepage if registration is complete', () => {
+      cy.get('@config').then((config) => {
+        cy.fixture('apiGetRegisterChallengeComplete.json').then((response) => {
+          cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+        });
+        // go to login page
+        cy.visit('#' + routesConf['login']['children']['fullPath']);
+        // log in
+        cy.fillAndSubmitLoginForm();
+        // wait for register challenge GET API request
+        cy.fixture('apiGetRegisterChallengeComplete.json').then((response) => {
+          cy.waitForRegisterChallengeGetApi(response);
+        });
+        // get redirected to homepage
+        cy.dataCy('index-title').should('be.visible');
+      });
+    });
+
+    it('should redirect user back to register challenge if registration status changes (e.g. denied as a team member)', () => {
+      cy.get('@config').then((config) => {
+        // override intercept register challenge GET API to challenge complete
+        cy.fixture('apiGetRegisterChallengeComplete.json').then((response) => {
+          cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+        });
+        // go to login page
+        cy.visit('#' + routesConf['login']['children']['fullPath']);
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // log in
+          cy.fillAndSubmitLoginForm();
+          // wait for register challenge GET API request
+          cy.fixture('apiGetRegisterChallengeComplete.json').then(
+            (response) => {
+              cy.waitForRegisterChallengeGetApi(response);
+            },
+          );
+          // get redirected to homepage
+          cy.dataCy('index-title').should('be.visible');
+          // wait for register challenge GET API request
+          cy.fixture('apiGetRegisterChallengeComplete.json').then(
+            (response) => {
+              cy.waitForRegisterChallengeGetApi(response);
+            },
+          );
+          // click on user select
+          cy.dataCy('user-select-desktop').within(() => {
+            cy.dataCy('user-select-input').should('be.visible').click();
+          });
+          // logout
+          cy.dataCy('menu-item')
+            .contains(win.i18n.global.t('userSelect.logout'))
+            .click();
+          // check that we are on login page
+          cy.url().should('include', routesConf['login']['path']);
+          // override intercept register challenge GET API to missing team
+          cy.fixture('apiGetRegisterChallengeMissingTeam.json').then(
+            (response) => {
+              cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+            },
+          );
+          // log in
+          cy.fillAndSubmitLoginForm();
+          // wait for register challenge GET API request
+          cy.fixture('apiGetRegisterChallengeMissingTeam.json').then(
+            (response) => {
+              cy.waitForRegisterChallengeGetApi(response);
+            },
+          );
+          // check that we are on register challenge page
+          cy.url().should(
+            'include',
+            routesConf['register_challenge']['children']['fullPath'],
+          );
+          cy.dataCy('debug-is-registration-in-progress-local-flag-value')
+            .should('be.visible')
+            .should('have.text', 'true');
+        });
       });
     });
   });

--- a/test/cypress/e2e/register_challenge_login.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_login.spec.cy.js
@@ -1,0 +1,97 @@
+import { systemTimeChallengeActive } from '../support/commonTests';
+import { routesConf } from '../../../src/router/routes_conf';
+import { defLocale } from '../../../src/i18n/def_locale';
+
+describe('Register Challenge registration with login', () => {
+  beforeEach(() => {
+    cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
+      cy.task('getAppConfig', process).then((config) => {
+        cy.wrap(config).as('config');
+        // intercept register challenge API
+        cy.fixture('refreshTokensResponseChallengeActive').then(
+          (refreshTokensResponseChallengeActive) => {
+            cy.fixture('loginRegisterResponseChallengeActive').then(
+              (loginRegisterResponseChallengeActive) => {
+                cy.interceptLoginRefreshAuthTokenVerifyEmailVerifyCampaignPhaseApi(
+                  config,
+                  defLocale,
+                  loginRegisterResponseChallengeActive,
+                  null,
+                  refreshTokensResponseChallengeActive,
+                  null,
+                  { has_user_verified_email_address: true },
+                );
+              },
+            );
+          },
+        );
+        cy.interceptThisCampaignGetApi(config, defLocale);
+        cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
+          cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+        });
+        cy.interceptRegisterChallengePostApi(config, defLocale);
+        cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+        cy.interceptMyTeamGetApi(config, defLocale);
+        cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+          (response) => {
+            cy.interceptIsUserOrganizationAdminGetApi(
+              config,
+              defLocale,
+              response,
+            );
+          },
+        );
+      });
+      // go to login page
+      cy.visit('#' + routesConf['login']['children']['fullPath']);
+      // alias i18n
+      cy.window().should('have.property', 'i18n');
+      cy.window().then((win) => {
+        cy.wrap(win.i18n).as('i18n');
+      });
+      // log in
+      cy.fillAndSubmitLoginForm();
+      // wait for register challenge page to load
+      cy.url().should(
+        'include',
+        routesConf['register_challenge']['children']['fullPath'],
+      );
+    });
+  });
+
+  context('login and registration with refresh on merch step', () => {
+    it('should be redirect to homepage after refreshing on step merch', () => {
+      cy.get('@config').then((config) => {
+        cy.passToStep6();
+        // select merch
+        cy.dataCy('form-card-merch-female')
+          .first()
+          .find('[data-cy="form-card-merch-link"]')
+          .click();
+        // close dialog
+        cy.dataCy('dialog-close').click();
+        // verify dialog is closed
+        cy.dataCy('dialog-merch').should('not.exist');
+        // intercept register challenge GET API based on filled data
+        cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
+          (response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          },
+        );
+        // refresh page
+        cy.reload();
+        // wait for register challenge GET API endpoint
+        cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
+          (response) => {
+            cy.waitForRegisterChallengeGetApi(config, defLocale, response);
+          },
+        );
+        // wait for register challenge page to load
+        cy.url().should(
+          'include',
+          routesConf['register_challenge']['children']['fullPath'],
+        );
+      });
+    });
+  });
+});

--- a/test/cypress/e2e/register_challenge_login.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_login.spec.cy.js
@@ -62,6 +62,15 @@ describe('Register Challenge registration with login', () => {
   context('login and registration with refresh on merch step', () => {
     it('should be redirect to homepage after refreshing on step merch', () => {
       cy.get('@config').then((config) => {
+        cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
+          cy.waitForRegisterChallengeGetApi(response);
+        });
+        // intercept register challenge GET API based on filled data
+        cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
+          (response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          },
+        );
         cy.passToStep6();
         // select merch
         cy.dataCy('form-card-merch-female')
@@ -72,18 +81,12 @@ describe('Register Challenge registration with login', () => {
         cy.dataCy('dialog-close').click();
         // verify dialog is closed
         cy.dataCy('dialog-merch').should('not.exist');
-        // intercept register challenge GET API based on filled data
-        cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
-          (response) => {
-            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
-          },
-        );
         // refresh page
-        cy.reload();
+        cy.visit('#' + routesConf['home']['children']['fullPath']);
         // wait for register challenge GET API endpoint
         cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
           (response) => {
-            cy.waitForRegisterChallengeGetApi(config, defLocale, response);
+            cy.waitForRegisterChallengeGetApi(response);
           },
         );
         // wait for register challenge page to load

--- a/test/cypress/e2e/register_challenge_login.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_login.spec.cy.js
@@ -59,8 +59,17 @@ describe('Register Challenge registration with login', () => {
     });
   });
 
-  context('login and registration with refresh on merch step', () => {
-    it('should be redirect to homepage after refreshing on step merch', () => {
+  context('login and registration', () => {
+    it('allows register from blank state and redirect to homepage', () => {
+      cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
+        cy.waitForRegisterChallengeGetApi(response);
+      });
+      cy.passToStep7();
+      cy.dataCy('step-7-continue').should('be.visible').click();
+      cy.dataCy('index-title').should('be.visible');
+    });
+
+    it('should not be redirected to homepage after refreshing on step merch', () => {
       cy.get('@config').then((config) => {
         cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
           cy.waitForRegisterChallengeGetApi(response);

--- a/test/cypress/e2e/register_challenge_login.spec.cy.js
+++ b/test/cypress/e2e/register_challenge_login.spec.cy.js
@@ -83,12 +83,6 @@ describe('Register Challenge registration with login', () => {
         cy.dataCy('dialog-merch').should('not.exist');
         // refresh page
         cy.visit('#' + routesConf['home']['children']['fullPath']);
-        // wait for register challenge GET API endpoint
-        cy.fixture('apiGetRegisterChallengeMissingMerch.json').then(
-          (response) => {
-            cy.waitForRegisterChallengeGetApi(response);
-          },
-        );
         // wait for register challenge page to load
         cy.url().should(
           'include',

--- a/test/cypress/fixtures/apiGetRegisterChallengeComplete.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeComplete.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "John",
+        "last_name": "Doe",
+        "nickname": "JD",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge-events-mobility",
+        "personal_data_opt_in": true,
+        "discount_coupon": "ZD-CZBGSD",
+        "payment_subject": "voucher",
+        "payment_type": "",
+        "payment_status": "done",
+        "payment_amount": null,
+        "payment_category": ""
+      },
+      "organization_type": "company",
+      "team_id": 2452,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 133
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetRegisterChallengeMissingMerch.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeMissingMerch.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "John",
+        "last_name": "Doe",
+        "nickname": "JD",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge-events-mobility",
+        "personal_data_opt_in": true,
+        "discount_coupon": "ZD-CZBGSD",
+        "payment_subject": "voucher",
+        "payment_type": "",
+        "payment_status": "done",
+        "payment_amount": null,
+        "payment_category": ""
+      },
+      "organization_type": "company",
+      "team_id": 2452,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": null
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetRegisterChallengeMissingTeam.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeMissingTeam.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "John",
+        "last_name": "Doe",
+        "nickname": "JD",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge-events-mobility",
+        "personal_data_opt_in": true,
+        "discount_coupon": "ZD-CZBGSD",
+        "payment_subject": "voucher",
+        "payment_type": "",
+        "payment_status": "done",
+        "payment_amount": null,
+        "payment_category": ""
+      },
+      "organization_type": "company",
+      "team_id": null,
+      "organization_id": null,
+      "subsidiary_id": null,
+      "t_shirt_size_id": null
+    }
+  ]
+}


### PR DESCRIPTION
Fix bug where registration allows to skip saving `merchId` to DB.

Steps to reproduce:
- Log into app as a user with incomplete registration.
- Complete registration up to step 6 (Merchandise).
- Select merchandise, or "I don't want merchandise" option.
- Refresh page or navigate to `/#/` home URL.
System allows to access home URL but `merchId` has not been saved. Login + logout returns user to registration page.

This happens because router rules use local store state. Once user selects merch, registration is completed on FE, although it has not been completed on BE.

Solution:
* Implement a new store variable `isRegistrationInProgressLocalFlag` which will get updated:
  * A) when state is loaded from BE;
  * B) when user completes registration by going to Step 7 (Summary) in app.
* Use new flag variable in `router/index.ts` to secure router rules.
* Add new E2E test file `register_challenge_login.spec.cy.js` and allow router redirect rules for it.
* Extend the `ShowOrganizationIds` debug component and display `isRegistrationInProgressLocalFlag` state.
* Add E2E tests for several scenarios with redirections.