### PR TITLE
test/cypress/e2e: use clock for fixed time in register challenge voucher tests

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -3509,6 +3509,7 @@ describe('Register Challenge page', () => {
 
   context('registration with payment voucher 95% discount', () => {
     beforeEach(() => {
+      cy.clock(systemTimeRegistrationPhase1May, ['Date']);
       cy.task('getAppConfig', process).then((config) => {
         cy.wrap(config).as('config');
         cy.fixture('apiGetThisCampaignMay.json').then((campaign) => {
@@ -3536,6 +3537,11 @@ describe('Register Challenge page', () => {
         cy.interceptIpAddressGetApi(config);
         cy.interceptPayuCreateOrderPostApi(config, defLocale);
         cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+        cy.fixture('apiPostPayuCreateOrderResponseNoRedirect.json').then(
+          (responseBody) => {
+            cy.interceptPayuCreateOrderPostApi(config, defLocale, responseBody);
+          },
+        );
       });
       cy.visit('#' + routesConf['register_challenge']['path']);
       cy.viewport('macbook-16');
@@ -3610,7 +3616,11 @@ describe('Register Challenge page', () => {
             cy.fixture(
               'apiPostPayuCreateOrderRequestVoucher95NoDonation.json',
             ).then((request) => {
-              cy.waitForPayuCreateOrderPostApi(request);
+              cy.fixture('apiPostPayuCreateOrderResponseNoRedirect.json').then(
+                (response) => {
+                  cy.waitForPayuCreateOrderPostApi(request, response);
+                },
+              );
             });
           });
         });
@@ -3620,6 +3630,7 @@ describe('Register Challenge page', () => {
 
   context('registration with payment voucher 95% discount', () => {
     beforeEach(() => {
+      cy.clock(systemTimeRegistrationPhase1May, ['Date']);
       cy.task('getAppConfig', process).then((config) => {
         cy.wrap(config).as('config');
         cy.fixture('apiGetThisCampaignMay.json').then((campaign) => {
@@ -3649,6 +3660,11 @@ describe('Register Challenge page', () => {
         cy.interceptIpAddressGetApi(config);
         cy.interceptPayuCreateOrderPostApi(config, defLocale);
         cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+        cy.fixture('apiPostPayuCreateOrderResponseNoRedirect.json').then(
+          (responseBody) => {
+            cy.interceptPayuCreateOrderPostApi(config, defLocale, responseBody);
+          },
+        );
       });
       cy.visit('#' + routesConf['register_challenge']['path']);
       cy.viewport('macbook-16');
@@ -3717,7 +3733,11 @@ describe('Register Challenge page', () => {
                   cy.fixture(
                     'apiPostPayuCreateOrderRequestVoucher95NoDonation.json',
                   ).then((request) => {
-                    cy.waitForPayuCreateOrderPostApi(request);
+                    cy.fixture(
+                      'apiPostPayuCreateOrderResponseNoRedirect.json',
+                    ).then((response) => {
+                      cy.waitForPayuCreateOrderPostApi(request, response);
+                    });
                   });
                 },
               );


### PR DESCRIPTION
Issue: Some of the `register_challenge.spec.cy.js` E2E tests fail because they are comparing current prices with prices fixed in given time.

Solution: Use `clock` to specify fixed time for test.
Additionally, resolve another problem, where tests stopped working after redirecting to PayU. Use response fixture with empty redirect field to stop test from redirecting to new URL before test finishes.