### PR TITLE
src/stores: add loader waiting period after user cancels PayU payment

### DIFF
--- a/src/components/register/RegisterChallengePaymentMessages.vue
+++ b/src/components/register/RegisterChallengePaymentMessages.vue
@@ -62,6 +62,7 @@ export default defineComponent({
 
     const isWaitingForConfirmation = computed<boolean>((): boolean => {
       const isStateWaiting =
+        registerChallengeStore.getIsPaymentSubjectOrganization &&
         registerChallengeStore.getPaymentState === PaymentState.waiting;
       const isPaymentDonationWithSubjectOrganization =
         registerChallengeStore.getIsPaymentSubjectOrganization &&

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -832,6 +832,7 @@ textRegistrationWaitingForConfirmationNoCoordinator = "Vaše organizace ještě 
 textRegistrationWaitingForCoordinator = "Platbu ještě musí schválit koordinátor vaší organizace."
 textPayuWaitingForPayment = "Vaši platbu stále zpracováváme. Prosím zkontrolujte stav registrace za několik minut."
 textTeamInfo = "V jednom týmu může být max. 5 členů."
+textWaitingForPaymentLoader = "Čekáme na zpracování vaší platby. V případě, že jste platbu zrušili záměrně, prosím počkejte {seconds} sekund, než budete moci pokračovat v registraci."
 titleDeliveryAddress = "Doručovací adresa"
 titleRegisterToChallenge.may = "Registrace do Květnové výzvy"
 titleRegisterToChallenge.october = "Registrace do Říjnové výzvy"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -830,6 +830,7 @@ textRegistrationWaitingForConfirmationNoCoordinator = "Your organization does no
 textRegistrationWaitingForCoordinator = "Your payment still needs to be approved by your organization's coordinator."
 textPayuWaitingForPayment = "We are still processing your payment. Please check your registration status in a few minutes."
 textTeamInfo = "In one team, there can be a maximum of 5 members."
+textWaitingForPaymentLoader = "We are waiting for your payment to be processed. If you intentionally cancelled the payment, please wait {seconds} seconds before you can continue with the registration."
 titleDeliveryAddress = "Delivery address"
 titleRegisterToChallenge.may = "Register for May challenge"
 titleRegisterToChallenge.october = "Register for October challenge"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -830,6 +830,7 @@ textRegistrationWaitingForConfirmationNoCoordinator = "Vaša organizácia ešte 
 textRegistrationWaitingForCoordinator = "Platbu ešte musí schváliť koordinátor vašej organizácie."
 textPayuWaitingForPayment = "Vašu platbu stále spracovávame. Prosím skontrolujte stav registrácie o niekoľko minút."
 textTeamInfo = "V jednom tíme může být max. 5 členů."
+textWaitingForPaymentLoader = "Čakáme na spracovanie vašej platby. V prípade, že ste platbu zrušili zámerne, prosím počkajte {seconds} sekúnd, než budete môcť pokračovať v registrácii."
 titleDeliveryAddress = "Doručovacia adresa"
 titleRegisterToChallenge.may = "Registrácia na májovú výzvu"
 titleRegisterToChallenge.october = "Registrácia na októbrovú výzvu"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -155,7 +155,8 @@ export default defineComponent({
       }
       await registerChallengeStore.loadRegisterChallengeToStore();
       /**
-       * Depending on the paymentState, and isPayuTransactionInitiated flag
+       * Depending on whether payment is successful,
+       * and isPayuTransactionInitiated flag
        * we determine if situation is:
        * - refreshing page after returning from payment
        * - returning to a started payment

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -142,7 +142,6 @@ export default defineComponent({
     const isPayuTransactionInitiated = computed(
       () => registerChallengeStore.getIsPayuTransactionInitiated,
     );
-    const paymentState = computed(() => registerChallengeStore.getPaymentState);
 
     const router = useRouter();
 
@@ -171,13 +170,13 @@ export default defineComponent({
 
       if (
         isPayuTransactionInitiated.value &&
-        paymentState.value === PaymentState.done
+        registerChallengeStore.getIsPaymentSuccessful
       ) {
         // entry-fee/donation was paid - go to payment step
         onContinue();
       } else if (
         isPayuTransactionInitiated.value &&
-        paymentState.value !== PaymentState.done
+        !registerChallengeStore.getIsPaymentSuccessful
       ) {
         // trigger a periodic registration data refetch + display message
         registerChallengeStore.startRegisterChallengePeriodicCheck();
@@ -185,7 +184,7 @@ export default defineComponent({
         onContinue();
       } else if (
         !isPayuTransactionInitiated.value &&
-        paymentState.value === PaymentState.done
+        registerChallengeStore.getIsPaymentSuccessful
       ) {
         // if payment is done, it should always be safe to continue
         onContinue();

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -337,9 +337,21 @@ export default defineComponent({
       () => registerChallengeStore.getIsRegistrationComplete,
     );
 
-    const secondsToWait =
+    const secondsToWaitDef = ref(
       rideToWorkByBikeConfig.checkRegisterChallengeStatusMaxRepetitions *
-      rideToWorkByBikeConfig.checkRegisterChallengeStatusIntervalSeconds;
+        rideToWorkByBikeConfig.checkRegisterChallengeStatusIntervalSeconds,
+    );
+
+    const secondsToWait = computed(() => {
+      return secondsToWaitDef;
+    });
+
+    const payCheckWaitLoadingTimer = setInterval(() => {
+      if (secondsToWaitDef.value <= 0 || !isPeriodicCheckInProgress.value) {
+        clearInterval(payCheckWaitLoadingTimer);
+      }
+      secondsToWaitDef.value -= 1;
+    }, 1000);
 
     return {
       borderRadius,
@@ -540,7 +552,7 @@ export default defineComponent({
               color="primary"
               :label="
                 $t('register.challenge.textWaitingForPaymentLoader', {
-                  seconds: secondsToWait,
+                  seconds: secondsToWait.value,
                 })
               "
               label-class="text-primary"

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -289,6 +289,10 @@ export default defineComponent({
       );
     });
 
+    const isPeriodicCheckInProgress = computed<boolean>(
+      () => registerChallengeStore.getIsPeriodicCheckInProgress,
+    );
+
     const isLoadingPayuOrder = computed(() => {
       return registerChallengeStore.isLoadingPayuOrder;
     });
@@ -333,6 +337,10 @@ export default defineComponent({
       () => registerChallengeStore.getIsRegistrationComplete,
     );
 
+    const secondsToWait =
+      rideToWorkByBikeConfig.checkRegisterChallengeStatusMaxRepetitions *
+      rideToWorkByBikeConfig.checkRegisterChallengeStatusIntervalSeconds;
+
     return {
       borderRadius,
       contactEmail,
@@ -369,6 +377,7 @@ export default defineComponent({
       doneIconImgSrcStepper7,
       merchId,
       isPaymentAmount,
+      isPeriodicCheckInProgress,
       isRegistrationComplete,
       isRegistrationEntryFeePaidViaPayu,
       isShownCreateOrderButton,
@@ -384,6 +393,7 @@ export default defineComponent({
       onCompleteRegistration,
       registerChallengeStore,
       competitionStart,
+      secondsToWait,
     };
   },
 });
@@ -462,7 +472,7 @@ export default defineComponent({
             :done-icon="doneIconImgSrcStepper2"
             :done="step > 2"
             :header-nav="step > 2"
-            class="bg-white q-mt-lg"
+            class="relative-position bg-white q-mt-lg"
             data-cy="step-2"
           >
             <!-- Form: Payment -->
@@ -487,6 +497,7 @@ export default defineComponent({
                 v-if="!isRegistrationEntryFeePaidViaPayu"
               />
             </q-form>
+            <!-- Navigation -->
             <q-stepper-navigation class="flex justify-end">
               <q-btn
                 unelevated
@@ -523,6 +534,19 @@ export default defineComponent({
                 data-cy="step-2-continue"
               />
             </q-stepper-navigation>
+            <!-- Loader -->
+            <q-inner-loading
+              :showing="isPeriodicCheckInProgress"
+              color="primary"
+              :label="
+                $t('register.challenge.textWaitingForPaymentLoader', {
+                  seconds: secondsToWait,
+                })
+              "
+              label-class="text-primary"
+              label-style="max-width: 200px; font-weight: 600;"
+              data-cy="waiting-for-payment-loader"
+            />
           </q-step>
           <!-- Step: Organization type -->
           <q-step

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -931,7 +931,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
           intervalId = null;
           this.checkPaymentStatusRepetitionCount = 0;
           this.setIsPeriodicCheckInProgress(false);
-          this.$log?.debug(
+          this.$log?.info(
             'Reset interval ID, repetition count, and periodic check status.',
           );
         }

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -112,6 +112,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     isLoadingPayuOrder: false,
     isLoadingUserOrganizationAdmin: false,
     isPayuTransactionInitiated: false,
+    isPeriodicCheckInProgress: false,
     checkPaymentStatusRepetitionCount: 0,
     isSelectedRegisterCoordinator: false,
     hasOrganizationAdmin: null as boolean | null,
@@ -317,6 +318,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     getIsUserStaff: (state): boolean | null => state.personalDetails.isStaff,
     getIsMerchandiseSavedIntoDb: (state): boolean =>
       state.isMerchandiseSavedIntoDb,
+    getIsPeriodicCheckInProgress(): boolean {
+      return this.isPeriodicCheckInProgress;
+    },
   },
 
   actions: {
@@ -399,6 +403,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     setIsMerchandiseSavedIntoDb(isMerchandiseSavedIntoDb: boolean) {
       this.isMerchandiseSavedIntoDb = isMerchandiseSavedIntoDb;
+    },
+    setIsPeriodicCheckInProgress(isPeriodicCheckInProgress: boolean) {
+      this.isPeriodicCheckInProgress = isPeriodicCheckInProgress;
     },
     /**
      * Load registration data from API and set store state
@@ -923,7 +930,10 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
           this.$log?.debug(`Cleared interval ID <${intervalId}>.`);
           intervalId = null;
           this.checkPaymentStatusRepetitionCount = 0;
-          this.$log?.debug('Reset interval ID and repetition count.');
+          this.setIsPeriodicCheckInProgress(false);
+          this.$log?.debug(
+            'Reset interval ID, repetition count, and periodic check status.',
+          );
         }
       };
 
@@ -973,6 +983,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       };
 
       // start interval
+      this.setIsPeriodicCheckInProgress(true);
       intervalId = setInterval(
         checkRegisterChallenge,
         rideToWorkByBikeConfig.checkRegisterChallengeStatusIntervalSeconds *
@@ -1083,6 +1094,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       'isLoadingMerchandise',
       'isLoadingFilteredMerchandise',
       'isLoadingPayuOrder',
+      'isPeriodicCheckInProgress',
       'checkPaymentStatusRepetitionCount',
       'isLoadingUserOrganizationAdmin',
     ],

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -3876,6 +3876,146 @@ describe('Register Challenge page', () => {
       });
     });
   });
+
+  /**
+   * This test check behavior after going to PayU payment,
+   * and clicking back button in browser.
+   * UI initiates a periodic check for payment status, during which
+   * other UI elements on payment step need to be disabled and an info
+   * message needs to be displayed.
+   */
+  context('registration in process, waiting for individual payment', () => {
+    beforeEach(() => {
+      cy.viewport('macbook-16');
+      cy.clock(systemTimeChallengeActive, [
+        'Date',
+        'setInterval',
+        'clearInterval',
+      ]).then((clock) => {
+        cy.wrap(clock).as('clock');
+        cy.task('getAppConfig', process).then((config) => {
+          cy.wrap(config).as('config');
+          // intercept register challenge API
+          cy.fixture('refreshTokensResponseChallengeActive').then(
+            (refreshTokensResponseChallengeActive) => {
+              cy.fixture('loginRegisterResponseChallengeActive').then(
+                (loginRegisterResponseChallengeActive) => {
+                  cy.interceptLoginRefreshAuthTokenVerifyEmailVerifyCampaignPhaseApi(
+                    config,
+                    defLocale,
+                    loginRegisterResponseChallengeActive,
+                    null,
+                    refreshTokensResponseChallengeActive,
+                    null,
+                    { has_user_verified_email_address: true },
+                  );
+                },
+              );
+            },
+          );
+          cy.interceptThisCampaignGetApi(config, defLocale);
+          cy.fixture(
+            'apiGetRegisterChallengeIndividualWaitingMinAmount.json',
+          ).then((response) => {
+            cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+          });
+          cy.fixture('apiPostRegisterChallengeResponsePaymentNone.json').then(
+            (responseBody) => {
+              cy.interceptRegisterChallengePostApi(
+                config,
+                defLocale,
+                responseBody,
+              );
+            },
+          );
+          cy.interceptRegisterChallengeCoreApiRequests(config, defLocale);
+          cy.interceptMyTeamGetApi(config, defLocale);
+          cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+            (response) => {
+              cy.interceptIsUserOrganizationAdminGetApi(
+                config,
+                defLocale,
+                response,
+              );
+            },
+          );
+          cy.fixture('apiGetDiscountCouponResponseFull.json').then(
+            (response) => {
+              cy.interceptDiscountCouponGetApi(
+                config,
+                defLocale,
+                response.results[0].name,
+                response,
+              );
+            },
+          );
+          cy.fixture('apiPostPayuCreateOrderResponse.json').then(
+            (responseBody) => {
+              cy.interceptPayuCreateOrderPostApi(
+                config,
+                defLocale,
+                responseBody,
+              );
+            },
+          );
+        });
+      });
+    });
+
+    it.only('after going to PayU payment, runs periodic check for payment status (set-is-paid-from-ui-true)', () => {
+      cy.get('@config').then((config) => {
+        cy.visit('#' + routesConf['register_challenge']['path']);
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // go to register challenge page
+          // wait for register challenge GET API
+          cy.fixture(
+            'apiGetRegisterChallengeIndividualWaitingMinAmount.json',
+          ).then((response) => {
+            cy.waitForRegisterChallengeGetApi(response);
+          });
+          // UI loader is visible
+          cy.dataCy('waiting-for-payment-loader')
+            .should('be.visible')
+            .and(
+              'contain',
+              win.i18n.global.t(
+                'register.challenge.textWaitingForPaymentLoader',
+                {
+                  seconds:
+                    config.checkRegisterChallengeStatusMaxRepetitions *
+                    config.checkRegisterChallengeStatusIntervalSeconds,
+                },
+              ),
+            );
+          // move clock forward by 1 minute
+          cy.get('@clock').then((clock) => {
+            clock.tick(
+              1000 * 20 * config.checkRegisterChallengeStatusMaxRepetitions +
+                1000,
+            );
+          });
+          // check that total number of requests to register challenge GET API is 4
+          cy.get('@getRegisterChallenge.all').should(
+            'have.length',
+            1 + config.checkRegisterChallengeStatusMaxRepetitions,
+          );
+          // after the check, loader is not visible
+          cy.dataCy('waiting-for-payment-loader').should('not.exist');
+          // messages are visible
+          cy.dataCy('payment-messages').should('be.visible');
+          // UI shows message "waiting for payment"
+          cy.dataCy('registration-payu-waiting-for-payment').should(
+            'be.visible',
+          );
+          // UI does NOT show message "waiting for coordinator"
+          cy.dataCy('registration-waiting-for-confirmation').should(
+            'not.exist',
+          );
+        });
+      });
+    });
+  });
 });
 
 function checkActiveIcon(activeStep) {

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -3962,7 +3962,7 @@ describe('Register Challenge page', () => {
       });
     });
 
-    it.only('after going to PayU payment, runs periodic check for payment status (set-is-paid-from-ui-true)', () => {
+    it('after going to PayU payment, runs periodic check for payment status (set-is-paid-from-ui-true)', () => {
       cy.get('@config').then((config) => {
         cy.visit('#' + routesConf['register_challenge']['path']);
         cy.window().should('have.property', 'i18n');
@@ -3988,6 +3988,15 @@ describe('Register Challenge page', () => {
                 },
               ),
             );
+          // messages are visible
+          cy.dataCy('payment-messages').should('be.visible');
+          // UI shows message "waiting for payment"
+          cy.dataCy('registration-payu-waiting-for-payment')
+            .should('be.visible')
+            .and(
+              'contain',
+              win.i18n.global.t('register.challenge.textPayuWaitingForPayment'),
+            );
           // move clock forward by 1 minute
           cy.get('@clock').then((clock) => {
             clock.tick(
@@ -4002,11 +4011,9 @@ describe('Register Challenge page', () => {
           );
           // after the check, loader is not visible
           cy.dataCy('waiting-for-payment-loader').should('not.exist');
-          // messages are visible
-          cy.dataCy('payment-messages').should('be.visible');
-          // UI shows message "waiting for payment"
+          // UI does NOT show message "waiting for payment"
           cy.dataCy('registration-payu-waiting-for-payment').should(
-            'be.visible',
+            'not.exist',
           );
           // UI does NOT show message "waiting for coordinator"
           cy.dataCy('registration-waiting-for-confirmation').should(

--- a/test/cypress/fixtures/apiGetRegisterChallengeIndividualWaitingMinAmount.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeIndividualWaitingMinAmount.json
@@ -1,0 +1,35 @@
+{
+  "count": 0,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "email": "foo@bar.com",
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "individual",
+        "payment_type": "",
+        "payment_status": "waiting",
+        "payment_amount": 390,
+        "payment_category": "entry_fee",
+        "approved_for_team": "undecided"
+      },
+      "organization_type": "",
+      "team_id": null,
+      "organization_id": null,
+      "subsidiary_id": null,
+      "t_shirt_size_id": null
+    }
+  ]
+}


### PR DESCRIPTION
Add loader waiting period after user cancels PayU payment to prevent accidentally overwriting registration state.

* Add state variable `isPeriodicCheckInProgress` to `registerChallenge` store.
* Use the new variable to display `q-inner-loading` component in `RegisterChallengePage`
* Add loader label.
* Use `getIsPaymentSuccessful` to check payment success to accept both `done` and `no_admission` (motivated by failing tests).
* Make `isWaitingForConfirmation` message in `RegisterChallengePaymentMessages` show only for subject organization (motivated by current use case).