### PR TITLE
src/components/__tests__: fix checkbox element selector

### DIFF
--- a/src/components/__tests__/FormRegisterCoordinator.cy.js
+++ b/src/components/__tests__/FormRegisterCoordinator.cy.js
@@ -371,7 +371,7 @@ function coreTests() {
     ).should('be.visible');
     // test responsibility checkbox checked
     cy.dataCy('form-register-coordinator-responsibility')
-      .find('.q-checkbox')
+      .find('.q-checkbox__inner')
       .click();
     // responsibility - required message hidden
     cy.contains(
@@ -384,7 +384,9 @@ function coreTests() {
       i18n.global.t('register.coordinator.form.messageTermsRequired'),
     ).should('be.visible');
     // test terms checkbox checked
-    cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
+    cy.dataCy('form-register-coordinator-terms')
+      .find('.q-checkbox__inner')
+      .click();
     // terms - required message hidden
     cy.contains(
       i18n.global.t('register.coordinator.form.messageTermsRequired'),
@@ -403,10 +405,12 @@ function coreTests() {
       fillFormRegisterCoordinator();
       // check responsibility checkbox
       cy.dataCy('form-register-coordinator-responsibility')
-        .find('.q-checkbox')
+        .find('.q-checkbox__inner')
         .click();
       // check terms checkbox
-      cy.dataCy('form-register-coordinator-terms').find('.q-checkbox').click();
+      cy.dataCy('form-register-coordinator-terms')
+        .find('.q-checkbox__inner')
+        .click();
       // submit form
       cy.dataCy('form-register-coordinator-submit').click();
       // wait for API call to finish


### PR DESCRIPTION
Issue: Currently `FormRegisterCoordinator` component test fails with message:

```
1) <FormRegisterCoordinator>
       mobile
         validates checkboxes correctly:
     AssertionError: Timed out retrying after 60000ms: Expected not to find content: 'Musíte souhlasit se zpracováním osobních údajů' but continuously found it.
```

Update selectors to target clicks on checkbox instead of label element which contains external link.