### PR TITLE
src/composables: add home page prizes menu link item

### DIFF
--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -49,6 +49,12 @@ export const useMenu = () => {
         title: 'results',
         disabled: true,
       },
+      {
+        url: routesConf['prizes']['children']['fullPath'],
+        icon: 'svguse:icons/drawer_menu/icons.svg#lucide-badge-percent',
+        name: 'discounts',
+        title: 'discounts',
+      },
     ];
 
     if (unref(isUserOrganizationAdmin)) {


### PR DESCRIPTION
Show prizes page in the sidebar menu and bottom mobile panel by adding it to `useMenu` composable.

---

TODO: Confirm prizes functionality