### PR TITLE
src/components: use REST API wp_slug field in the FormFieldSelectCity component 

### DIFF
--- a/src/adapters/registerChallengeAdapter.ts
+++ b/src/adapters/registerChallengeAdapter.ts
@@ -58,6 +58,7 @@ export const registerChallengeAdapter = {
       language: apiData.personal_details.language,
       voucher: apiData.personal_details.discount_coupon,
       citySlug: apiData.city_slug,
+      cityWpSlug: apiData.city_wp_slug,
     };
   },
 

--- a/src/components/__tests__/FormFieldSelectCity.cy.js
+++ b/src/components/__tests__/FormFieldSelectCity.cy.js
@@ -74,7 +74,47 @@ function coreTests() {
         .within(() => {
           cy.get('.q-item').first().click();
         });
-      cy.wrap(model).its('value').should('eq', citiesResponse.results[0].slug);
+      cy.wrap(model)
+        .its('value')
+        .should('eq', citiesResponse.results[0].wp_slug);
+    });
+  });
+
+  it('works correctly with non-unique wp_slug', () => {
+    cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
+      cy.waitForCitiesApi();
+      // choose city with different slug and wp_slug
+      cy.dataCy('form-select-city').click();
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').contains(citiesResponse.results[6].name).click();
+        });
+      // modelValue is set to chosen city wp_slug
+      cy.wrap(model)
+        .its('value')
+        .should('eq', citiesResponse.results[6].wp_slug);
+      // select contains chosen city name
+      cy.dataCy('form-select-city').should(
+        'contain',
+        citiesResponse.results[6].name,
+      );
+      // choose city with same wp_slug as previous city
+      cy.dataCy('form-select-city').click();
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').contains(citiesResponse.results[12].name).click();
+        });
+      // modelValue is set to chosen city wp_slug
+      cy.wrap(model)
+        .its('value')
+        .should('eq', citiesResponse.results[12].wp_slug);
+      // select contains chosen city name
+      cy.dataCy('form-select-city').should(
+        'contain',
+        citiesResponse.results[12].name,
+      );
     });
   });
 }

--- a/src/components/types/ApiRegistration.ts
+++ b/src/components/types/ApiRegistration.ts
@@ -44,6 +44,7 @@ export type RegisterChallengeResult = {
   t_shirt_size_id: number | null;
   organization_type: string;
   city_slug: string | null;
+  city_wp_slug: string | null;
 };
 
 export type RegisterChallengeResponse = {

--- a/src/components/types/City.ts
+++ b/src/components/types/City.ts
@@ -2,6 +2,7 @@ export interface City {
   id: number;
   name: string;
   slug: string;
+  wp_slug: string;
 }
 
 export interface GetCitiesResponse {

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -256,13 +256,13 @@ export default defineComponent({
         await registerChallengeStore.loadMyTeamToStore(logger);
       }
       // if citySlug is not available, try reloading register challenge data
-      if (!registerChallengeStore.getCitySlug) {
+      if (!registerChallengeStore.getCityWpSlug) {
         await registerChallengeStore.loadRegisterChallengeToStore();
       }
       // if citySlug is available, load posts, else we can't load posts
-      if (registerChallengeStore.getCitySlug) {
+      if (registerChallengeStore.getCityWpSlug) {
         posts.value = await loadPosts(
-          getOffersFeedParamSet(registerChallengeStore.getCitySlug),
+          getOffersFeedParamSet(registerChallengeStore.getCityWpSlug),
         );
       }
     });

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -77,20 +77,24 @@ export default defineComponent({
 
     onMounted(async () => {
       // if citySlug is not available, try reloading register challenge data
-      if (!registerChallengeStore.getCitySlug) {
+      if (!registerChallengeStore.getCityWpSlug) {
         await registerChallengeStore.loadRegisterChallengeToStore();
       }
       // if citySlug is available, load posts, else we can't load posts
-      if (registerChallengeStore.getCitySlug) {
+      if (registerChallengeStore.getCityWpSlug) {
         // load offers and prizes in parallel
         const [offers, prizes] = await Promise.all([
-          loadPosts(getOffersFeedParamSet(registerChallengeStore.getCitySlug)),
-          loadPosts(getPrizesFeedParamSet(registerChallengeStore.getCitySlug)),
+          loadPosts(
+            getOffersFeedParamSet(registerChallengeStore.getCityWpSlug),
+          ),
+          loadPosts(
+            getPrizesFeedParamSet(registerChallengeStore.getCityWpSlug),
+          ),
         ]);
         postsOffers.value = offers;
         postsPrizes.value = prizes;
         // set default value for city select
-        city.value = registerChallengeStore.getCitySlug;
+        city.value = registerChallengeStore.getCityWpSlug;
       }
       // initiate watcher after the citySlug is loaded
       watch(city, async (newSlug: string | null) => {

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -98,6 +98,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     merchandiseCards: {} as Record<Gender, MerchandiseCard[]>,
     myTeam: null as MyTeamResults | null,
     citySlug: null as string | null,
+    cityWpSlug: null as string | null,
     formRegisterCoordinator: deepObjectWithSimplePropsCopy(
       emptyFormRegisterCoordinator,
     ),
@@ -147,6 +148,7 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       state.merchandiseCards,
     getMyTeam: (state): MyTeamResults | null => state.myTeam,
     getCitySlug: (state): string | null => state.citySlug,
+    getCityWpSlug: (state): string | null => state.cityWpSlug,
     getPaymentCategory: (state): PaymentCategory => state.paymentCategory,
     getIsSelectedRegisterCoordinator: (state): boolean =>
       state.isSelectedRegisterCoordinator,
@@ -350,6 +352,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     setCitySlug(citySlug: string | null) {
       this.citySlug = citySlug;
     },
+    setCityWpSlug(cityWpSlug: string | null) {
+      this.cityWpSlug = cityWpSlug;
+    },
     setPaymentCategory(paymentCategory: PaymentCategory) {
       this.paymentCategory = paymentCategory;
     },
@@ -549,6 +554,10 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       );
       this.setCitySlug(parsedResponse.citySlug);
       this.$log?.debug(`City slug store updated to <${this.getCitySlug}>.`);
+      this.setCityWpSlug(parsedResponse.cityWpSlug);
+      this.$log?.debug(
+        `City WP slug store updated to <${this.getCityWpSlug}>.`,
+      );
       if (parsedResponse.language) {
         this.setLanguage(parsedResponse.language);
         this.$log?.debug(`Language store updated to <${this.getLanguage}>.`);

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -48,7 +48,7 @@ describe('Home page', () => {
             cy.interceptOffersGetApi(
               config,
               defLocale,
-              response.results[0].city_slug,
+              response.results[0].city_wp_slug,
               offers,
             );
             cy.wrap(offers).as('offers');
@@ -385,7 +385,7 @@ describe('Home page', () => {
             cy.interceptOffersGetApi(
               config,
               defLocale,
-              response.results[0].city_slug,
+              response.results[0].city_wp_slug,
               offers,
             );
             cy.wrap(offers).as('offers');
@@ -447,7 +447,7 @@ describe('Home page', () => {
             cy.interceptOffersGetApi(
               config,
               defLocale,
-              response.results[0].city_slug,
+              response.results[0].city_wp_slug,
               offers,
             );
             cy.wrap(offers).as('offers');

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -19,12 +19,12 @@ describe('Prizes page', () => {
         cy.interceptOffersGetApi(
           config,
           defLocale,
-          response.results[0].city_slug,
+          response.results[0].city_wp_slug,
         );
         cy.interceptPrizesGetApi(
           config,
           defLocale,
-          response.results[0].city_slug,
+          response.results[0].city_wp_slug,
         );
         cy.interceptCitiesGetApi(config, defLocale);
       });
@@ -78,13 +78,13 @@ describe('Prizes page', () => {
               cy.interceptOffersGetApi(
                 config,
                 defLocale,
-                response.results[0].city_slug,
+                response.results[0].city_wp_slug,
                 responseEmpty,
               );
               cy.interceptPrizesGetApi(
                 config,
                 defLocale,
-                response.results[0].city_slug,
+                response.results[0].city_wp_slug,
                 responseEmpty,
               );
             });

--- a/test/cypress/fixtures/apiGetCitiesResponse.json
+++ b/test/cypress/fixtures/apiGetCitiesResponse.json
@@ -6,102 +6,122 @@
     {
       "id": 41,
       "name": "Brandýs nad Labem",
-      "slug": "brandys-nad-labem"
+      "slug": "brandys-nad-labem",
+      "wp_slug": "brandys-nad-labem"
     },
     {
       "id": 29,
       "name": "Břeclav",
-      "slug": "breclav"
+      "slug": "breclav",
+      "wp_slug": "breclav"
     },
     {
       "id": 5,
       "name": "Brno",
-      "slug": "brno"
+      "slug": "brno",
+      "wp_slug": "brno"
     },
     {
       "id": 14,
       "name": "České Budějovice",
-      "slug": "ceske-budejovice"
+      "slug": "ceske-budejovice",
+      "wp_slug": "ceske-budejovice"
     },
     {
       "id": 15,
       "name": "Hradec Králové",
-      "slug": "hradec-kralove"
+      "slug": "hradec-kralove",
+      "wp_slug": "hradec-kralove"
     },
     {
       "id": 26,
       "name": "Hranice",
-      "slug": "hranice"
+      "slug": "hranice",
+      "wp_slug": "hranice"
     },
     {
       "id": 16,
       "name": "Jablonec nad Nisou",
-      "slug": "jablonec-nad-nisou"
+      "slug": "jablonec-nad-nisou",
+      "wp_slug": "liberec"
     },
     {
       "id": 7,
       "name": "Jihlava",
-      "slug": "jihlava"
+      "slug": "jihlava",
+      "wp_slug": "jihlava"
     },
     {
       "id": 17,
       "name": "Jindřichův Hradec",
-      "slug": "jindrichuv-hradec"
+      "slug": "jindrichuv-hradec",
+      "wp_slug": "jindrichuv-hradec"
     },
     {
       "id": 22,
       "name": "Karviná",
-      "slug": "karvina"
+      "slug": "karvina",
+      "wp_slug": "karvina"
     },
     {
       "id": 34,
       "name": "Kladno",
-      "slug": "kladno"
+      "slug": "kladno",
+      "wp_slug": "kladno"
     },
     {
       "id": 42,
       "name": "Krnov",
-      "slug": "krnov"
+      "slug": "krnov",
+      "wp_slug": "krnov"
     },
     {
       "id": 6,
       "name": "Liberec",
-      "slug": "liberec"
+      "slug": "liberec",
+      "wp_slug": "liberec"
     },
     {
       "id": 44,
       "name": "Litvínov",
-      "slug": "litvinov"
+      "slug": "litvinov",
+      "wp_slug": "most"
     },
     {
       "id": 40,
       "name": "Most",
-      "slug": "most"
+      "slug": "most",
+      "wp_slug": "most"
     },
     {
       "id": 27,
       "name": "Nové Město nad Metují",
-      "slug": "nove-mesto-nad-metuji"
+      "slug": "nove-mesto-nad-metuji",
+      "wp_slug": "nove-mesto-nad-metuji"
     },
     {
       "id": 24,
       "name": "Nový Jičín",
-      "slug": "novy-jicin"
+      "slug": "novy-jicin",
+      "wp_slug": "novy-jicin"
     },
     {
       "id": 8,
       "name": "Olomouc",
-      "slug": "olomouc"
+      "slug": "olomouc",
+      "wp_slug": "olomouc"
     },
     {
       "id": 9,
       "name": "Ostrava",
-      "slug": "ostrava"
+      "slug": "ostrava",
+      "wp_slug": "ostrava"
     },
     {
       "id": 18,
       "name": "Otrokovice",
-      "slug": "otrokovice"
+      "slug": "otrokovice",
+      "wp_slug": "otrokovice"
     }
   ]
 }

--- a/test/cypress/fixtures/apiGetCitiesResponseNext.json
+++ b/test/cypress/fixtures/apiGetCitiesResponseNext.json
@@ -6,67 +6,80 @@
     {
       "id": 21,
       "name": "Pardubice",
-      "slug": "pardubice"
+      "slug": "pardubice",
+      "wp_slug": "pardubice"
     },
     {
       "id": 10,
       "name": "Plzeň",
-      "slug": "plzen"
+      "slug": "plzen",
+      "wp_slug": "plzen"
     },
     {
       "id": 4,
       "name": "Praha",
-      "slug": "praha"
+      "slug": "praha",
+      "wp_slug": "praha"
     },
     {
       "id": 20,
       "name": "Přerov",
-      "slug": "prerov"
+      "slug": "prerov",
+      "wp_slug": "prerov"
     },
     {
       "id": 37,
       "name": "Příbram",
-      "slug": "pribram"
+      "slug": "pribram",
+      "wp_slug": "pribram"
     },
     {
       "id": 31,
       "name": "Říčany u Prahy",
-      "slug": "ricany-u-prahy"
+      "slug": "ricany-u-prahy",
+      "wp_slug": "ricany-u-prahy"
     },
     {
       "id": 33,
       "name": "Rychnov nad Kněžnou",
-      "slug": "rychnov-n-kneznou"
+      "slug": "rychnov-n-kneznou",
+      "wp_slug": "rychnov-n-kneznou"
     },
     {
       "id": 36,
       "name": "Třebíč",
-      "slug": "trebic"
+      "slug": "trebic",
+      "wp_slug": "trebic"
     },
     {
       "id": 11,
       "name": "Uherské Hradiště",
-      "slug": "uherske-hradiste"
+      "slug": "uherske-hradiste",
+      "wp_slug": "uherske-hradiste"
     },
     {
       "id": 12,
       "name": "Ústí nad Labem",
-      "slug": "usti-nad-labem"
+      "slug": "usti-nad-labem",
+      "wp_slug": "usti-nad-labem"
     },
     {
       "id": 35,
       "name": "Žďár nad Sázavou",
-      "slug": "zdar-nad-sazavou"
+      "slug": "zdar-nad-sazavou",
+      "wp_slug": "zdar-nad-sazavou"
     },
     {
       "id": 32,
       "name": "Zlín",
-      "slug": "zlin"
+      "slug": "zlin",
+      "wp_slug": "zlin"
     },
     {
       "id": 30,
       "name": "Znojmo",
-      "slug": "znojmo"
+      "slug": "znojmo",
+      "wp_slug": "znojmo"
     }
   ]
 }

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfile.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfile.json
@@ -25,6 +25,7 @@
         "payment_amount": 390
       },
       "city_slug": "praha",
+      "city_wp_slug": "praha",
       "organization_type": "company",
       "team_id": 2451,
       "organization_id": 987,


### PR DESCRIPTION
Add API field `wp_slug` to be used in `FormFieldSelectCity` component.
This is to allow app BE to be synced with current WP slugs independent of city names.

* Add API field `wp_slug` to `cities/` and `register-challenge/` GET endpoints.
* Update tests and components accordingly.
* Update `FormFieldSelectCity` to handle a) `wp_slug` different from `slug` b) `wp_slug` being a non-unique identifier (QSelect option `value` is `slug` field, which should be unique).