### PR TITLE
src/components/__tests__: fix RegisterChallengePaymentMessages component tests by intercepting coupon validation request

### DIFF
--- a/src/components/__tests__/RegisterChallengePaymentMessages.cy.js
+++ b/src/components/__tests__/RegisterChallengePaymentMessages.cy.js
@@ -29,6 +29,26 @@ describe('<RegisterChallengePaymentMessages>', () => {
   context('payment step', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
+      // intercept coupon FULL endpoint
+      cy.fixture('apiGetDiscountCouponResponseFull').then((apiResponse) => {
+        cy.interceptDiscountCouponGetApi(
+          rideToWorkByBikeConfig,
+          i18n,
+          apiResponse.results[0].name,
+          apiResponse,
+        );
+      });
+      // intercept coupon HALF endpoint
+      cy.fixture('apiGetDiscountCouponResponseHalfWithDonation').then(
+        (apiResponse) => {
+          cy.interceptDiscountCouponGetApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            apiResponse.results[0].name,
+            apiResponse,
+          );
+        },
+      );
       cy.mount(RegisterChallengePaymentMessages, {
         props: {
           isPaymentStep: true,
@@ -216,6 +236,26 @@ describe('<RegisterChallengePaymentMessages>', () => {
   context('summary step', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
+      // intercept coupon FULL endpoint
+      cy.fixture('apiGetDiscountCouponResponseFull').then((apiResponse) => {
+        cy.interceptDiscountCouponGetApi(
+          rideToWorkByBikeConfig,
+          i18n,
+          apiResponse.results[0].name,
+          apiResponse,
+        );
+      });
+      // intercept coupon HALF endpoint
+      cy.fixture('apiGetDiscountCouponResponseHalfWithDonation').then(
+        (apiResponse) => {
+          cy.interceptDiscountCouponGetApi(
+            rideToWorkByBikeConfig,
+            i18n,
+            apiResponse.results[0].name,
+            apiResponse,
+          );
+        },
+      );
       cy.mount(RegisterChallengePaymentMessages, {
         props: {
           isPaymentStep: false,

--- a/test/cypress/fixtures/apiGetDiscountCouponResponseHalfWithDonation.json
+++ b/test/cypress/fixtures/apiGetDiscountCouponResponseHalfWithDonation.json
@@ -1,0 +1,12 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "name": "KP-BBGEPR",
+      "discount": 50,
+      "available": true
+    }
+  ]
+}


### PR DESCRIPTION
Issue:
Component test  for `RegisterChallengePaymentMessages` occasionally fails on test `renders donation success message for voucher full with donation`.

This PR adds API request intercept for the coupon code used in the register-challenge data fixture. This fixes error messages within the test and stops test from failing (on 10 consecutive runs).