### PR TITLE
src/utils: fix displaying CardOffer link-to-web button and update its label

### DIFF
--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -545,7 +545,7 @@ title = "Akční nabídky"
 button = "Všech {count} slev"
 
 [index.cardOffer]
-buttonUseVoucher = "Uplatnit voucher"
+buttonUseVoucher = "Jít na web"
 offerValidFrom = "Akce začíná {startDate}"
 offerValidTo = "Akce končí {endDate}"
 offerValidFromTo = "Akce začíná {startDate} a končí {endDate}"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -541,7 +541,7 @@ title = "Special offers"
 button = "All {count} offers"
 
 [index.cardOffer]
-buttonUseVoucher = "Use my voucher"
+buttonUseVoucher = "Go to website"
 offerValidFrom = "Offer is valid from {startDate}"
 offerValidTo = "Offer is valid until {endDate}"
 offerValidFromTo = "Offer is valid from {startDate} until {endDate}"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -543,7 +543,7 @@ title = "Špeciálne ponuky"
 button = "Všetkých {count} zliav"
 
 [index.cardOffer]
-buttonUseVoucher = "Uplatniť voucher"
+buttonUseVoucher = "Ísť na web"
 offerValidFrom = "Akcia začína {startDate}"
 offerValidTo = "Akcia končí {endDate}"
 offerValidFromTo = "Akcia začína {startDate} a končí {endDate}"

--- a/src/utils/get_normalized_absolute_url.ts
+++ b/src/utils/get_normalized_absolute_url.ts
@@ -4,10 +4,15 @@
  * The function also trims any whitespace from the input URL.
  * @param {string} url - URL to normalize
  * @returns {string} Normalized URL with proper HTTPS protocol
+ *   or empty string if url is empty
  */
 export const getNormalizedAbsoluteUrl = (url: string): string => {
   // trim whitespace
   url = url.trim();
+  // empty url
+  if (!url) {
+    return '';
+  }
   // check if url starts with http:// or https://
   if (!/^https?:\/\//i.test(url)) {
     // If not, prepend https://

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -178,6 +178,30 @@ function coreTests() {
             });
           },
         );
+        // check first offer - example without link
+        cy.dataCy('discount-offers-item').first().click();
+        cy.dataCy('dialog-offer').should('be.visible');
+        // has title
+        cy.dataCy('dialog-header')
+          .find('h3')
+          .should('be.visible')
+          .and('contain', offers[0].title);
+        // has no link
+        cy.dataCy('dialog-offer-link').should('not.exist');
+        // close dialog
+        cy.dataCy('dialog-close').should('be.visible').click();
+        // check second offer - example with link
+        cy.dataCy('discount-offers-item').eq(1).click();
+        cy.dataCy('dialog-offer').should('be.visible');
+        // has title
+        cy.dataCy('dialog-header')
+          .find('h3')
+          .should('be.visible')
+          .and('contain', offers[1].title);
+        // has link
+        cy.dataCy('dialog-offer-link')
+          .should('be.visible')
+          .and('have.attr', 'href', offers[1].voucher_url);
       });
     });
   });

--- a/test/cypress/fixtures/apiGetOffersResponse.json
+++ b/test/cypress/fixtures/apiGetOffersResponse.json
@@ -26,7 +26,7 @@
     "url": "https://dopracenakole.cz/mesto/hradec-kralove/caj-na-triko-dpnk-hk-27-30-5",
     "published": "2025-03-05",
     "voucher": "",
-    "voucher_url": "",
+    "voucher_url": "https://www.recyupcy.cz/",
     "akce_na_triko": "1",
     "start_date": "2025-05-01 00:00",
     "end_date": "2025-05-31",


### PR DESCRIPTION
Fix displaying `CardOffer` link-to-web button.

* Fix returned URL in `get_normalized_absolute_url` util function.
* Update translation strings.
* Add E2E test that checks the link-to-web button display based on fixture data.