### PR TITLE
src/components: update calculation for enabled and disabled dates in RoutesCalendar

### DIFF
--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -1,7 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
 import RoutesCalendar from 'components/routes/RoutesCalendar.vue';
 import { i18n } from '../../boot/i18n';
-import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { useTripsStore } from 'src/stores/trips';
 import { useChallengeStore } from 'src/stores/challenge';
 
@@ -39,7 +38,6 @@ const selectorRoutesCalendar = 'routes-calendar';
 // variables
 const routeCountSingle = 1;
 const routeCountMultiple = 2;
-const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
 
 const dayNames = [
   i18n.global.t('time.mondayShort'),
@@ -121,40 +119,42 @@ describe('<RoutesCalendar>', () => {
         .should('have.length', 0);
       /**
        * Above tests suffice for a 1-day logging window case.
-       * Following tests apply for past days if challengeLoggingWindowDays > 1.
+       * Following tests apply for past days if days_active > 1.
        */
-      if (challengeLoggingWindowDays > 1) {
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemToWorkLogged)
-          .first()
-          .click({ force: true });
-        // only one route should be active
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemFromWorkActive)
-          .should('have.length', 0);
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemToWorkActive)
-          .should('have.length', 1);
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemFromWorkLogged)
-          .first()
-          .click({ force: true });
-        // only one route should be active
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemFromWorkActive)
-          .should('have.length', 1);
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemToWorkActive)
-          .should('have.length', 0);
-        // select today's "to work" route
-        cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemFromWorkActive)
-          .should('have.length', 0);
-        cy.dataCy(selectorRoutesCalendar)
-          .find(dataSelectorItemToWorkActive)
-          .should('have.length', 1);
-      }
+      cy.fixture('apiGetThisCampaign.json').then((response) => {
+        if (response.results[0].days_active > 1) {
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemToWorkLogged)
+            .first()
+            .click({ force: true });
+          // only one route should be active
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemFromWorkActive)
+            .should('have.length', 0);
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemToWorkActive)
+            .should('have.length', 1);
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemFromWorkLogged)
+            .first()
+            .click({ force: true });
+          // only one route should be active
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemFromWorkActive)
+            .should('have.length', 1);
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemToWorkActive)
+            .should('have.length', 0);
+          // select today's "to work" route
+          cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemFromWorkActive)
+            .should('have.length', 0);
+          cy.dataCy(selectorRoutesCalendar)
+            .find(dataSelectorItemToWorkActive)
+            .should('have.length', 1);
+        }
+      });
     });
   });
 });
@@ -219,37 +219,39 @@ function coreTests() {
     checkTodayToWorkActive();
     /**
      * Above tests suffice for a 1-day logging window case.
-     * Following tests apply for past days if challengeLoggingWindowDays > 1.
+     * Following tests apply for past days if days_active > 1.
      */
-    if (challengeLoggingWindowDays > 1) {
-      // select a past day's to work route
-      cy.get(classSelectorPastDayNotDisabled)
-        .first()
-        .find(dataSelectorItemFromWork)
-        .click();
-      // from work is active
-      checkTodayToWorkActive();
-      checkTodayFromWorkActive();
-      checkPastDayToWorkActive();
-      // disable today's "to work" route
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-      checkTodayToWorkInactive();
-      checkTodayFromWorkActive();
-      checkPastDayToWorkActive();
-      // disable today's "from work" route
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
-      checkTodayToWorkInactive();
-      checkTodayFromWorkInactive();
-      checkPastDayToWorkActive();
-      // disable a past day's to work route
-      cy.get(classSelectorPastDayNotDisabled)
-        .first()
-        .find(dataSelectorItemFromWork)
-        .click();
-      checkTodayToWorkInactive();
-      checkTodayFromWorkInactive();
-      checkPastDayToWorkInactive();
-    }
+    cy.fixture('apiGetThisCampaign.json').then((response) => {
+      if (response.results[0].days_active > 1) {
+        // select a past day's to work route
+        cy.get(classSelectorPastDayNotDisabled)
+          .first()
+          .find(dataSelectorItemFromWork)
+          .click();
+        // from work is active
+        checkTodayToWorkActive();
+        checkTodayFromWorkActive();
+        checkPastDayToWorkActive();
+        // disable today's "to work" route
+        cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+        checkTodayToWorkInactive();
+        checkTodayFromWorkActive();
+        checkPastDayToWorkActive();
+        // disable today's "from work" route
+        cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
+        checkTodayToWorkInactive();
+        checkTodayFromWorkInactive();
+        checkPastDayToWorkActive();
+        // disable a past day's to work route
+        cy.get(classSelectorPastDayNotDisabled)
+          .first()
+          .find(dataSelectorItemFromWork)
+          .click();
+        checkTodayToWorkInactive();
+        checkTodayFromWorkInactive();
+        checkPastDayToWorkInactive();
+      }
+    });
   });
 
   it('does not allow to select a day outside current month', () => {
@@ -267,25 +269,27 @@ function coreTests() {
   });
 
   it('it allows to select max number of logged routes', () => {
-    // click on all routes to work
-    cy.dataCy(selectorRoutesCalendar)
-      .find(dataSelectorItemToWorkEmpty)
-      .each((item) => {
-        cy.wrap(item).click({ force: true });
-      });
-    // max routes that should be active is the logging window from config
-    cy.dataCy(selectorRoutesCalendar)
-      .find(dataSelectorItemToWorkActive)
-      .should('have.length.at.most', challengeLoggingWindowDays);
-    cy.dataCy(selectorRoutesCalendar)
-      .find(dataSelectorItemFromWorkEmpty)
-      .each((item) => {
-        cy.wrap(item).click({ force: true });
-      });
-    // max routes that should be active is the logging window from config
-    cy.dataCy(selectorRoutesCalendar)
-      .find(dataSelectorItemFromWorkActive)
-      .should('have.length.at.most', challengeLoggingWindowDays);
+    cy.fixture('apiGetThisCampaign.json').then((response) => {
+      // click on all routes to work
+      cy.dataCy(selectorRoutesCalendar)
+        .find(dataSelectorItemToWorkEmpty)
+        .each((item) => {
+          cy.wrap(item).click({ force: true });
+        });
+      // max routes that should be active is the logging window from config
+      cy.dataCy(selectorRoutesCalendar)
+        .find(dataSelectorItemToWorkActive)
+        .should('have.length.at.most', response.results[0].days_active);
+      cy.dataCy(selectorRoutesCalendar)
+        .find(dataSelectorItemFromWorkEmpty)
+        .each((item) => {
+          cy.wrap(item).click({ force: true });
+        });
+      // max routes that should be active is the logging window from config
+      cy.dataCy(selectorRoutesCalendar)
+        .find(dataSelectorItemFromWorkActive)
+        .should('have.length.at.most', response.results[0].days_active);
+    });
   });
 
   it('renders panel with dynamic heading if routes are selected', () => {

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -38,8 +38,8 @@ const selectorRoutesCalendar = 'routes-calendar';
 // variables
 const routeCountSingle = 1;
 const routeCountMultiple = 2;
-const dateWithNoLoggedRoute = new Date(2024, 8, 27);
-const dateWithLoggedRoute = new Date(2024, 8, 26);
+const dateWithNoLoggedRoute = new Date(2025, 4, 27);
+const dateWithLoggedRoute = new Date(2025, 4, 26);
 
 const dayNames = [
   i18n.global.t('time.mondayShort'),
@@ -68,7 +68,7 @@ describe('<RoutesCalendar>', () => {
       });
       // setup store with commute modes
       cy.setupTripsStoreWithCommuteModes(useTripsStore);
-      cy.fixture('apiGetThisCampaign.json').then((response) => {
+      cy.fixture('apiGetThisCampaignMay.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
           store.setDaysActive(response.results[0].days_active);
           store.setPhaseSet(response.results[0].phase_set);
@@ -94,7 +94,7 @@ describe('<RoutesCalendar>', () => {
         });
         // setup store with commute modes
         cy.setupTripsStoreWithCommuteModes(useTripsStore);
-        cy.fixture('apiGetThisCampaign.json').then((response) => {
+        cy.fixture('apiGetThisCampaignMay.json').then((response) => {
           cy.wrap(useChallengeStore()).then((store) => {
             store.setDaysActive(response.results[0].days_active);
             store.setPhaseSet(response.results[0].phase_set);
@@ -125,7 +125,7 @@ describe('<RoutesCalendar>', () => {
          * Above tests suffice for a 1-day logging window case.
          * Following tests apply for past days if days_active > 1.
          */
-        cy.fixture('apiGetThisCampaign.json').then((response) => {
+        cy.fixture('apiGetThisCampaignMay.json').then((response) => {
           if (response.results[0].days_active > 1) {
             cy.dataCy(selectorRoutesCalendar)
               .find(dataSelectorItemToWorkLogged)
@@ -228,7 +228,7 @@ function coreTests() {
      * Above tests suffice for a 1-day logging window case.
      * Following tests apply for past days if days_active > 1.
      */
-    cy.fixture('apiGetThisCampaign.json').then((response) => {
+    cy.fixture('apiGetThisCampaignMay.json').then((response) => {
       if (response.results[0].days_active > 1) {
         // select a past day's to work route
         cy.get(classSelectorPastDayNotDisabled)
@@ -276,7 +276,7 @@ function coreTests() {
   });
 
   it('it allows to select max number of logged routes', () => {
-    cy.fixture('apiGetThisCampaign.json').then((response) => {
+    cy.fixture('apiGetThisCampaignMay.json').then((response) => {
       // click on all routes to work
       cy.dataCy(selectorRoutesCalendar)
         .find(dataSelectorItemToWorkEmpty)

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -60,7 +60,7 @@ describe('<RoutesCalendar>', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       // set default date
-      const now = new Date(2024, 5, 17);
+      const now = new Date(2024, 8, 27);
       cy.clock(new Date(now), ['Date']);
       cy.wrap(now).as('now');
       cy.mount(RoutesCalendar, {
@@ -71,6 +71,7 @@ describe('<RoutesCalendar>', () => {
       cy.fixture('apiGetThisCampaign.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
           store.setDaysActive(response.results[0].days_active);
+          store.setPhaseSet(response.results[0].phase_set);
         });
       });
       cy.viewport('macbook-16');
@@ -83,7 +84,7 @@ describe('<RoutesCalendar>', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       // set default date
-      const now = new Date(2024, 5, 16);
+      const now = new Date(2024, 8, 26);
       cy.clock(new Date(now), ['Date']);
       cy.wrap(now).as('now');
       cy.mount(RoutesCalendar, {
@@ -94,6 +95,7 @@ describe('<RoutesCalendar>', () => {
       cy.fixture('apiGetThisCampaign.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
           store.setDaysActive(response.results[0].days_active);
+          store.setPhaseSet(response.results[0].phase_set);
         });
       });
       cy.viewport('macbook-16');

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -3,6 +3,7 @@ import RoutesCalendar from 'components/routes/RoutesCalendar.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { useTripsStore } from 'src/stores/trips';
+import { useChallengeStore } from 'src/stores/challenge';
 
 // selectors
 const classSelectorCurrentDay = '.q-current-day';
@@ -60,13 +61,18 @@ describe('<RoutesCalendar>', () => {
       setActivePinia(createPinia());
       // set default date
       const now = new Date(2024, 5, 17);
-      cy.clock(now);
+      cy.clock(new Date(now), ['Date']);
       cy.wrap(now).as('now');
       cy.mount(RoutesCalendar, {
         props: {},
       });
       // setup store with commute modes
       cy.setupTripsStoreWithCommuteModes(useTripsStore);
+      cy.fixture('apiGetThisCampaign.json').then((response) => {
+        cy.wrap(useChallengeStore()).then((store) => {
+          store.setDaysActive(response.results[0].days_active);
+        });
+      });
       cy.viewport('macbook-16');
     });
 
@@ -78,13 +84,18 @@ describe('<RoutesCalendar>', () => {
       setActivePinia(createPinia());
       // set default date
       const now = new Date(2024, 5, 16);
-      cy.clock(now);
+      cy.clock(new Date(now), ['Date']);
       cy.wrap(now).as('now');
       cy.mount(RoutesCalendar, {
         props: {},
       });
       // setup store with commute modes
       cy.setupTripsStoreWithCommuteModes(useTripsStore);
+      cy.fixture('apiGetThisCampaign.json').then((response) => {
+        cy.wrap(useChallengeStore()).then((store) => {
+          store.setDaysActive(response.results[0].days_active);
+        });
+      });
       cy.viewport('macbook-16');
     });
 
@@ -142,136 +153,6 @@ describe('<RoutesCalendar>', () => {
           .find(dataSelectorItemToWorkActive)
           .should('have.length', 1);
       }
-    });
-  });
-
-  context('desktop - current date', () => {
-    beforeEach(() => {
-      setActivePinia(createPinia());
-      // skipping the cy.clock call, as it breaks the interaction with q-dialog
-      cy.mount(RoutesCalendar, {
-        props: {},
-      });
-      // setup store with commute modes
-      cy.setupTripsStoreWithCommuteModes(useTripsStore);
-      cy.viewport('macbook-16');
-    });
-
-    it('renders panel with dynamic heading if routes are selected', () => {
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-      // Note: cy.dataCy(selectorRouteCalendarPanel) is "not visible" because of its CSS properties.
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
-            count: routeCountSingle,
-          }),
-        );
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorInputTransportType)
-        .should('be.visible');
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorRouteInputDistance)
-        .should('be.visible');
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('routes.titleBottomPanel', routeCountMultiple, {
-            count: routeCountMultiple,
-          }),
-        );
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('not.be.visible');
-    });
-
-    it('renders inputs and allows saving when value is entered', () => {
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
-            count: routeCountSingle,
-          }),
-        );
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorInputTransportType)
-        .should('be.visible');
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorRouteInputDistance)
-        .should('be.visible');
-      // save disabed
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorButtonSave)
-        .should('be.visible')
-        .and('be.disabled');
-      // fill in distance
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorInputDistance)
-        .should('be.visible')
-        .focus();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorInputDistance)
-        .should('be.visible')
-        .clear();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorInputDistance)
-        .should('be.visible')
-        .type('10');
-      // save enabled
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorButtonSave)
-        .should('not.be.disabled');
-      // save
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorButtonSave)
-        .click();
-      // panel is closed
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('not.be.visible');
-    });
-
-    it('allows to manually close panel and reopen on interaction', () => {
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-      // show panel with 1 route
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
-            count: routeCountSingle,
-          }),
-        );
-      // close button
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogClose)
-        .click();
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('not.be.visible');
-      // select new route
-      cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
-      // show panel with 2 routes
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(dataSelectorDialogHeader)
-        .should('be.visible')
-        .and(
-          'contain',
-          i18n.global.t('routes.titleBottomPanel', routeCountMultiple, {
-            count: routeCountMultiple,
-          }),
-        );
     });
   });
 });
@@ -403,6 +284,119 @@ function coreTests() {
     cy.dataCy(selectorRoutesCalendar)
       .find(dataSelectorItemFromWorkActive)
       .should('have.length.at.most', challengeLoggingWindowDays);
+  });
+
+  it('renders panel with dynamic heading if routes are selected', () => {
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    // Note: cy.dataCy(selectorRouteCalendarPanel) is "not visible" because of its CSS properties.
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
+          count: routeCountSingle,
+        }),
+      );
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorInputTransportType)
+      .should('be.visible');
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorRouteInputDistance)
+      .should('be.visible');
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('routes.titleBottomPanel', routeCountMultiple, {
+          count: routeCountMultiple,
+        }),
+      );
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('not.be.visible');
+  });
+
+  it('renders inputs and allows saving when value is entered', () => {
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
+          count: routeCountSingle,
+        }),
+      );
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorInputTransportType)
+      .should('be.visible');
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorRouteInputDistance)
+      .should('be.visible');
+    // save disabed
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorButtonSave)
+      .should('be.visible')
+      .and('be.disabled');
+    // fill in distance
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorInputDistance)
+      .should('be.visible')
+      .focus();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorInputDistance)
+      .should('be.visible')
+      .clear();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorInputDistance)
+      .should('be.visible')
+      .type('10');
+    // save enabled
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorButtonSave)
+      .should('not.be.disabled');
+    // save
+    cy.dataCy(selectorRouteCalendarPanel).find(dataSelectorButtonSave).click();
+    // panel is closed
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('not.be.visible');
+  });
+
+  it('allows to manually close panel and reopen on interaction', () => {
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
+    // show panel with 1 route
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
+          count: routeCountSingle,
+        }),
+      );
+    // close button
+    cy.dataCy(selectorRouteCalendarPanel).find(dataSelectorDialogClose).click();
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('not.be.visible');
+    // select new route
+    cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
+    // show panel with 2 routes
+    cy.dataCy(selectorRouteCalendarPanel)
+      .find(dataSelectorDialogHeader)
+      .should('be.visible')
+      .and(
+        'contain',
+        i18n.global.t('routes.titleBottomPanel', routeCountMultiple, {
+          count: routeCountMultiple,
+        }),
+      );
   });
 }
 

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -43,7 +43,10 @@ import { routesConf } from 'src/router/routes_conf';
 
 // fixtures
 import routeListFixture from '../../../test/cypress/fixtures/routeList.json';
+import routesListCalendarFixture from '../../../test/cypress/fixtures/routeListCalendar.json';
+
 const routeList: RouteItem[] = routeListFixture as RouteItem[];
+const routeListCalendar: RouteItem[] = routesListCalendarFixture as RouteItem[];
 
 export default defineComponent({
   name: 'RouteTabs',
@@ -74,6 +77,7 @@ export default defineComponent({
       activeTab,
       lockedTabs,
       routeList,
+      routeListCalendar,
       routesConf,
       RouteTab,
       isLocked,
@@ -144,7 +148,7 @@ export default defineComponent({
         :name="RouteTab.calendar"
         data-cy="route-tabs-panel-calendar"
       >
-        <routes-calendar />
+        <routes-calendar :routes="routeListCalendar" />
       </q-tab-panel>
       <!-- Panel: List -->
       <q-tab-panel :name="RouteTab.list" data-cy="route-tabs-panel-list">

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -43,10 +43,7 @@ import { routesConf } from 'src/router/routes_conf';
 
 // fixtures
 import routeListFixture from '../../../test/cypress/fixtures/routeList.json';
-import routesListCalendarFixture from '../../../test/cypress/fixtures/routeListCalendar.json';
-
 const routeList: RouteItem[] = routeListFixture as RouteItem[];
-const routeListCalendar: RouteItem[] = routesListCalendarFixture as RouteItem[];
 
 export default defineComponent({
   name: 'RouteTabs',
@@ -77,7 +74,6 @@ export default defineComponent({
       activeTab,
       lockedTabs,
       routeList,
-      routeListCalendar,
       routesConf,
       RouteTab,
       isLocked,
@@ -148,7 +144,7 @@ export default defineComponent({
         :name="RouteTab.calendar"
         data-cy="route-tabs-panel-calendar"
       >
-        <routes-calendar :routes="routeListCalendar" />
+        <routes-calendar />
       </q-tab-panel>
       <!-- Panel: List -->
       <q-tab-panel :name="RouteTab.list" data-cy="route-tabs-panel-list">

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -82,7 +82,7 @@ export default defineComponent({
      * This is done based on two conditions:
      * 1. Future date (date is after today)
      * 2. Day is outside the `competition` phase date range
-     * @returns {string | null} date in `YYYY-MM-DD` format
+     * @returns {string | null} - Date in `YYYY-MM-DD` format
      */
     const disabledAfter = computed((): string | null => {
       const timestampToday = parseTimestamp(today());
@@ -116,7 +116,7 @@ export default defineComponent({
      * This is done based on two conditions:
      * 1. Window of logging days before today
      * 2. Day is outside the `competition` phase date range
-     * @returns {string | null} date in `YYYY-MM-DD` format
+     * @returns {string | null} - Date in `YYYY-MM-DD` format
      */
     const disabledBefore = computed((): string | null => {
       const timestampToday = parseTimestamp(today());

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -37,14 +37,14 @@ import RouteCalendarPanel from './RouteCalendarPanel.vue';
 // composables
 import { useCalendarRoutes } from '../../composables/useCalendarRoutes';
 
-// config
-import { rideToWorkByBikeConfig } from '../../boot/global_vars';
-
 // enums
 import { TransportDirection } from '../types/Route';
 
 // fixtures
 import routesListCalendarFixture from '../../../test/cypress/fixtures/routeListCalendar.json';
+
+// stores
+import { useChallengeStore } from '../../stores/challenge';
 
 // types
 import type { Timestamp } from '@quasar/quasar-ui-qcalendar';
@@ -58,13 +58,18 @@ export default defineComponent({
     RouteCalendarPanel,
   },
   setup() {
+    const challengeStore = useChallengeStore();
     const calendar = ref<typeof QCalendarMonth | null>(null);
     const selectedDate = ref<string>(today());
     const locale = computed((): string => {
       return i18n.global.locale;
     });
+
     // disable logging outside the specified time window
-    const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
+    const challengeLoggingWindowDays = computed(
+      () => challengeStore.getDaysActive,
+    );
+
     const disabledAfter = computed((): string | null => {
       const timestamp = parseTimestamp(today());
       const timestampFuture = timestamp
@@ -75,7 +80,7 @@ export default defineComponent({
     const disabledBefore = computed((): string | null => {
       const timestamp = parseTimestamp(today());
       const timestampPast = timestamp
-        ? addToDate(timestamp, { day: -1 * challengeLoggingWindowDays })
+        ? addToDate(timestamp, { day: -1 * challengeLoggingWindowDays.value })
         : null;
       return timestampPast?.date || null;
     });

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -312,6 +312,7 @@ export default defineComponent({
         :day-min-height="100"
       >
         <template #day="{ scope: { timestamp, outside } }">
+          <!-- TODO: make the empty slots display only on the challenge days -->
           <div v-if="!timestamp.future" class="q-my-sm" data-cy="calendar-day">
             <!-- Route to work -->
             <calendar-item-display

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -76,16 +76,13 @@ export default defineComponent({
       return i18n.global.locale;
     });
 
-    // disable logging outside the specified time window
-    const challengeLoggingWindowDays = computed(
-      () => challengeStore.getDaysActive,
-    );
-
     /**
      * Disable logging after a date
+     * Calendar disables all dates after the returned date.
      * This is done based on two conditions:
      * 1. Future date (date is after today)
      * 2. Day is outside the `competition` phase date range
+     * @returns {string | null} date in `YYYY-MM-DD` format
      */
     const disabledAfter = computed((): string | null => {
       const timestampToday = parseTimestamp(today());
@@ -115,15 +112,17 @@ export default defineComponent({
 
     /**
      * Disable logging before a date
+     * Calendar disables all dates before the returned date.
      * This is done based on two conditions:
      * 1. Window of logging days before today
      * 2. Day is outside the `competition` phase date range
+     * @returns {string | null} date in `YYYY-MM-DD` format
      */
     const disabledBefore = computed((): string | null => {
       const timestampToday = parseTimestamp(today());
       const timestampStartOfLoggingWindow = timestampToday
         ? addToDate(timestampToday, {
-            day: -1 * challengeLoggingWindowDays.value,
+            day: -1 * challengeStore.getDaysActive,
           })
         : null;
       const dateStartOfLoggingWindow = makeDate(timestampStartOfLoggingWindow);

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -12,6 +12,9 @@
  * - `CalendarItemDisplay`: Component to render calendar items.
  * - `RouteCalendarPanel`: Component to render dialog panel.
  *
+ * @props
+ * - `routes`: Array of routes to display in the calendar.
+ *
  * @example
  * <routes-calendar />
  *
@@ -25,6 +28,7 @@ import {
   getDate,
   makeDate,
   nextDay,
+  prevDay,
   parseTimestamp,
   QCalendarMonth,
   today,
@@ -44,9 +48,6 @@ import { useCalendarRoutes } from '../../composables/useCalendarRoutes';
 import { TransportDirection } from '../types/Route';
 import { PhaseType } from '../types/Challenge';
 
-// fixtures
-import routesListCalendarFixture from '../../../test/cypress/fixtures/routeListCalendar.json';
-
 // stores
 import { useChallengeStore } from '../../stores/challenge';
 
@@ -61,7 +62,13 @@ export default defineComponent({
     CalendarNavigation,
     RouteCalendarPanel,
   },
-  setup() {
+  props: {
+    routes: {
+      type: Array as PropType<RouteDay[]>,
+      default: () => [],
+    },
+  },
+  setup(props) {
     const challengeStore = useChallengeStore();
     const calendar = ref<typeof QCalendarMonth | null>(null);
     const selectedDate = ref<string>(today());
@@ -103,7 +110,7 @@ export default defineComponent({
 
       return isTomorrowBeforeCompetitionDateTo
         ? getDate(timestampTomorrow)
-        : getDate(timestampCompetitionPhaseDateTo);
+        : getDate(nextDay(timestampCompetitionPhaseDateTo));
     });
 
     /**
@@ -143,7 +150,7 @@ export default defineComponent({
 
       return isStartOfLoggingWindowAfterCompetitionPhaseDateFrom
         ? getDate(timestampStartOfLoggingWindow)
-        : getDate(timestampCompetitionPhaseDateFrom);
+        : getDate(prevDay(timestampCompetitionPhaseDateFrom));
     });
 
     // Define calendar CSS vars for calendar theme
@@ -177,7 +184,7 @@ export default defineComponent({
     }
 
     // Get data
-    const days = ref<RouteDay[]>(routesListCalendarFixture as RouteDay[]);
+    const days = ref<RouteDay[]>(props.routes);
 
     const {
       activeRoutes,

--- a/src/stores/challenge.ts
+++ b/src/stores/challenge.ts
@@ -84,6 +84,9 @@ export const useChallengeStore = defineStore('challenge', {
     setPriceLevel(priceLevel: PriceLevel[]): void {
       this.priceLevel = priceLevel;
     },
+    setDaysActive(daysActive: number | null): void {
+      this.daysActive = daysActive;
+    },
     async loadPhaseSet(): Promise<void> {
       const { campaigns, loadCampaign } = useApiGetCampaign(this.$log);
       await loadCampaign();

--- a/src/stores/challenge.ts
+++ b/src/stores/challenge.ts
@@ -87,6 +87,9 @@ export const useChallengeStore = defineStore('challenge', {
     setDaysActive(daysActive: number | null): void {
       this.daysActive = daysActive;
     },
+    setPhaseSet(phaseSet: Phase[]): void {
+      this.phaseSet = phaseSet;
+    },
     async loadPhaseSet(): Promise<void> {
       const { campaigns, loadCampaign } = useApiGetCampaign(this.$log);
       await loadCampaign();
@@ -94,7 +97,7 @@ export const useChallengeStore = defineStore('challenge', {
         this.$log?.debug(
           `Saving phase set <${JSON.stringify(campaigns.value[0].phase_set, null, 2)}>.`,
         );
-        this.phaseSet = campaigns.value[0].phase_set;
+        this.setPhaseSet(campaigns.value[0].phase_set);
         this.$log?.debug(
           `New phase set <${JSON.stringify(this.getPhaseSet, null, 2)}>.`,
         );
@@ -106,7 +109,7 @@ export const useChallengeStore = defineStore('challenge', {
         this.$log?.debug(
           `Set store this campaign active days value <${campaigns.value[0].days_active}>.`,
         );
-        this.daysActive = campaigns.value[0].days_active;
+        this.setDaysActive(campaigns.value[0].days_active);
         this.$log?.debug(
           `New this camapaing active days value <${this.daysActive}>.`,
         );
@@ -118,7 +121,7 @@ export const useChallengeStore = defineStore('challenge', {
         this.$log?.debug(
           `Set store this campaing max team members <${campaigns.value[0].max_team_members}>.`,
         );
-        this.maxTeamMembers = campaigns.value[0].max_team_members;
+        this.setMaxTeamMembers(campaigns.value[0].max_team_members);
         this.$log?.debug(
           `New this campaing max team members value <${this.maxTeamMembers}>.`,
         );
@@ -130,7 +133,7 @@ export const useChallengeStore = defineStore('challenge', {
         this.$log?.debug(
           `Set store this campaign price level <${campaigns.value[0].price_level}>.`,
         );
-        this.priceLevel = campaigns.value[0].price_level;
+        this.setPriceLevel(campaigns.value[0].price_level);
       } else {
         this.$log?.info('No this campaign price level found.');
       }
@@ -145,9 +148,7 @@ export const useChallengeStore = defineStore('challenge', {
      */
     getIsChallengeInPhase(phaseType: PhaseType): boolean {
       this.$log?.debug(`Checking if challenge is in <${phaseType}> phase.`);
-      const phase = this.phaseSet.find(
-        (phase: Phase) => phase.phase_type === phaseType,
-      );
+      const phase = this.getPhaseFromSet(phaseType);
       if (phase) {
         const startDate: number = new Date(phase.date_from).getTime();
         const endDate: number = new Date(phase.date_to).getTime();
@@ -168,6 +169,12 @@ export const useChallengeStore = defineStore('challenge', {
       }
       this.$log?.debug(`No <${phaseType}> phase type found.`);
       return false;
+    },
+    getPhaseFromSet(phaseType: PhaseType): Phase | null {
+      return (
+        this.phaseSet.find((phase: Phase) => phase.phase_type === phaseType) ||
+        null
+      );
     },
   },
 

--- a/test/cypress/fixtures/routeListCalendar.json
+++ b/test/cypress/fixtures/routeListCalendar.json
@@ -40,6 +40,7 @@
     "toWork": {
       "id": "00001",
       "date": "2024-09-26",
+      "transport": "bicycle",
       "distance": "20.00",
       "direction": "toWork"
     },

--- a/test/cypress/fixtures/routeListCalendar.json
+++ b/test/cypress/fixtures/routeListCalendar.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "10001",
-    "date": "2024-06-14",
+    "date": "2024-09-24",
     "toWork": {
       "id": "00001",
-      "date": "2024-06-14",
+      "date": "2024-09-24",
       "transport": "bicycle",
       "distance": "20.00",
       "direction": "toWork"
     },
     "fromWork": {
       "id": "00002",
-      "date": "2024-06-14",
+      "date": "2024-09-24",
       "transport": "bicycle",
       "distance": "5.00",
       "direction": "fromWork"
@@ -19,17 +19,16 @@
   },
   {
     "id": "10002",
-    "date": "2024-06-15",
+    "date": "2024-09-25",
     "toWork": {
       "id": "00001",
-      "date": "2024-06-15",
+      "date": "2024-09-25",
       "transport": "bicycle",
-      "distance": "21.00",
       "direction": "toWork"
     },
     "fromWork": {
       "id": "00002",
-      "date": "2024-06-15",
+      "date": "2024-09-25",
       "transport": "bicycle",
       "distance": "19.00",
       "direction": "fromWork"
@@ -37,11 +36,10 @@
   },
   {
     "id": "10003",
-    "date": "2024-06-16",
+    "date": "2024-09-26",
     "toWork": {
       "id": "00001",
-      "date": "2024-06-16",
-      "transport": "bicycle",
+      "date": "2024-09-26",
       "distance": "20.00",
       "direction": "toWork"
     },

--- a/test/cypress/fixtures/routeListCalendar.json
+++ b/test/cypress/fixtures/routeListCalendar.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "10001",
-    "date": "2024-09-24",
+    "date": "2025-05-24",
     "toWork": {
       "id": "00001",
-      "date": "2024-09-24",
+      "date": "2025-05-24",
       "transport": "bicycle",
       "distance": "20.00",
       "direction": "toWork"
     },
     "fromWork": {
       "id": "00002",
-      "date": "2024-09-24",
+      "date": "2025-05-24",
       "transport": "bicycle",
       "distance": "5.00",
       "direction": "fromWork"
@@ -19,16 +19,16 @@
   },
   {
     "id": "10002",
-    "date": "2024-09-25",
+    "date": "2025-05-25",
     "toWork": {
       "id": "00001",
-      "date": "2024-09-25",
+      "date": "2025-05-25",
       "transport": "bicycle",
       "direction": "toWork"
     },
     "fromWork": {
       "id": "00002",
-      "date": "2024-09-25",
+      "date": "2025-05-25",
       "transport": "bicycle",
       "distance": "19.00",
       "direction": "fromWork"
@@ -36,10 +36,10 @@
   },
   {
     "id": "10003",
-    "date": "2024-09-26",
+    "date": "2025-05-26",
     "toWork": {
       "id": "00001",
-      "date": "2024-09-26",
+      "date": "2025-05-26",
       "transport": "bicycle",
       "distance": "20.00",
       "direction": "toWork"


### PR DESCRIPTION
Update calculation for enabled and disabled dates in `RoutesCalendar`.

* `RoutesCalendar.vue` - update logic for calculating the `disabled-before` and `disabled-after` attribute values based on `challenge` phase, current date and the `days_active` of campaign (logging window). 
* `RoutesCalendar.vue` - add temporary prop for testing (will be replaced by fetching routes from store).
* `RoutesCalendar.cy.js` - add tests related to enabled and disabled sections of calendar on different dates.
* `RoutesCalendar.cy.js` - reorganize (thanks to using scope for `cy.clock` function, we no longer need to separate pop-up panel test into a standalone context - moved tests to `coreTests` function).