### PR TITLE
src/pages: display a list of upcoming events on PrizesPage component

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -148,6 +148,12 @@ dateTimeFormatsAllLocales = '''
   "monthDay": {
     "month": "numeric",
     "day": "numeric"
+  },
+  "monthDayHourMinute" : {
+    "month": "numeric",
+    "day": "numeric",
+    "hour": "numeric",
+    "minute": "numeric"
   }
 }
 '''

--- a/src/adapters/feedAdapter.ts
+++ b/src/adapters/feedAdapter.ts
@@ -144,7 +144,7 @@ const buildOfferMetadata = (
       )
     : '';
   // if post is event, use start date with time
-  if (type === OfferEventType.oneDayEvent) {
+  if (type === OfferEventType.oneDayEvent && post.start_date) {
     startDateFormatted += ` - ${startTimeFormatted}`;
     metadata.push({
       id: CardOfferMetadataKey.validity,

--- a/src/adapters/feedAdapter.ts
+++ b/src/adapters/feedAdapter.ts
@@ -131,17 +131,14 @@ const buildOfferMetadata = (
   // format dates
   let startDateFormatted: string = '';
   startDateFormatted = post.start_date
-    ? i18n.global.d(date.extractDate(post.start_date, 'YYYY-MM-DD'), 'monthDay')
+    ? i18n.global.d(new Date(post.start_date), 'monthDay')
     : '';
   const endDateFormatted: string = post.end_date
-    ? i18n.global.d(date.extractDate(post.end_date, 'YYYY-MM-DD'), 'monthDay')
+    ? i18n.global.d(new Date(post.end_date), 'monthDay')
     : '';
   // format time for events (one-day offers)
   const startTimeFormatted: string = post.start_date
-    ? date.formatDate(
-        date.extractDate(post.start_date, 'YYYY-MM-DD HH:mm'),
-        'HH:mm',
-      )
+    ? date.formatDate(new Date(post.start_date), 'HH:mm')
     : '';
   // if post is event, use start date with time
   if (type === OfferEventType.oneDayEvent && post.start_date) {

--- a/src/adapters/feedAdapter.ts
+++ b/src/adapters/feedAdapter.ts
@@ -7,12 +7,7 @@ import { isOfferValidMoreThanOneDay } from '../utils/get_offer_valid';
 
 // enums
 import { CardOfferMetadataKey } from '../components/enums/Card';
-import { OfferCategorySlug } from '../components/enums/Offers';
-
-export enum PostType {
-  offer = 'offer',
-  event = 'event',
-}
+import { OfferCategorySlug, OfferEventType } from '../components/enums/Offers';
 
 // types
 import type { CardOffer } from '../components/types/Card';
@@ -40,7 +35,9 @@ export const feedAdapter = {
         // first filter offers that last more than one day
         .filter((post) => isOfferValidMoreThanOneDay(post))
         // map posts to card offer format
-        .map((post) => this.mapPostsToCardOffer(post, PostType.offer))
+        .map((post) =>
+          this.mapPostsToCardOffer(post, OfferEventType.multiDayOffer),
+        )
     );
   },
 
@@ -55,17 +52,19 @@ export const feedAdapter = {
         // first filter one-day offers only
         .filter((post) => !isOfferValidMoreThanOneDay(post))
         // map posts to card offer format
-        .map((post) => this.mapPostsToCardOffer(post, PostType.event))
+        .map((post) =>
+          this.mapPostsToCardOffer(post, OfferEventType.oneDayEvent),
+        )
     );
   },
 
   /**
    * Map posts to CardOffer format
    * @param {Offer} post - Post from API
-   * @param {PostType} type - Post type
+   * @param {OfferEventType} type - Post type
    * @returns {CardOffer} - Post in card format
    */
-  mapPostsToCardOffer(post: Offer, type: PostType): CardOffer {
+  mapPostsToCardOffer(post: Offer, type: OfferEventType): CardOffer {
     // default icon slug
     let slug = OfferCategorySlug.discount;
     // if post has categories, use first category slug
@@ -123,7 +122,10 @@ export const feedAdapter = {
  * @param {Offer} post - Offer
  * @returns {CardMetadata[]} - Metadata
  */
-const buildOfferMetadata = (post: Offer, type: PostType): CardMetadata[] => {
+const buildOfferMetadata = (
+  post: Offer,
+  type: OfferEventType,
+): CardMetadata[] => {
   const icon = 'mdi-calendar';
   const metadata: CardMetadata[] = [];
   // format dates
@@ -142,7 +144,7 @@ const buildOfferMetadata = (post: Offer, type: PostType): CardMetadata[] => {
       )
     : '';
   // if post is event, use start date with time
-  if (type === PostType.event) {
+  if (type === OfferEventType.oneDayEvent) {
     startDateFormatted += ` - ${startTimeFormatted}`;
     metadata.push({
       id: CardOfferMetadataKey.validity,

--- a/src/adapters/feedAdapter.ts
+++ b/src/adapters/feedAdapter.ts
@@ -1,6 +1,3 @@
-// libraries
-import { date } from 'quasar';
-
 // composables
 import { i18n } from '../boot/i18n';
 import { isOfferValidMoreThanOneDay } from '../utils/get_offer_valid';
@@ -136,17 +133,15 @@ const buildOfferMetadata = (
   const endDateFormatted: string = post.end_date
     ? i18n.global.d(new Date(post.end_date), 'monthDay')
     : '';
-  // format time for events (one-day offers)
-  const startTimeFormatted: string = post.start_date
-    ? date.formatDate(new Date(post.start_date), 'HH:mm')
-    : '';
+
   // if post is event, use start date with time
   if (type === OfferEventType.oneDayEvent && post.start_date) {
-    startDateFormatted += ` - ${startTimeFormatted}`;
     metadata.push({
       id: CardOfferMetadataKey.validity,
       text: i18n.global.t('index.cardOffer.offerValidFrom', {
-        startDate: startDateFormatted,
+        startDate: post.start_date
+          ? i18n.global.d(new Date(post.start_date), 'monthDayHourMinute')
+          : '', // format time for events (one-day offers)
       }),
       icon: icon,
     });

--- a/src/components/enums/Offers.ts
+++ b/src/components/enums/Offers.ts
@@ -21,6 +21,11 @@ export enum ApiOfferParamPageSubtype {
   prize = 'prize',
 }
 
+export enum OfferEventType {
+  oneDayEvent = 'one_day_event',
+  multiDayOffer = 'multi_day_offer',
+}
+
 export enum OfferCategorySlug {
   alcoDrinks = 'alko-napoje',
   bikeRide = 'cyklojizda',

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -234,13 +234,14 @@ titleNational = "Národní partneři"
 titleMedia = "Mediální partneři"
 titleOrganizers = "Výzvu pořádá"
 
-
 [prizes]
 textAvailablePrizes = "Týmy, které obdrží výhru, losujeme z týmů, které splnily celkovou pravidelnost vyšší než 60 %."
+textEventsEmpty = "Ve vašem městě zatím nejsou naplánované žádné události."
 textSpecialOffers = "Pozor na dobu platnosti nabídek. Některé platí několik dní, jiné vyprší v den konce výzvy, jiné platí i po výzvě."
 textOffersEmpty = "Ve vašem městě jsme zatím nenašli žádné slevy, průběžně je ale doplňujeme. Přijďte se podívat za pár dní."
 textPrizesEmpty = "Ceny zatím nebyly zveřejněny, brzy je tu uvidíte."
 titleAvailablePrizes = "Možné výhry za výzvu Pravidelnost týmu"
+titleEvents = "Nadcházející události"
 titlePrizes = "Slevy a výhry"
 titleSpecialOffers = "Akční nabídky"
 

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -236,10 +236,12 @@ titleOrganizers = "Challenge organized by"
 
 [prizes]
 textAvailablePrizes = "The teams that will receive the prize will be drawn from the teams that have achieved an overall regularity of more than 60%."
+textEventsEmpty = "No events are currently planned in your city."
 textSpecialOffers = "Please note the validity period of the offers. Some are valid for a few days, others expire on the day the call ends, and others expire after the call."
 textOffersEmpty = "We haven't found any discounts in your city yet, but we're adding them gradually. Come back in a few days."
 textPrizesEmpty = "Prizes haven't been published yet, you'll see them here soon."
 titleAvailablePrizes = "Prizes available for the Team Regularity Challenge"
+titleEvents = "Upcoming events"
 titlePrizes = "Discounts and offers"
 titleSpecialOffers = "Special offers"
 

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -236,10 +236,12 @@ titleOrganizers = "Výzvu organizuje"
 
 [prizes]
 textAvailablePrizes = "Tímy, ktoré získajú cenu, budú vyžrebované z tímov, ktoré dosiahli celkovú pravidelnosť viac ako 60 %."
+textEventsEmpty = "Vo vašom meste zatiaľ nie sú naplánované žiadne udalosti."
 textSpecialOffers = "Upozorňujeme na obdobie platnosti ponúk. Niektoré sú platné niekoľko dní, iné vypršia v deň ukončenia hovoru a ďalšie po ukončení hovoru."
 textOffersEmpty = "Vo vašom meste sme zatiaľ nenašli žiadne zľavy, postupne ich však dopĺňame. Príďte sa pozrieť za pár dní."
 textPrizesEmpty = "Ceny zatiaľ neboli zverejnené, čoskoro ich tu uvidíte."
 titleAvailablePrizes = "Možné ceny pre Pravidelnosť tímu"
+titleEvents = "Nadchádzajúce udalosti"
 titlePrizes = "Zľavy a výhry"
 titleSpecialOffers = "Špeciálne ponuky"
 

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -176,7 +176,7 @@ export default defineComponent({
         </div>
       </div>
 
-      <!-- Section: Special events -->
+      <!-- Section: Events -->
       <div class="q-mt-xl">
         <section-heading data-cy="events-title">
           {{ $t('prizes.titleEvents') }}

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -70,7 +70,12 @@ export default defineComponent({
     const postsOffers = ref<Offer[]>([]);
     const postsPrizes = ref<Offer[]>([]);
     const { isLoading, loadPosts } = useApiGetPosts(logger);
-    const cards = computed(() => feedAdapter.toCardOffer(postsOffers.value));
+    const cardsOffer = computed(() =>
+      feedAdapter.toCardOffer(postsOffers.value),
+    );
+    const cardsEvent = computed(() =>
+      feedAdapter.toCardEvent(postsOffers.value),
+    );
     const prizesCards = computed(() =>
       feedAdapter.toCardPrize(postsPrizes.value),
     );
@@ -112,7 +117,8 @@ export default defineComponent({
 
     return {
       city,
-      cards,
+      cardsOffer,
+      cardsEvent,
       isLoading,
       prizesCards,
       enabledSelectCity,
@@ -146,7 +152,7 @@ export default defineComponent({
             {{ $t('prizes.textSpecialOffers') }}
           </template>
         </section-heading>
-        <div v-if="cards.length > 0 || isLoading" class="q-mt-lg">
+        <div v-if="cardsOffer.length > 0 || isLoading" class="q-mt-lg">
           <section-columns
             :columns="3"
             class="q-col-gutter-lg"
@@ -157,7 +163,7 @@ export default defineComponent({
             </template>
             <template v-else>
               <card-offer
-                v-for="card in cards"
+                v-for="card in cardsOffer"
                 :key="card.title"
                 :card="card"
                 data-cy="discount-offers-item"
@@ -167,6 +173,35 @@ export default defineComponent({
         </div>
         <div v-else class="q-mt-lg q-mb-xl text-grey-7">
           <span>{{ $t('prizes.textOffersEmpty') }}</span>
+        </div>
+      </div>
+
+      <!-- Section: Special events -->
+      <div class="q-mt-xl">
+        <section-heading data-cy="events-title">
+          {{ $t('prizes.titleEvents') }}
+        </section-heading>
+        <div v-if="cardsEvent.length > 0 || isLoading" class="q-mt-lg">
+          <section-columns
+            :columns="3"
+            class="q-col-gutter-lg"
+            data-cy="events-list"
+          >
+            <template v-if="isLoading">
+              <card-offer-skeleton v-for="i in 3" :key="i" />
+            </template>
+            <template v-else>
+              <card-offer
+                v-for="card in cardsEvent"
+                :key="card.title"
+                :card="card"
+                data-cy="events-item"
+              />
+            </template>
+          </section-columns>
+        </div>
+        <div v-else class="q-mt-lg q-mb-xl text-grey-7">
+          <span>{{ $t('prizes.textEventsEmpty') }}</span>
         </div>
       </div>
 

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -315,6 +315,49 @@ function coreTests() {
             expect($el.text()).to.equal(translation);
           });
         });
+      cy.dataCy('events-list').should('be.visible');
+      cy.fixture('apiGetOffersResponse.json').then((offers) => {
+        // check if list has correct number of items
+        cy.wrap(
+          offers.filter((offer) => !isOfferValidMoreThanOneDay(offer)),
+        ).then((displayedOffers) => {
+          cy.dataCy('events-item')
+            .should('be.visible')
+            .and('have.length', displayedOffers.length);
+          // check that each item has correct data
+          cy.dataCy('events-item').each((item, index) => {
+            cy.wrap(item).should('contain', displayedOffers[index].title);
+          });
+        });
+      });
+    });
+  });
+
+  it('allows to filter the list of events by selecting a city', () => {
+    cy.waitForOffersApi();
+    cy.dataCy('form-field-select-city').should('be.visible');
+    cy.dataCy('form-field-select-city').find('.q-field__append').click();
+    cy.get('.q-menu')
+      .should('be.visible')
+      .within(() => {
+        cy.get('.q-item').first().click();
+      });
+    cy.fixture('apiGetOffersResponseAlternative.json').then((posts) => {
+      cy.waitForOffersApi(posts);
+      // display list of events
+      cy.dataCy('events-list').should('be.visible');
+      // check if list has correct number of items
+      cy.wrap(posts.filter((post) => !isOfferValidMoreThanOneDay(post))).then(
+        (displayedEvents) => {
+          cy.dataCy('events-item')
+            .should('be.visible')
+            .and('have.length', displayedEvents.length);
+          // check that each item has correct data
+          cy.dataCy('events-item').each((item, index) => {
+            cy.wrap(item).should('contain', displayedEvents[index].title);
+          });
+        },
+      );
     });
   });
 

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -306,6 +306,18 @@ function coreTests() {
     });
   });
 
+  it('renders a list of events', () => {
+    cy.get('@i18n').then((i18n) => {
+      cy.dataCy('events-title')
+        .should('be.visible')
+        .then(($el) => {
+          cy.wrap(i18n.global.t('prizes.titleEvents')).then((translation) => {
+            expect($el.text()).to.equal(translation);
+          });
+        });
+    });
+  });
+
   it.skip('renders a list of partners', () => {
     cy.dataCy('list-partners').should('be.visible');
   });

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -100,7 +100,7 @@ describe('Prizes page', () => {
       });
     });
 
-    it('renders empty state for offers and prizes', () => {
+    it('renders empty state for offers, prizes and events', () => {
       cy.get('@i18n').then((i18n) => {
         // empty offers
         cy.dataCy('discount-offers-title').should('be.visible');
@@ -114,6 +114,13 @@ describe('Prizes page', () => {
         cy.dataCy('available-prizes-list').should('not.exist');
         cy.dataCy('available-prizes-item').should('not.exist');
         cy.contains(i18n.global.t('prizes.textPrizesEmpty')).should(
+          'be.visible',
+        );
+        // empty events
+        cy.dataCy('events-title').should('be.visible');
+        cy.dataCy('events-list').should('not.exist');
+        cy.dataCy('events-item').should('not.exist');
+        cy.contains(i18n.global.t('prizes.textEventsEmpty')).should(
           'be.visible',
         );
       });

--- a/test/cypress/fixtures/apiGetOffersResponse.json
+++ b/test/cypress/fixtures/apiGetOffersResponse.json
@@ -61,5 +61,131 @@
     "excerpt": "",
     "content": "",
     "image": "https://dopracenakole.cz/app/uploads/dpnksleva-600x400.jpg"
+  },
+  {
+    "id": 22403,
+    "title": "Ve\u0159ejn\u00e1 cyklod\u00edlna \u2013 duben",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/verejna-cyklodilna-2",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "",
+    "akce_na_triko": "1",
+    "start_date": "2025-04-29 17:00",
+    "end_date": "",
+    "categories": [
+      {
+        "name": "cykloservis",
+        "slug": "cykloservis",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/cykloservis"
+      }
+    ],
+    "excerpt": "",
+    "content": "",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/IMG_1106-600x800.jpg"
+  },
+  {
+    "id": 32989,
+    "title": "Ve\u0159ejn\u00e1 cyklod\u00edlna \u2013 kv\u011bten",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/verejna-cyklodilna-kveten",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "https:\/\/mestoplzen.cz\/mesto\/plzen\/verejna-cyklodilna-kveten",
+    "akce_na_triko": "1",
+    "start_date": "2025-05-27 17:00",
+    "end_date": "",
+    "categories": [
+      {
+        "name": "cykloservis",
+        "slug": "cykloservis",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/cykloservis"
+      }
+    ],
+    "excerpt": "",
+    "content": "<p>N\u011bco v\u00e1m na kole racht\u00e1 a pot\u0159ebovali byste to poladit? Zastavte se u kav\u00e1rny Dru\u017eba v Sedl\u00e1\u010dkov\u011b ul. 19. Na m\u00edst\u011b budou na\u0161i mechanici a kolo v\u00e1m omrknou, pomohou s opravami nebo porad\u00ed. Pokud pot\u0159ebujete vym\u011bnit du\u0161i, \u0159et\u011bz apod., p\u0159ivezte si pot\u0159ebn\u00e9 v\u011bci s sebou. T\u011b\u0161\u00edme se na v\u00e1s.<\/p>\n<p>Akce prob\u00edh\u00e1 od 17.00 do 18.30 h.<\/p>\n",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/cyklodilna-1-600x399.jpg"
+  },
+  {
+    "id": 12939,
+    "title": "Sn\u00eddan\u011b pro cyklist(k)y a p\u011b\u0161\u00ed",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/snidane-pro-cyklisty",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "",
+    "akce_na_triko": "1",
+    "start_date": "2025-05-28 06:00",
+    "end_date": "",
+    "categories": [
+      {
+        "name": "sn\u00eddan\u011b, sva\u010dina, piknik",
+        "slug": "snidane",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/snidane"
+      }
+    ],
+    "excerpt": "",
+    "content": "",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/333077128-698885592032489-1048867389964207426-n-600x900.jpg"
+  },
+  {
+    "id": 26240,
+    "title": "Cyklop\u00e1rty \u2013 z\u00e1v\u011bre\u010dn\u00fd ve\u010d\u00edrek v Plzni",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/cykloparty-s-vyhlasenim-vysledku",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "",
+    "akce_na_triko": "",
+    "start_date": "2025-06-18 17:00",
+    "end_date": "2025-06-18",
+    "categories": [
+      {
+        "name": "ve\u010d\u00edrek",
+        "slug": "vecirek",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/vecirek"
+      }
+    ],
+    "excerpt": "",
+    "content": "",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/2025\/03\/448881695-799908945578227-5050424772746097621-n-1-600x400.jpg"
+  },
+  {
+    "id": 26251,
+    "title": "Ve\u0159ejn\u00e1 cyklod\u00edlna \u2013 \u010derven",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/verejna-cyklodilna",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "",
+    "akce_na_triko": "1",
+    "start_date": "2025-06-24 17:00",
+    "end_date": "",
+    "categories": [
+      {
+        "name": "cykloservis",
+        "slug": "cykloservis",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/cykloservis"
+      }
+    ],
+    "excerpt": "",
+    "content": "",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/IMG_1100-600x450.jpg"
+  },
+  {
+    "id": 26254,
+    "title": "Ve\u0159ejn\u00e1 cyklod\u00edlna \u2013 \u010dervenec",
+    "url": "https:\/\/dopracenakole.cz\/mesto\/plzen\/verejna-cyklodilna-3",
+    "published": "2025-03-10",
+    "voucher": "",
+    "voucher_url": "",
+    "akce_na_triko": "1",
+    "start_date": "2025-07-29 17:00",
+    "end_date": "",
+    "categories": [
+      {
+        "name": "cykloservis",
+        "slug": "cykloservis",
+        "url": "https:\/\/dopracenakole.cz\/kategorie\/cykloservis"
+      }
+    ],
+    "excerpt": "",
+    "content": "",
+    "image": "https:\/\/dopracenakole.cz\/app\/uploads\/IMG_1089-600x450.jpg"
   }
 ]

--- a/test/cypress/fixtures/apiGetOffersResponseAlternative.json
+++ b/test/cypress/fixtures/apiGetOffersResponseAlternative.json
@@ -118,7 +118,7 @@
     "voucher_url": "",
     "akce_na_triko": "1",
     "start_date": "2025-05-01 09:00",
-    "end_date": "",
+    "end_date": "2025-05-01",
     "categories": [
       {
         "name": "cyklojízda, procházka, výlet",


### PR DESCRIPTION
Display a list of upcoming events on `PrizesPage`.

* Extend `feedAdapter` to get events from fetched posts.
* Add enum for type distinction between `oneDayEvent` and `multiDayOffer`.
* Display Event in cards (same as offers).
* Extend E2E tests (and fixtures where needed - add event-type data).