### PR TITLE
src/components/routes: hide Map and App tabs in RouteTabs component

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
+      // https: true
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true
+      https: true,
       open: true, // opens browser window automatically
     },
 

--- a/src/components/__tests__/RouteTabs.cy.js
+++ b/src/components/__tests__/RouteTabs.cy.js
@@ -22,6 +22,31 @@ describe('<RouteTabs>', () => {
     coreTests();
   });
 
+  context('desktop - hidden tabs', () => {
+    beforeEach(() => {
+      cy.mount(RouteTabs, {
+        props: {
+          hidden: ['map', 'app'],
+        },
+      });
+      cy.viewport('macbook-16');
+    });
+
+    it('does not render tabs or panels marked as hidden', () => {
+      cy.dataCy('route-tabs-button-map').should('not.exist');
+      cy.dataCy('route-tabs-button-app').should('not.exist');
+      cy.dataCy('route-tabs-panel-map').should('not.exist');
+      cy.dataCy('route-tabs-panel-app').should('not.exist');
+    });
+
+    it('renders tabs and panels not marked as hidden', () => {
+      cy.dataCy('route-tabs-button-calendar').click();
+      cy.dataCy('route-tabs-panel-calendar').should('be.visible');
+      cy.dataCy('route-tabs-button-list').click();
+      cy.dataCy('route-tabs-panel-list').should('be.visible');
+    });
+  });
+
   context('desktop - locked tabs', () => {
     beforeEach(() => {
       cy.mount(RouteTabs, {

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -105,6 +105,7 @@ export default defineComponent({
       data-cy="route-tabs"
     >
       <q-route-tab
+        v-if="!isHidden(RouteTab.calendar)"
         :to="routesConf['routes_calendar'].path"
         :name="RouteTab.calendar"
         icon="mdi-calendar-blank"
@@ -115,6 +116,7 @@ export default defineComponent({
         data-cy="route-tabs-button-calendar"
       />
       <q-route-tab
+        v-if="!isHidden(RouteTab.list)"
         :to="routesConf['routes_list'].path"
         :name="RouteTab.list"
         icon="mdi-format-list-bulleted"
@@ -153,13 +155,18 @@ export default defineComponent({
     <q-tab-panels v-model="activeTab" animated>
       <!-- Panel: Calendar -->
       <q-tab-panel
+        v-if="!isHidden(RouteTab.calendar)"
         :name="RouteTab.calendar"
         data-cy="route-tabs-panel-calendar"
       >
         <routes-calendar />
       </q-tab-panel>
       <!-- Panel: List -->
-      <q-tab-panel :name="RouteTab.list" data-cy="route-tabs-panel-list">
+      <q-tab-panel
+        v-if="!isHidden(RouteTab.list)"
+        :name="RouteTab.list"
+        data-cy="route-tabs-panel-list"
+      >
         <div class="text-h6">{{ $t('routes.tabList') }}</div>
         <route-list-edit :routes="routeList" data-cy="route-list-edit" />
         <route-list-display :routes="routeList" data-cy="route-list-display" />

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -72,11 +72,9 @@ export default defineComponent({
     const activeTab = ref('');
     // getter function for locked state
     const isLocked = (tab: RouteTab): boolean => {
-      if (!props.locked.length) return false;
       return props.locked.includes(tab);
     };
     const isHidden = (tab: RouteTab): boolean => {
-      if (!props.hidden.length) return false;
       return props.hidden.includes(tab);
     };
 

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -4,6 +4,10 @@
  *
  * @description * Use this component to render tabs on the Routes page.
  *
+ * @props
+ * - `locked` (RouteTab[]): Array of tab names that are locked - disabled.
+ * - `hidden` (RouteTab[]): Array of tab names that are hidden - not displayed.
+ *
  * @slots
  * - `calendar`: For calendar view.
  * - `list`: For list view.

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -59,24 +59,30 @@ export default defineComponent({
       type: Array as () => RouteTab[],
       default: () => [],
     },
+    hidden: {
+      type: Array as () => RouteTab[],
+      default: () => [],
+    },
   },
   setup(props) {
     const activeTab = ref('');
-    // list locked tabs - exposed for testing and further logic
-    const lockedTabs = props.locked;
     // getter function for locked state
     const isLocked = (tab: RouteTab): boolean => {
-      if (!lockedTabs.length) return false;
-      return lockedTabs.includes(tab);
+      if (!props.locked.length) return false;
+      return props.locked.includes(tab);
+    };
+    const isHidden = (tab: RouteTab): boolean => {
+      if (!props.hidden.length) return false;
+      return props.hidden.includes(tab);
     };
 
     return {
       activeTab,
-      lockedTabs,
       routeList,
       routesConf,
       RouteTab,
       isLocked,
+      isHidden,
     };
   },
 });
@@ -115,6 +121,7 @@ export default defineComponent({
         data-cy="route-tabs-button-list"
       />
       <q-route-tab
+        v-if="!isHidden(RouteTab.map)"
         :to="routesConf['routes_map'].path"
         :name="RouteTab.map"
         icon="mdi-map"
@@ -125,6 +132,7 @@ export default defineComponent({
         data-cy="route-tabs-button-map"
       />
       <q-route-tab
+        v-if="!isHidden(RouteTab.app)"
         :to="routesConf['routes_app'].path"
         :name="RouteTab.app"
         icon="mdi-cellphone"
@@ -153,12 +161,20 @@ export default defineComponent({
         <route-list-display :routes="routeList" data-cy="route-list-display" />
       </q-tab-panel>
       <!-- Panel: Map -->
-      <q-tab-panel :name="RouteTab.map" data-cy="route-tabs-panel-map">
+      <q-tab-panel
+        v-if="!isHidden(RouteTab.map)"
+        :name="RouteTab.map"
+        data-cy="route-tabs-panel-map"
+      >
         <div class="text-h6">{{ $t('routes.tabMap') }}</div>
         <RoutesMap />
       </q-tab-panel>
       <!-- Panel: App -->
-      <q-tab-panel :name="RouteTab.app" data-cy="route-tabs-panel-app">
+      <q-tab-panel
+        v-if="!isHidden(RouteTab.app)"
+        :name="RouteTab.app"
+        data-cy="route-tabs-panel-app"
+      >
         <div class="text-h6">{{ $t('routes.tabApp') }}</div>
         <routes-apps data-cy="routes-apps" />
       </q-tab-panel>

--- a/src/pages/RoutesPage.vue
+++ b/src/pages/RoutesPage.vue
@@ -13,7 +13,7 @@
         </template>
       </page-heading>
     </div>
-    <route-tabs data-cy="route-tabs" />
+    <route-tabs :hidden="[RouteTab.map, RouteTab.app]" data-cy="route-tabs" />
   </q-page>
 </template>
 
@@ -24,6 +24,9 @@ import { defineComponent, onMounted } from 'vue';
 // components
 import PageHeading from 'src/components/global/PageHeading.vue';
 import RouteTabs from 'src/components/routes/RouteTabs.vue';
+
+// enums
+import { RouteTab } from 'src/components/types/Route';
 
 // stores
 import { useTripsStore } from 'src/stores/trips';
@@ -42,6 +45,10 @@ export default defineComponent({
         await tripsStore.loadCommuteModes();
       }
     });
+
+    return {
+      RouteTab,
+    };
   },
 });
 </script>


### PR DESCRIPTION
Hide Map and App tabs in `RouteTabs` component.

* Enable `hidden` prop in `RouteTabs` component which allows to dynamically hide some tabs.
* Hide `map` and `app` tabs on `RoutesPage.vue`
* Update component tests.