### PR TITLE
src/stores: add logic for loading school pricing from campaign API

### DIFF
--- a/src/components/enums/Challenge.ts
+++ b/src/components/enums/Challenge.ts
@@ -7,4 +7,5 @@ export enum ChallengeStatus {
 export enum PriceLevelCategory {
   basic = 'basic',
   company = 'company',
+  school = 'school',
 }

--- a/src/stores/registerChallenge.ts
+++ b/src/stores/registerChallenge.ts
@@ -228,6 +228,19 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       }
       return 0;
     },
+    /**
+     * Get default payment amount for school registration
+     * Used when saving challenge registration with school payment.
+     * @returns {number} - Default school payment amount
+     */
+    getDefaultPaymentAmountSchool(): number {
+      const challengeStore = useChallengeStore();
+      const currentPriceLevels = challengeStore.getCurrentPriceLevels;
+      if (currentPriceLevels[PriceLevelCategory.school]) {
+        return currentPriceLevels[PriceLevelCategory.school].price;
+      }
+      return 0;
+    },
     getIsPayuTransactionInitiated: (state): boolean =>
       state.isPayuTransactionInitiated,
     getIsPaymentCategoryDonation: (state): boolean => {
@@ -249,6 +262,9 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
     },
     getIsPaymentUnsuccessful: (state): boolean => {
       return state.paymentState === PaymentState.unknown;
+    },
+    getIsPaymentSubjectSchool: (state): boolean => {
+      return state.paymentSubject === PaymentSubject.school;
     },
     getIsPaymentSubjectOrganization: (state): boolean => {
       return [PaymentSubject.company, PaymentSubject.school].includes(
@@ -587,6 +603,13 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
       }
 
       const isPaymentOrganization = this.getIsPaymentSubjectOrganization;
+      // set default payment amount for organization
+      let defaultOrganizationPaymentAmount =
+        this.getDefaultPaymentAmountCompany;
+      // if school, set payment amount for school
+      if (this.getIsPaymentSubjectSchool) {
+        defaultOrganizationPaymentAmount = this.getDefaultPaymentAmountSchool;
+      }
       /**
        * Defines what data is sent to the API for each step
        * Data with `null` value is discarded by the
@@ -616,12 +639,12 @@ export const useRegisterChallengeStore = defineStore('registerChallenge', {
             {
               teamId: this.teamId,
               paymentSubject: this.paymentSubject,
-              paymentAmount: this.getDefaultPaymentAmountCompany,
+              paymentAmount: defaultOrganizationPaymentAmount,
               paymentCategory: PaymentCategory.entryFee,
               products: [
                 {
                   name: rideToWorkByBikeConfig.rtwbbChallengeEntryFeeOrderedProductName,
-                  unitPrice: this.getDefaultPaymentAmountCompany,
+                  unitPrice: defaultOrganizationPaymentAmount,
                   quantity: 1,
                 },
               ],

--- a/src/utils/price_levels.ts
+++ b/src/utils/price_levels.ts
@@ -16,9 +16,16 @@ const emptyPriceLevelCompany = {
   takes_effect_on: '',
 } as PriceLevel;
 
+const emptyPriceLevelSchool = {
+  name: PriceLevelCategory.school,
+  category: PriceLevelCategory.school,
+  price: 0,
+  takes_effect_on: '',
+} as PriceLevel;
+
 /**
  * Get current price levels for each category
- * Returns the most recent price levels for basic and company categories
+ * Returns the most recent price levels for basic, company and school categories
  * based on takes_effect_on date
  * @returns {Record<PriceLevelCategory, PriceLevel>} - Current price levels
  *   by category
@@ -32,6 +39,7 @@ export const getCurrentPriceLevelsUtil = (
     const priceLevelsEmpty = {} as Record<PriceLevelCategory, PriceLevel>;
     priceLevelsEmpty[PriceLevelCategory.basic] = emptyPriceLevelBasic;
     priceLevelsEmpty[PriceLevelCategory.company] = emptyPriceLevelCompany;
+    priceLevelsEmpty[PriceLevelCategory.school] = emptyPriceLevelSchool;
     return priceLevelsEmpty;
   }
   if (!now) now = getCurrentDateTimeAccordingTimezone();
@@ -44,6 +52,9 @@ export const getCurrentPriceLevelsUtil = (
   );
   const priceLevelsCompany = priceLevels.filter(
     (priceLevel) => priceLevel[category] === PriceLevelCategory.company,
+  );
+  const priceLevelsSchool = priceLevels.filter(
+    (priceLevel) => priceLevel[category] === PriceLevelCategory.school,
   );
 
   const sortByDate = (priceLevels: Array<PriceLevel>): Array<PriceLevel> => {
@@ -94,6 +105,9 @@ export const getCurrentPriceLevelsUtil = (
   const currentPriceLevelCategoryComputed = getCurrentPriceLevel(
     sortByDate(priceLevelsCompany),
   );
+  const currentPriceLevelSchoolComputed = getCurrentPriceLevel(
+    sortByDate(priceLevelsSchool),
+  );
   if (currentPriceLevelBasicComputed)
     priceLevelComputed[PriceLevelCategory.basic] =
       currentPriceLevelBasicComputed;
@@ -102,6 +116,10 @@ export const getCurrentPriceLevelsUtil = (
     priceLevelComputed[PriceLevelCategory.company] =
       currentPriceLevelCategoryComputed;
   else priceLevelComputed[PriceLevelCategory.company] = emptyPriceLevelCompany;
+  if (currentPriceLevelSchoolComputed)
+    priceLevelComputed[PriceLevelCategory.school] =
+      currentPriceLevelSchoolComputed;
+  else priceLevelComputed[PriceLevelCategory.school] = emptyPriceLevelSchool;
   return priceLevelComputed;
 };
 

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -1825,6 +1825,89 @@ describe('Register Challenge page', () => {
       );
     });
 
+    it('submits form state on 1st, 5th and 6th step (school payment)', () => {
+      cy.clock(systemTimeChallengeActive, ['Date']);
+      cy.passToStep2();
+      // test API post request (personal details)
+      cy.fixture('apiPostRegisterChallengePersonalDetailsRequest.json').then(
+        (request) => {
+          cy.waitForRegisterChallengePostApi(request);
+        },
+      );
+      // on step 2
+      cy.dataCy('step-2').find('.q-stepper__step-content').should('be.visible');
+      cy.dataCy(getRadioOption(OrganizationType.school))
+        .should('be.visible')
+        .click();
+      // open organization select
+      cy.dataCy('form-field-company').should('be.visible').click();
+      // from menu select first organization
+      cy.get('.q-menu').within(() => {
+        cy.get('.q-item').first().click();
+      });
+      // go to next step
+      cy.dataCy('step-2-continue').should('be.visible').click();
+      // test API post request (empty voucher)
+      cy.fixture('apiPostRegisterChallengeVoucherNoneRequest.json').then(
+        (request) => {
+          cy.waitForRegisterChallengePostApi(request);
+        },
+      );
+      // participation is preselected - continue
+      cy.dataCy('step-3-continue').should('be.visible').click();
+      // organization is preselected - select address
+      cy.dataCy('form-company-address').find('.q-field__append').last().click();
+      // select option
+      cy.get('.q-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('.q-item').first().click();
+        });
+      // go to next step
+      cy.dataCy('step-4-continue').should('be.visible').click();
+      // select first available team (this is the second team, first is full)
+      cy.dataCy('form-select-table-team')
+        .should('be.visible')
+        .find('.q-radio:not(.disabled)')
+        .first()
+        .click();
+      // go to next step
+      cy.dataCy('step-5-continue').should('be.visible').click();
+      // test API post request
+      cy.fixture('apiPostRegisterChallengeTeamSchoolPaymentRequest.json').then(
+        (request) => {
+          cy.waitForRegisterChallengePostApi(request);
+        },
+      );
+      // select first merch option
+      cy.dataCy('form-card-merch-female')
+        .first()
+        .find('[data-cy="form-card-merch-link"]')
+        .click();
+      // close dialog
+      cy.dataCy('dialog-close').click();
+      // verify dialog is closed
+      cy.dataCy('dialog-merch').should('not.exist');
+      // fill in phone number
+      cy.fixture('apiPostRegisterChallengeMerchandiseRequest.json').then(
+        (request) => {
+          cy.dataCy('form-merch-phone-input')
+            .find('input')
+            .type(request.telephone);
+        },
+      );
+      // enable telephone opt-in
+      cy.dataCy('form-merch-phone-opt-in-input').click();
+      // go to next step
+      cy.dataCy('step-6-continue').should('be.visible').click();
+      // test API post request (merchandise)
+      cy.fixture('apiPostRegisterChallengeMerchandiseRequest.json').then(
+        (request) => {
+          cy.waitForRegisterChallengePostApi(request);
+        },
+      );
+    });
+
     it('submits personal details with empty newsletter', () => {
       cy.fixture('apiPostRegisterChallengePersonalDetailsRequest').then(
         (personalDetailsRequest) => {

--- a/test/cypress/fixtures/apiGetThisCampaign.json
+++ b/test/cypress/fixtures/apiGetThisCampaign.json
@@ -45,6 +45,12 @@
           "takes_effect_on": "2024-09-01"
         },
         {
+          "name": "1. fáze startovného pro školy",
+          "price": 234.0,
+          "category": "school",
+          "takes_effect_on": "2024-09-01"
+        },
+        {
           "name": "2. fáze startovného pro jednotlivce",
           "price": 400.0,
           "category": "basic",
@@ -57,6 +63,12 @@
           "takes_effect_on": "2024-09-18"
         },
         {
+          "name": "2. fáze startovného pro školy",
+          "price": 240.0,
+          "category": "school",
+          "takes_effect_on": "2024-09-18"
+        },
+        {
           "name": "3. fáze startovného pro jednotlivce",
           "price": 430.0,
           "category": "basic",
@@ -66,6 +78,12 @@
           "name": "3. fáze startovného pro firmy",
           "price": 430.0,
           "category": "company",
+          "takes_effect_on": "2024-09-28"
+        },
+        {
+          "name": "3. fáze startovného pro školy",
+          "price": 250.0,
+          "category": "school",
           "takes_effect_on": "2024-09-28"
         }
       ],

--- a/test/cypress/fixtures/apiPostRegisterChallengeTeamSchoolPaymentRequest.json
+++ b/test/cypress/fixtures/apiPostRegisterChallengeTeamSchoolPaymentRequest.json
@@ -1,0 +1,13 @@
+{
+  "payment_amount": 234,
+  "payment_subject": "school",
+  "payment_category": "entry_fee",
+  "products": [
+    {
+      "name": "RTWBB challenge entry fee",
+      "unitPrice": 234,
+      "quantity": 1
+    }
+  ],
+  "team_id": 2452
+}

--- a/test/cypress/fixtures/getCurrentPriceLevelsUtilTestData.json
+++ b/test/cypress/fixtures/getCurrentPriceLevelsUtilTestData.json
@@ -13,6 +13,12 @@
           "price": 470,
           "category": "basic",
           "takes_effect_on": "2025-01-28"
+        },
+        {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
         }
       ],
       "actual_date": "2025-01-28",
@@ -27,6 +33,12 @@
           "name": "1. vlna registrace",
           "price": 470,
           "category": "company",
+          "takes_effect_on": "2025-01-28"
+        },
+        "school": {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
           "takes_effect_on": "2025-01-28"
         }
       }
@@ -44,6 +56,12 @@
           "price": 470,
           "category": "basic",
           "takes_effect_on": "2025-01-28"
+        },
+        {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
         }
       ],
       "actual_date": "2025-01-29",
@@ -58,6 +76,12 @@
           "name": "1. vlna registrace",
           "price": 470,
           "category": "company",
+          "takes_effect_on": "2025-01-28"
+        },
+        "school": {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
           "takes_effect_on": "2025-01-28"
         }
       }
@@ -77,6 +101,12 @@
           "takes_effect_on": "2025-01-28"
         },
         {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
@@ -86,6 +116,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-30"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         }
       ],
@@ -102,6 +138,12 @@
           "price": 470,
           "category": "company",
           "takes_effect_on": "2025-01-30"
+        },
+        "school": {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
+          "takes_effect_on": "2025-01-30"
         }
       }
     },
@@ -117,6 +159,12 @@
           "name": "1. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
           "takes_effect_on": "2025-01-28"
         },
         {
@@ -145,6 +193,12 @@
           "price": 470,
           "category": "company",
           "takes_effect_on": "2025-01-28"
+        },
+        "school": {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
         }
       }
     },
@@ -163,6 +217,12 @@
           "takes_effect_on": "2025-01-28"
         },
         {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
@@ -172,6 +232,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-30"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         }
       ],
@@ -187,6 +253,12 @@
           "name": "1. vlna registrace",
           "price": 470,
           "category": "company",
+          "takes_effect_on": "2025-01-28"
+        },
+        "school": {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
           "takes_effect_on": "2025-01-28"
         }
       }
@@ -206,6 +278,12 @@
           "takes_effect_on": "2025-01-28"
         },
         {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
@@ -215,6 +293,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-30"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         }
       ],
@@ -230,6 +314,12 @@
           "name": "company",
           "price": 0,
           "category": "company",
+          "takes_effect_on": ""
+        },
+        "school": {
+          "name": "school",
+          "price": 0,
+          "category": "school",
           "takes_effect_on": ""
         }
       }
@@ -249,6 +339,12 @@
           "takes_effect_on": "2025-01-28"
         },
         {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
@@ -258,6 +354,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-30"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         },
         {
@@ -270,6 +372,12 @@
           "name": "3. vlna registrace",
           "price": 500,
           "category": "basic",
+          "takes_effect_on": "2025-02-05"
+        },
+        {
+          "name": "3. vlna registrace",
+          "price": 250,
+          "category": "school",
           "takes_effect_on": "2025-02-05"
         }
       ],
@@ -285,6 +393,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
+          "takes_effect_on": "2025-01-30"
+        },
+        "school": {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         }
       }
@@ -304,6 +418,12 @@
           "takes_effect_on": "2025-01-28"
         },
         {
+          "name": "1. vlna registrace",
+          "price": 234,
+          "category": "school",
+          "takes_effect_on": "2025-01-28"
+        },
+        {
           "name": "2. vlna registrace",
           "price": 470,
           "category": "company",
@@ -313,6 +433,12 @@
           "name": "2. vlna registrace",
           "price": 470,
           "category": "basic",
+          "takes_effect_on": "2025-01-30"
+        },
+        {
+          "name": "2. vlna registrace",
+          "price": 240,
+          "category": "school",
           "takes_effect_on": "2025-01-30"
         },
         {
@@ -325,6 +451,12 @@
           "name": "3. vlna registrace",
           "price": 500,
           "category": "basic",
+          "takes_effect_on": "2025-02-05"
+        },
+        {
+          "name": "3. vlna registrace",
+          "price": 250,
+          "category": "school",
           "takes_effect_on": "2025-02-05"
         }
       ],
@@ -340,6 +472,12 @@
           "name": "3. vlna registrace",
           "price": 500,
           "category": "company",
+          "takes_effect_on": "2025-02-05"
+        },
+        "school": {
+          "name": "3. vlna registrace",
+          "price": 250,
+          "category": "school",
           "takes_effect_on": "2025-02-05"
         }
       }
@@ -377,6 +515,12 @@
           "name": "company",
           "price": 0,
           "category": "company",
+          "takes_effect_on": ""
+        },
+        "school": {
+          "name": "school",
+          "price": 0,
+          "category": "school",
           "takes_effect_on": ""
         }
       }


### PR DESCRIPTION
Add logic for loading `school` pricing from campaign API and send it as the `payment_amount` field in `registerChallenge` store.

* Add `PriceLevelCategory` `school`.
* Update `price_levels.ts` util to process new category.
* Add logic to send new price based on paymentSubject in `registerChallenge`.
* Add E2E test and update test data in `getCurrentPriceLevelsUtilTestData` fixture (used in `unit_utils_tests.cy.js`).