### PR TITLE
src/stores:  add new feed store  with caching data ability 

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true,
+      // https: true
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true
+      https: true,
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
+      // https: true,
       open: true, // opens browser window automatically
     },
 

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -132,6 +132,7 @@ urlApiThisCampaign = "this_campaign/"
 
 checkIsEmailVerifiedInterval = 20 # seconds
 checkIsThisCampaignCompetitionPhaseTypeInterval = 20 # seconds
+feedRefreshCachedPostsIntervalHours = 24
 
 # DATE TIME FORMATS
 

--- a/src/components/__tests__/FormFieldSelectCity.cy.js
+++ b/src/components/__tests__/FormFieldSelectCity.cy.js
@@ -1,7 +1,6 @@
 import { ref } from 'vue';
 import FormFieldSelectCity from '../form/FormFieldSelectCity.vue';
 import { i18n } from '../../boot/i18n';
-import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { vModelAdapter } from '../../../test/cypress/utils';
 
 // variables
@@ -14,12 +13,20 @@ describe('<FormFieldSelectCity>', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       model.value = null;
-      cy.mount(FormFieldSelectCity, {
-        props: {
-          ...vModelAdapter(model),
-        },
+      cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
+        cy.fixture('apiGetCitiesResponseNext').then((citiesResponseNext) => {
+          cy.mount(FormFieldSelectCity, {
+            props: {
+              ...vModelAdapter(model),
+              cities: [
+                ...citiesResponse.results,
+                ...citiesResponseNext.results,
+              ],
+              loading: false,
+            },
+          });
+        });
       });
       cy.viewport('macbook-16');
     });
@@ -29,12 +36,20 @@ describe('<FormFieldSelectCity>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
-      cy.interceptCitiesGetApi(rideToWorkByBikeConfig, i18n);
       model.value = null;
-      cy.mount(FormFieldSelectCity, {
-        props: {
-          ...vModelAdapter(model),
-        },
+      cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
+        cy.fixture('apiGetCitiesResponseNext').then((citiesResponseNext) => {
+          cy.mount(FormFieldSelectCity, {
+            props: {
+              ...vModelAdapter(model),
+              cities: [
+                ...citiesResponse.results,
+                ...citiesResponseNext.results,
+              ],
+              loading: false,
+            },
+          });
+        });
       });
       cy.viewport('iphone-6');
     });
@@ -45,14 +60,13 @@ describe('<FormFieldSelectCity>', () => {
 
 function coreTests() {
   it('renders component', () => {
-    cy.waitForCitiesApi();
     cy.dataCy('form-field-select-city').should('be.visible');
     cy.dataCy('form-select-label')
       .should('be.visible')
       .and('contain', i18n.global.t('form.labelCity'));
     // click select
     cy.dataCy('form-select-city').click();
-
+    // check if all cities are visible
     cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
       cy.fixture('apiGetCitiesResponseNext').then((citiesResponseNext) => {
         cy.get('.q-menu .q-item__label')
@@ -67,7 +81,6 @@ function coreTests() {
 
   it('allows to select city and updates modelValue', () => {
     cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
-      cy.waitForCitiesApi();
       cy.dataCy('form-select-city').click();
       cy.get('.q-menu')
         .should('be.visible')
@@ -82,7 +95,6 @@ function coreTests() {
 
   it('works correctly with non-unique wp_slug', () => {
     cy.fixture('apiGetCitiesResponse').then((citiesResponse) => {
-      cy.waitForCitiesApi();
       // choose city with different slug and wp_slug
       cy.dataCy('form-select-city').click();
       cy.get('.q-menu')

--- a/src/components/form/FormFieldSelectCity.vue
+++ b/src/components/form/FormFieldSelectCity.vue
@@ -19,13 +19,10 @@
  */
 
 // libraries
-import { computed, defineComponent, inject, onMounted, ref, watch } from 'vue';
-
-import { useApiGetCities } from '../../composables/useApiGetCities';
+import { computed, defineComponent, ref, watch } from 'vue';
 
 // types
 import type { FormOption } from '../../components/types/Form';
-import type { Logger } from '../../components/types/Logger';
 
 export default defineComponent({
   name: 'FormFieldSelectCity',
@@ -36,23 +33,25 @@ export default defineComponent({
       required: false,
       default: null,
     },
+    cities: {
+      type: Array as () => City[],
+      required: true,
+    },
+    loading: {
+      type: Boolean,
+      required: true,
+    },
   },
   setup(props, { emit }) {
-    const logger = inject('vuejs3-logger') as Logger | null;
     const city = ref<FormOption | null>(null);
 
-    const { isLoading, cities, loadCities } = useApiGetCities(logger);
     const options = computed<FormOption[]>(() =>
-      cities.value.map((city) => ({
+      props.cities.map((city) => ({
         label: city.name,
         value: city.slug,
         slug: city.wp_slug,
       })),
     );
-
-    onMounted(async () => {
-      await loadCities();
-    });
 
     // update city when modelValue prop is available
     watch(
@@ -71,7 +70,6 @@ export default defineComponent({
 
     return {
       city,
-      isLoading,
       options,
     };
   },
@@ -91,7 +89,7 @@ export default defineComponent({
       dense
       outlined
       v-model="city"
-      :loading="isLoading"
+      :loading="loading"
       :options="options"
       :style="{ 'min-width': '160px' }"
       class="col-auto"

--- a/src/components/form/FormFieldSelectCity.vue
+++ b/src/components/form/FormFieldSelectCity.vue
@@ -8,12 +8,14 @@
  * @props
  * - `modelValue` (string|null) - Selected city slug.
  *   It should be of type `string`.
+ * - `cities` (City[]) - Array of cities from which options are generated.
+ * - `loading` (boolean) - Whether the cities are loading.
  *
  * @events
  * - `update:modelValue`: Emitted as a part of v-model structure.
  *
  * @example
- * <form-field-select-city v-model="city" />
+ * <form-field-select-city v-model="city" :cities="cities" :loading="loading" />
  *
  * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104327&t=XckLLHWI3q8VrRFl-1)
  */

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -51,6 +51,7 @@ export interface ConfigGlobal {
   rtwbbDonationOrderedProductName: string;
   checkRegisterChallengeStatusIntervalSeconds: number;
   checkRegisterChallengeStatusMaxRepetitions: number;
+  feedRefreshCachedPostsIntervalHours: number;
   iDontWantMerchandiseItemCode: string;
   notifyMessagePosition: string;
   mobileBottomPanelVisibleItems: number;

--- a/src/pages/CommunityPage.vue
+++ b/src/pages/CommunityPage.vue
@@ -15,7 +15,7 @@
  *
  * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104327&t=ZZSrUuLgRLYixhUu-1)
  */
-import { defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref, onMounted } from 'vue';
 
 // components
 import CardEvent from '../components/homepage/CardEvent.vue';
@@ -39,6 +39,9 @@ import listCardsFollow from '../../test/cypress/fixtures/listCardsFollow.json';
 import listCardsLocation from '../../test/cypress/fixtures/listCardsLocation.json';
 import listCardsPost from '../../test/cypress/fixtures/listCardsPost.json';
 
+// stores
+import { useFeedStore } from '../stores/feed';
+import { useRegisterChallengeStore } from '../stores/registerChallenge';
 // types
 import type {
   CardPost,
@@ -59,6 +62,12 @@ export default defineComponent({
     SectionHeading,
   },
   setup() {
+    const feedStore = useFeedStore();
+    const registerChallengeStore = useRegisterChallengeStore();
+    const isLoadingCities = computed<boolean>(
+      () => feedStore.getIsLoadingCities,
+    );
+    const cities = computed<City[]>(() => feedStore.getCities);
     const city = ref<number | null>(null);
 
     const cardsFollow = listCardsFollow as CardFollow[];
@@ -70,11 +79,26 @@ export default defineComponent({
     };
     const cardsLocation = listCardsLocation as CardLocationType[];
 
+    onMounted(async () => {
+      // if citySlug is not available, try reloading register challenge data
+      if (!registerChallengeStore.getCityWpSlug) {
+        await registerChallengeStore.loadRegisterChallengeToStore();
+        // set default value for city select
+        city.value = registerChallengeStore.getCityWpSlug;
+      }
+      if (!cities.value.length) {
+        // load cities
+        await feedStore.loadCities();
+      }
+    });
+
     return {
       buttonPosts,
       cardsFollow,
       cardsPost,
       cardsLocation,
+      isLoadingCities,
+      cities,
       city,
       events,
     };
@@ -96,6 +120,8 @@ export default defineComponent({
           <!-- Select: City -->
           <form-field-select-city
             v-model="city"
+            :cities="cities"
+            :loading="isLoadingCities"
             data-cy="form-field-select-city"
           />
         </template>

--- a/src/pages/CommunityPage.vue
+++ b/src/pages/CommunityPage.vue
@@ -84,6 +84,8 @@ export default defineComponent({
       if (!registerChallengeStore.getCityWpSlug) {
         await registerChallengeStore.loadRegisterChallengeToStore();
         // set default value for city select
+      }
+      if (registerChallengeStore.getCityWpSlug) {
         city.value = registerChallengeStore.getCityWpSlug;
       }
       if (!cities.value.length) {

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -14,7 +14,7 @@
  *
  * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104166&t=pZezzt4Cd9YZ0UzV-1)
  */
-import { computed, defineComponent, inject, onMounted, ref, watch } from 'vue';
+import { computed, defineComponent, onMounted, ref, watch } from 'vue';
 
 // adapters
 import { feedAdapter } from '../adapters/feedAdapter';
@@ -29,9 +29,6 @@ import ListPartners from '../components/global/ListPartners.vue';
 import PageHeading from 'components/global/PageHeading.vue';
 import SectionColumns from '../components/homepage/SectionColumns.vue';
 import SectionHeading from '../components/global/SectionHeading.vue';
-
-// composables
-import { useApiGetCities } from '../composables/useApiGetCities';
 
 // stores
 import { useRegisterChallengeStore } from '../stores/registerChallenge';
@@ -51,15 +48,13 @@ export default defineComponent({
     SectionHeading,
   },
   setup() {
-    const logger = inject('vuejs3-logger') as Logger | null;
     const registerChallengeStore = useRegisterChallengeStore();
     const feedStore = useFeedStore();
-    const isLoading = computed(() => feedStore.getIsLoading);
-    const {
-      isLoading: isLoadingCities,
-      cities,
-      loadCities,
-    } = useApiGetCities(logger);
+    const isLoading = computed<boolean>(() => feedStore.getIsLoading);
+    const isLoadingCities = computed<boolean>(
+      () => feedStore.getIsLoadingCities,
+    );
+    const cities = computed<City[]>(() => feedStore.getCities);
 
     const enabledSelectCity = true;
     const enabledPartners = false;
@@ -80,7 +75,10 @@ export default defineComponent({
       if (!registerChallengeStore.getCityWpSlug) {
         await registerChallengeStore.loadRegisterChallengeToStore();
       }
-      await loadCities();
+      if (!cities.value.length) {
+        // load cities
+        await feedStore.loadCities();
+      }
       // if citySlug is available, load posts, else we can't load posts
       if (registerChallengeStore.getCityWpSlug) {
         // check if feed needs refresh

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -14,7 +14,7 @@
  *
  * @see [Figma Design](https://www.figma.com/design/L8dVREySVXxh3X12TcFDdR/Do-pr%C3%A1ce-na-kole?node-id=4858-104166&t=pZezzt4Cd9YZ0UzV-1)
  */
-import { computed, defineComponent, onMounted, ref, watch } from 'vue';
+import { computed, defineComponent, inject, onMounted, ref, watch } from 'vue';
 
 // adapters
 import { feedAdapter } from '../adapters/feedAdapter';
@@ -29,6 +29,9 @@ import ListPartners from '../components/global/ListPartners.vue';
 import PageHeading from 'components/global/PageHeading.vue';
 import SectionColumns from '../components/homepage/SectionColumns.vue';
 import SectionHeading from '../components/global/SectionHeading.vue';
+
+// composables
+import { useApiGetCities } from '../composables/useApiGetCities';
 
 // stores
 import { useRegisterChallengeStore } from '../stores/registerChallenge';
@@ -48,9 +51,15 @@ export default defineComponent({
     SectionHeading,
   },
   setup() {
+    const logger = inject('vuejs3-logger') as Logger | null;
     const registerChallengeStore = useRegisterChallengeStore();
     const feedStore = useFeedStore();
     const isLoading = computed(() => feedStore.getIsLoading);
+    const {
+      isLoading: isLoadingCities,
+      cities,
+      loadCities,
+    } = useApiGetCities(logger);
 
     const enabledSelectCity = true;
     const enabledPartners = false;
@@ -71,6 +80,7 @@ export default defineComponent({
       if (!registerChallengeStore.getCityWpSlug) {
         await registerChallengeStore.loadRegisterChallengeToStore();
       }
+      await loadCities();
       // if citySlug is available, load posts, else we can't load posts
       if (registerChallengeStore.getCityWpSlug) {
         // check if feed needs refresh
@@ -91,9 +101,11 @@ export default defineComponent({
 
     return {
       city,
+      cities,
       cardsOffer,
       cardsEvent,
       isLoading,
+      isLoadingCities,
       prizesCards,
       enabledSelectCity,
       enabledPartners,
@@ -112,7 +124,9 @@ export default defineComponent({
           <!-- Select: City -->
           <form-field-select-city
             v-if="enabledSelectCity"
+            :cities="cities"
             v-model="city"
+            :loading="isLoadingCities"
             data-cy="form-field-select-city"
           />
         </template>

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -15,6 +15,7 @@ import type { Offer } from '../components/types/Offer';
 import type { City } from '../components/types/City';
 
 // utils
+import { timestampToDatetimeString } from '../utils';
 import {
   getOffersFeedParamSet,
   getPrizesFeedParamSet,
@@ -100,10 +101,15 @@ export const useFeedStore = defineStore('feed', {
       const timeNowMinusCacheRefreshInterval =
         dateMinusCacheRefreshInterval.getTime();
       this.$log?.debug(
-        `Last feed update <${new Date(lastUpdate).toLocaleString()}>, current datetime <${dateNow.toLocaleString()}>, current datetime minus cache refresh interval <${dateMinusCacheRefreshInterval.toLocaleString()}>`,
+        `Last feed update <${timestampToDatetimeString(lastUpdate / 1000)}>, ` +
+          ` current datetime <${timestampToDatetimeString(dateNow.getTime() / 1000)}>,` +
+          ' current datetime minus cache refresh interval' +
+          ` <${timestampToDatetimeString(dateMinusCacheRefreshInterval.getTime() / 1000)}>.`,
       );
       this.$log?.debug(
-        `Last feed update is older than current datetime minus cache refresh interval <${lastUpdate < timeNowMinusCacheRefreshInterval}>`,
+        'Last feed update is older than current datetime' +
+          ' minus cache refresh interval' +
+          ` <${lastUpdate < timeNowMinusCacheRefreshInterval}>.`,
       );
       return lastUpdate < timeNowMinusCacheRefreshInterval;
     },

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -87,11 +87,18 @@ export const useFeedStore = defineStore('feed', {
      * @returns {boolean} - Whether feed needs refresh
      */
     needsRefresh(state: FeedState): boolean {
-      if (!state.lastUpdated) return true;
+      const lastUpdate = state.lastUpdated;
+      if (!lastUpdate) return true;
       const now = new Date();
-      const lastUpdate = new Date(state.lastUpdated);
-      const oneDayAgo = date.subtractFromDate(now, { days: 1 });
-      return date.isSameDate(lastUpdate, oneDayAgo) || lastUpdate < oneDayAgo;
+      const oneDayAgo = date.addToDate(now, { days: -1 });
+      const timeOneDayAgo = oneDayAgo.getTime();
+      this.$log?.debug(
+        `Last feed update <${lastUpdate}>, now <${now.getTime()}>, one day ago <${timeOneDayAgo}>`,
+      );
+      this.$log?.debug(
+        `Last feed update is older than one day ago <${lastUpdate < timeOneDayAgo}>`,
+      );
+      return lastUpdate < timeOneDayAgo;
     },
   },
 
@@ -145,18 +152,6 @@ export const useFeedStore = defineStore('feed', {
       this.isLoadingCities = loading;
     },
     /**
-     * Clear all store data
-     * @returns {void}
-     */
-    clearStore(): void {
-      this.postsOffer = [];
-      this.postsPrize = [];
-      this.lastUpdated = null;
-      this.isLoading = false;
-      this.cities = [];
-      this.isLoadingCities = false;
-    },
-    /**
      * Load posts from API for a given city slug
      * @param {string} citySlug - City slug to load posts for
      * @returns {Promise<void>}
@@ -173,7 +168,7 @@ export const useFeedStore = defineStore('feed', {
 
       this.setPostsOffer(offers);
       this.setPostsPrize(prizes);
-      this.setLastUpdated(Date.now());
+      this.setLastUpdated(new Date().getTime());
       this.setIsLoading(false);
     },
     /**
@@ -190,7 +185,7 @@ export const useFeedStore = defineStore('feed', {
     /**
      * Attempt to refresh feed data if needed
      * @param {string} citySlug - City slug to load posts for
-     * @returns {Promise<void>}
+<void>}
      */
     async attemptFeedRefresh(citySlug: string): Promise<void> {
       if (this.needsRefresh) {
@@ -200,7 +195,21 @@ export const useFeedStore = defineStore('feed', {
         this.$log?.debug('Feed is up to date, skipping refresh.');
       }
     },
+    /**
+     * Clear all store data
+     * @returns {void}
+     */
+    clearStore(): void {
+      this.postsOffer = [];
+      this.postsPrize = [];
+      this.lastUpdated = null;
+      this.isLoading = false;
+      this.cities = [];
+      this.isLoadingCities = false;
+    },
   },
 
-  persist: true,
+  persist: {
+    omit: ['isLoading', 'isLoadingCities', 'cities'],
+  },
 });

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -1,0 +1,206 @@
+// libraries
+import { defineStore } from 'pinia';
+import { date } from 'quasar';
+
+// composables
+import { useApiGetPosts } from '../composables/useApiGetPosts';
+import { useApiGetCities } from '../composables/useApiGetCities';
+
+// types
+import type { Logger } from '../components/types/Logger';
+import type { Offer } from '../components/types/Offer';
+import type { City } from '../components/types/City';
+
+// utils
+import {
+  getOffersFeedParamSet,
+  getPrizesFeedParamSet,
+} from '../utils/get_feed_param_set';
+
+interface FeedState {
+  $log: Logger | null;
+  postsOffer: Offer[];
+  postsPrize: Offer[];
+  isLoading: boolean;
+  lastUpdated: number | null;
+  cities: City[];
+  isLoadingCities: boolean;
+}
+
+export const useFeedStore = defineStore('feed', {
+  state: (): FeedState => ({
+    // property set in pinia.js boot file
+    $log: null as Logger | null,
+    postsOffer: [],
+    postsPrize: [],
+    isLoading: false,
+    lastUpdated: null,
+    cities: [],
+    isLoadingCities: false,
+  }),
+
+  getters: {
+    /**
+     * Get all offer posts
+     * @returns {Offer[]} - Array of offer posts
+     */
+    getPostsOffer(state: FeedState): Offer[] {
+      return state.postsOffer;
+    },
+    /**
+     * Get all prize posts
+     * @returns {Offer[]} - Array of prize posts
+     */
+    getPostsPrize(state: FeedState): Offer[] {
+      return state.postsPrize;
+    },
+    /**
+     * Get loading state
+     * @returns {boolean} - Whether data is being loaded
+     */
+    getIsLoading(state: FeedState): boolean {
+      return state.isLoading;
+    },
+    /**
+     * Get timestamp of last update
+     * @returns {number | null} - Timestamp of last update or null if never updated
+     */
+    getLastUpdated(state: FeedState): number | null {
+      return state.lastUpdated;
+    },
+    /**
+     * Get all cities
+     * @returns {City[]} - Array of cities
+     */
+    getCities(state: FeedState): City[] {
+      return state.cities;
+    },
+    /**
+     * Get cities loading state
+     * @returns {boolean} - Whether cities are being loaded
+     */
+    getIsLoadingCities(state: FeedState): boolean {
+      return state.isLoadingCities;
+    },
+    /**
+     * Check if feed needs refresh (older than 24h)
+     * @returns {boolean} - Whether feed needs refresh
+     */
+    needsRefresh(state: FeedState): boolean {
+      if (!state.lastUpdated) return true;
+      const now = new Date();
+      const lastUpdate = new Date(state.lastUpdated);
+      const oneDayAgo = date.subtractFromDate(now, { days: 1 });
+      return date.isSameDate(lastUpdate, oneDayAgo) || lastUpdate < oneDayAgo;
+    },
+  },
+
+  actions: {
+    /**
+     * Set loading state
+     * @param {boolean} loading - New loading state
+     * @returns {void}
+     */
+    setIsLoading(loading: boolean): void {
+      this.isLoading = loading;
+    },
+    /**
+     * Set offer posts
+     * @param {Offer[]} posts - Array of offer posts to set
+     * @returns {void}
+     */
+    setPostsOffer(posts: Offer[]): void {
+      this.postsOffer = posts;
+    },
+    /**
+     * Set prize posts
+     * @param {Offer[]} posts - Array of prize posts to set
+     * @returns {void}
+     */
+    setPostsPrize(posts: Offer[]): void {
+      this.postsPrize = posts;
+    },
+    /**
+     * Set last updated timestamp
+     * @param {number} timestamp - Timestamp to set
+     * @returns {void}
+     */
+    setLastUpdated(timestamp: number): void {
+      this.lastUpdated = timestamp;
+    },
+    /**
+     * Set cities
+     * @param {City[]} cities - Array of cities to set
+     * @returns {void}
+     */
+    setCities(cities: City[]): void {
+      this.cities = cities;
+    },
+    /**
+     * Set cities loading state
+     * @param {boolean} loading - New loading state
+     * @returns {void}
+     */
+    setIsLoadingCities(loading: boolean): void {
+      this.isLoadingCities = loading;
+    },
+    /**
+     * Clear all store data
+     * @returns {void}
+     */
+    clearStore(): void {
+      this.postsOffer = [];
+      this.postsPrize = [];
+      this.lastUpdated = null;
+      this.isLoading = false;
+      this.cities = [];
+      this.isLoadingCities = false;
+    },
+    /**
+     * Load posts from API for a given city slug
+     * @param {string} citySlug - City slug to load posts for
+     * @returns {Promise<void>}
+     */
+    async loadPosts(citySlug: string): Promise<void> {
+      const { loadPosts } = useApiGetPosts(this.$log);
+      this.setIsLoading(true);
+
+      // load offers and prizes in parallel
+      const [offers, prizes] = await Promise.all([
+        loadPosts(getOffersFeedParamSet(citySlug)),
+        loadPosts(getPrizesFeedParamSet(citySlug)),
+      ]);
+
+      this.setPostsOffer(offers);
+      this.setPostsPrize(prizes);
+      this.setLastUpdated(Date.now());
+      this.setIsLoading(false);
+    },
+    /**
+     * Load cities from API
+     * @returns {Promise<void>}
+     */
+    async loadCities(): Promise<void> {
+      const { cities, loadCities } = useApiGetCities(this.$log);
+      this.setIsLoadingCities(true);
+      await loadCities();
+      this.setCities(cities.value);
+      this.setIsLoadingCities(false);
+    },
+    /**
+     * Attempt to refresh feed data if needed
+     * @param {string} citySlug - City slug to load posts for
+     * @returns {Promise<void>}
+     */
+    async attemptFeedRefresh(citySlug: string): Promise<void> {
+      if (this.needsRefresh) {
+        this.$log?.debug('Feed needs refresh, loading new data.');
+        await this.loadPosts(citySlug);
+      } else {
+        this.$log?.debug('Feed is up to date, skipping refresh.');
+      }
+    },
+  },
+
+  persist: true,
+});

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -185,7 +185,7 @@ export const useFeedStore = defineStore('feed', {
     /**
      * Attempt to refresh feed data if needed
      * @param {string} citySlug - City slug to load posts for
-<void>}
+     * @returns {Promise<void>}
      */
     async attemptFeedRefresh(citySlug: string): Promise<void> {
       if (this.needsRefresh) {

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -189,10 +189,10 @@ export const useFeedStore = defineStore('feed', {
      */
     async attemptFeedRefresh(citySlug: string): Promise<void> {
       if (this.needsRefresh) {
-        this.$log?.debug('Feed needs refresh, loading new data.');
+        this.$log?.info('Feed needs refresh, loading new data.');
         await this.loadPosts(citySlug);
       } else {
-        this.$log?.debug('Feed is up to date, skipping refresh.');
+        this.$log?.info('Feed is up to date, skipping refresh.');
       }
     },
     /**

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -6,6 +6,9 @@ import { date } from 'quasar';
 import { useApiGetPosts } from '../composables/useApiGetPosts';
 import { useApiGetCities } from '../composables/useApiGetCities';
 
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
 // types
 import type { Logger } from '../components/types/Logger';
 import type { Offer } from '../components/types/Offer';
@@ -89,16 +92,20 @@ export const useFeedStore = defineStore('feed', {
     needsRefresh(state: FeedState): boolean {
       const lastUpdate = state.lastUpdated;
       if (!lastUpdate) return true;
-      const now = new Date();
-      const oneDayAgo = date.subtractFromDate(now, { days: 1 });
-      const timeOneDayAgo = oneDayAgo.getTime();
+      const dateNow = new Date();
+      const { feedRefreshCachedPostsIntervalHours } = rideToWorkByBikeConfig;
+      const dateMinusCacheRefreshInterval = date.subtractFromDate(dateNow, {
+        hours: feedRefreshCachedPostsIntervalHours,
+      });
+      const timeNowMinusCacheRefreshInterval =
+        dateMinusCacheRefreshInterval.getTime();
       this.$log?.debug(
-        `Last feed update <${lastUpdate}>, now <${now.getTime()}>, one day ago <${timeOneDayAgo}>`,
+        `Last feed update <${new Date(lastUpdate).toLocaleString()}>, current datetime <${dateNow.toLocaleString()}>, current datetime minus cache refresh interval <${dateMinusCacheRefreshInterval.toLocaleString()}>`,
       );
       this.$log?.debug(
-        `Last feed update is older than one day ago <${lastUpdate < timeOneDayAgo}>`,
+        `Last feed update is older than current datetime minus cache refresh interval <${lastUpdate < timeNowMinusCacheRefreshInterval}>`,
       );
-      return lastUpdate < timeOneDayAgo;
+      return lastUpdate < timeNowMinusCacheRefreshInterval;
     },
   },
 

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -90,7 +90,7 @@ export const useFeedStore = defineStore('feed', {
       const lastUpdate = state.lastUpdated;
       if (!lastUpdate) return true;
       const now = new Date();
-      const oneDayAgo = date.addToDate(now, { days: -1 });
+      const oneDayAgo = date.subtractFromDate(now, { days: 1 });
       const timeOneDayAgo = oneDayAgo.getTime();
       this.$log?.debug(
         `Last feed update <${lastUpdate}>, now <${now.getTime()}>, one day ago <${timeOneDayAgo}>`,

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -353,7 +353,7 @@ export const useLoginStore = defineStore('login', {
       // clear registerChallenge store
       const registerChallengeStore = useRegisterChallengeStore();
       registerChallengeStore.resetPersistentProperties();
-      // clear feed store
+      // clear feed store on logout
       const feedStore = useFeedStore();
       feedStore.clearStore();
       // redirect to login page

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -18,6 +18,7 @@ import { routesConf } from '../router/routes_conf';
 // stores
 import { useRegisterStore } from './register';
 import { useChallengeStore } from './challenge';
+import { useFeedStore } from './feed';
 import { useRegisterChallengeStore } from './registerChallenge';
 
 // types
@@ -352,6 +353,9 @@ export const useLoginStore = defineStore('login', {
       // clear registerChallenge store
       const registerChallengeStore = useRegisterChallengeStore();
       registerChallengeStore.resetPersistentProperties();
+      // clear feed store
+      const feedStore = useFeedStore();
+      feedStore.clearStore();
       // redirect to login page
       if (this.$router) {
         this.$log?.debug(


### PR DESCRIPTION
Add new store `feed.ts` and cache data fetched from WordPress endpoint.

* Refactor loading offers, prizes and cities into `feed.ts` store.
* Add persistency and caching mechanism - loading feed once in 24 hours.
* Use the store actions to fetch data on `IndexPage` and `PrizesPage`.
* Update `FormFieldSelectCity.vue` to accept `cities` prop from wrapping page - this allows to first fetch cities and then set the initial select value, all within the page `onMounted` hook.
* Update loading cities on `CommunityPage`.