### PR TITLE
config: add app config global vars for max loaded posts param in feed API query URL

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -133,6 +133,8 @@ urlApiThisCampaign = "this_campaign/"
 checkIsEmailVerifiedInterval = 20 # seconds
 checkIsThisCampaignCompetitionPhaseTypeInterval = 20 # seconds
 feedRefreshCachedPostsIntervalHours = 24
+apiFeedMaxOffersNumber = 50
+apiFeedMaxPrizesNumber = 50
 
 # DATE TIME FORMATS
 

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -52,6 +52,8 @@ export interface ConfigGlobal {
   checkRegisterChallengeStatusIntervalSeconds: number;
   checkRegisterChallengeStatusMaxRepetitions: number;
   feedRefreshCachedPostsIntervalHours: number;
+  apiFeedMaxOffersNumber: number;
+  apiFeedMaxPrizesNumber: number;
   iDontWantMerchandiseItemCode: string;
   notifyMessagePosition: string;
   mobileBottomPanelVisibleItems: number;

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -259,7 +259,7 @@ export default defineComponent({
         posts.value = await loadPosts(
           getOffersFeedParamSet(
             registerChallengeStore.getCityWpSlug,
-            rideToWorkByBikeConfig,
+            rideToWorkByBikeConfig.apiFeedMaxOffersNumber,
           ),
         );
       }

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -256,8 +256,11 @@ export default defineComponent({
       }
       // if citySlug is available, load posts, else we can't load posts
       if (registerChallengeStore.getCityWpSlug) {
-        await feedStore.attemptFeedRefresh(
-          registerChallengeStore.getCityWpSlug,
+        posts.value = await loadPosts(
+          getOffersFeedParamSet(
+            registerChallengeStore.getCityWpSlug,
+            rideToWorkByBikeConfig,
+          ),
         );
       }
     });

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -30,6 +30,9 @@ import PageHeading from 'components/global/PageHeading.vue';
 import SectionColumns from '../components/homepage/SectionColumns.vue';
 import SectionHeading from '../components/global/SectionHeading.vue';
 
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
 // stores
 import { useRegisterChallengeStore } from '../stores/registerChallenge';
 import { useFeedStore } from '../stores/feed';
@@ -81,18 +84,36 @@ export default defineComponent({
       }
       // if citySlug is available, load posts, else we can't load posts
       if (registerChallengeStore.getCityWpSlug) {
-        // check if feed needs refresh
-        await feedStore.attemptFeedRefresh(
-          registerChallengeStore.getCityWpSlug,
-        );
+        // load offers and prizes in parallel
+        const [offers, prizes] = await Promise.all([
+          loadPosts(
+            getOffersFeedParamSet(
+              registerChallengeStore.getCityWpSlug,
+              rideToWorkByBikeConfig,
+            ),
+          ),
+          loadPosts(
+            getPrizesFeedParamSet(
+              registerChallengeStore.getCityWpSlug,
+              rideToWorkByBikeConfig,
+            ),
+          ),
+        ]);
+        postsOffers.value = offers;
+        postsPrizes.value = prizes;
         // set default value for city select
         city.value = registerChallengeStore.getCityWpSlug;
       }
       // initiate watcher after the citySlug is loaded
       watch(city, async (newSlug: string | null) => {
         if (newSlug) {
-          // force load new posts for the new city
-          await feedStore.loadPosts(newSlug);
+          // load offers and prizes in parallel
+          const [offers, prizes] = await Promise.all([
+            loadPosts(getOffersFeedParamSet(newSlug, rideToWorkByBikeConfig)),
+            loadPosts(getPrizesFeedParamSet(newSlug, rideToWorkByBikeConfig)),
+          ]);
+          postsOffers.value = offers;
+          postsPrizes.value = prizes;
         }
       });
     });

--- a/src/pages/PrizesPage.vue
+++ b/src/pages/PrizesPage.vue
@@ -89,13 +89,13 @@ export default defineComponent({
           loadPosts(
             getOffersFeedParamSet(
               registerChallengeStore.getCityWpSlug,
-              rideToWorkByBikeConfig,
+              rideToWorkByBikeConfig.apiFeedMaxOffersNumber,
             ),
           ),
           loadPosts(
             getPrizesFeedParamSet(
               registerChallengeStore.getCityWpSlug,
-              rideToWorkByBikeConfig,
+              rideToWorkByBikeConfig.apiFeedMaxPrizesNumber,
             ),
           ),
         ]);
@@ -109,8 +109,18 @@ export default defineComponent({
         if (newSlug) {
           // load offers and prizes in parallel
           const [offers, prizes] = await Promise.all([
-            loadPosts(getOffersFeedParamSet(newSlug, rideToWorkByBikeConfig)),
-            loadPosts(getPrizesFeedParamSet(newSlug, rideToWorkByBikeConfig)),
+            loadPosts(
+              getOffersFeedParamSet(
+                newSlug,
+                rideToWorkByBikeConfig.apiFeedMaxOffersNumber,
+              ),
+            ),
+            loadPosts(
+              getPrizesFeedParamSet(
+                newSlug,
+                rideToWorkByBikeConfig.apiFeedMaxPrizesNumber,
+              ),
+            ),
           ]);
           postsOffers.value = offers;
           postsPrizes.value = prizes;

--- a/src/utils/get_feed_param_set.ts
+++ b/src/utils/get_feed_param_set.ts
@@ -8,6 +8,7 @@ import {
 } from '../components/enums/Offers';
 
 // types
+import type { ConfigGlobal } from 'src/components/types';
 import type { GetOffersParams } from '../components/types/Offer';
 
 /**
@@ -17,6 +18,7 @@ import type { GetOffersParams } from '../components/types/Offer';
  */
 export const getOffersFeedParamSet = (
   citySlug: string,
+  config: ConfigGlobal,
 ): Partial<GetOffersParams> => {
   const currentYear = new Date().getFullYear();
 
@@ -27,7 +29,7 @@ export const getOffersFeedParamSet = (
     _post_type: ApiOfferParamPostType.locations,
     _page_subtype: ApiOfferParamPageSubtype.event,
     _post_parent: citySlug,
-    _number: '1000',
+    _number: config.apiFeedMaxOffersNumber.toString(),
     _year: currentYear.toString(),
   };
 };
@@ -39,6 +41,7 @@ export const getOffersFeedParamSet = (
  */
 export const getPrizesFeedParamSet = (
   citySlug: string,
+  config: ConfigGlobal,
 ): Partial<GetOffersParams> => {
   const currentYear = new Date().getFullYear();
 
@@ -49,7 +52,7 @@ export const getPrizesFeedParamSet = (
     _post_type: ApiOfferParamPostType.locations,
     _page_subtype: ApiOfferParamPageSubtype.prize,
     _post_parent: citySlug,
-    _number: '1000',
+    _number: config.apiFeedMaxPrizesNumber.toString(),
     _year: currentYear.toString(),
   };
 };

--- a/src/utils/get_feed_param_set.ts
+++ b/src/utils/get_feed_param_set.ts
@@ -8,7 +8,6 @@ import {
 } from '../components/enums/Offers';
 
 // types
-import type { ConfigGlobal } from 'src/components/types';
 import type { GetOffersParams } from '../components/types/Offer';
 
 /**
@@ -18,7 +17,7 @@ import type { GetOffersParams } from '../components/types/Offer';
  */
 export const getOffersFeedParamSet = (
   citySlug: string,
-  config: ConfigGlobal,
+  numberOfPosts: number,
 ): Partial<GetOffersParams> => {
   const currentYear = new Date().getFullYear();
 
@@ -29,7 +28,7 @@ export const getOffersFeedParamSet = (
     _post_type: ApiOfferParamPostType.locations,
     _page_subtype: ApiOfferParamPageSubtype.event,
     _post_parent: citySlug,
-    _number: config.apiFeedMaxOffersNumber.toString(),
+    _number: numberOfPosts.toString(),
     _year: currentYear.toString(),
   };
 };
@@ -41,7 +40,7 @@ export const getOffersFeedParamSet = (
  */
 export const getPrizesFeedParamSet = (
   citySlug: string,
-  config: ConfigGlobal,
+  numberOfPosts: number,
 ): Partial<GetOffersParams> => {
   const currentYear = new Date().getFullYear();
 
@@ -52,7 +51,7 @@ export const getPrizesFeedParamSet = (
     _post_type: ApiOfferParamPostType.locations,
     _page_subtype: ApiOfferParamPageSubtype.prize,
     _post_parent: citySlug,
-    _number: config.apiFeedMaxPrizesNumber.toString(),
+    _number: numberOfPosts.toString(),
     _year: currentYear.toString(),
   };
 };

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -547,7 +547,7 @@ Cypress.Commands.add(
       apiDefaultLang,
       i18n,
     );
-    const getOffersParams = getOffersFeedParamSet(citySlug);
+    const getOffersParams = getOffersFeedParamSet(citySlug, config);
     const objectToParams = (obj) => {
       return Object.keys(obj)
         .map((key) => `${key}=${obj[key]}`)
@@ -596,7 +596,7 @@ Cypress.Commands.add(
       apiDefaultLang,
       i18n,
     );
-    const getPrizesParams = getPrizesFeedParamSet(citySlug);
+    const getPrizesParams = getPrizesFeedParamSet(citySlug, config);
     const objectToParams = (obj) => {
       return Object.keys(obj)
         .map((key) => `${key}=${obj[key]}`)

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -547,7 +547,10 @@ Cypress.Commands.add(
       apiDefaultLang,
       i18n,
     );
-    const getOffersParams = getOffersFeedParamSet(citySlug, config);
+    const getOffersParams = getOffersFeedParamSet(
+      citySlug,
+      config.apiFeedMaxOffersNumber,
+    );
     const objectToParams = (obj) => {
       return Object.keys(obj)
         .map((key) => `${key}=${obj[key]}`)
@@ -596,7 +599,10 @@ Cypress.Commands.add(
       apiDefaultLang,
       i18n,
     );
-    const getPrizesParams = getPrizesFeedParamSet(citySlug, config);
+    const getPrizesParams = getPrizesFeedParamSet(
+      citySlug,
+      config.apiFeedMaxPrizesNumber,
+    );
     const objectToParams = (obj) => {
       return Object.keys(obj)
         .map((key) => `${key}=${obj[key]}`)


### PR DESCRIPTION
Add config vars for max loaded posts param in feed API query.

* Replace fixed `_number` parameter in prizes and offers request param with dynamic value from global config.