### PR TITLE
src/pages: fix loading posts on IndexPage and PrizesPage + add reset to default city

### DIFF
--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -256,11 +256,9 @@ export default defineComponent({
       }
       // if citySlug is available, load posts, else we can't load posts
       if (registerChallengeStore.getCityWpSlug) {
-        posts.value = await loadPosts(
-          getOffersFeedParamSet(
-            registerChallengeStore.getCityWpSlug,
-            rideToWorkByBikeConfig.apiFeedMaxOffersNumber,
-          ),
+        // refresh feed data if needed
+        await feedStore.attemptFeedRefresh(
+          registerChallengeStore.getCityWpSlug,
         );
       }
     });

--- a/src/stores/feed.ts
+++ b/src/stores/feed.ts
@@ -175,8 +175,18 @@ export const useFeedStore = defineStore('feed', {
 
       // load offers and prizes in parallel
       const [offers, prizes] = await Promise.all([
-        loadPosts(getOffersFeedParamSet(citySlug)),
-        loadPosts(getPrizesFeedParamSet(citySlug)),
+        loadPosts(
+          getOffersFeedParamSet(
+            citySlug,
+            rideToWorkByBikeConfig.apiFeedMaxOffersNumber,
+          ),
+        ),
+        loadPosts(
+          getPrizesFeedParamSet(
+            citySlug,
+            rideToWorkByBikeConfig.apiFeedMaxPrizesNumber,
+          ),
+        ),
       ]);
 
       this.setPostsOffer(offers);


### PR DESCRIPTION
Fix loading posts on `IndexPage` and `PrizesPage`

Additionally, address the following issue:
* Go to the page `/prizes`.
* Select another city than my default competition city.
* Go to `/home` or another page.
* Come back to `/prizes`.
* Component should display posts for the default competition city again (reset), but shows the saved posts for another city that was previously selected.

To prevent this, reset the `feed` store when leaving the `PrizesPage` with other than the default city selected.