### PR TITLE
src/composables: add ability to log routes from Calendar view with useApiPostTrips composable

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
+      // https: true
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true
+      https: true,
       open: true, // opens browser window automatically
     },
 

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -135,6 +135,7 @@ checkIsThisCampaignCompetitionPhaseTypeInterval = 20 # seconds
 feedRefreshCachedPostsIntervalHours = 24
 apiFeedMaxOffersNumber = 50
 apiFeedMaxPrizesNumber = 50
+apiTripsSourceApplicationId = 'RTWBB'
 
 # DATE TIME FORMATS
 

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -135,7 +135,7 @@ checkIsThisCampaignCompetitionPhaseTypeInterval = 20 # seconds
 feedRefreshCachedPostsIntervalHours = 24
 apiFeedMaxOffersNumber = 50
 apiFeedMaxPrizesNumber = 50
-apiTripsSourceApplicationId = 'RTWBB'
+apiTripsSourceApplicationId = 'RTWBB web app'
 
 # DATE TIME FORMATS
 

--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -1,11 +1,14 @@
 import { i18n } from '../boot/i18n';
 
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
 // enums
 import { TransportDirection } from '../components/types/Route';
 import { TripDirection } from '../components/types/Trip';
 
 // types
-import type { Trip } from '../components/types/Trip';
+import type { Trip, TripPostPayload } from '../components/types/Trip';
 import type {
   RouteItem,
   TransportType,
@@ -43,5 +46,28 @@ export const tripsAdapter = {
       // TODO: Handle the route feature data
       routeFeature: null as RouteFeature | null,
     };
+  },
+
+  /**
+   * Convert RouteItem to TripPostPayload format
+   * @param {RouteItem} routeItem - Route item to convert
+   * @returns {TripPostPayload} - Trip post payload
+   */
+  toTripPostPayload(routeItem: RouteItem): TripPostPayload {
+    const direction =
+      routeItem.direction === TransportDirection.toWork
+        ? TripDirection.to
+        : TripDirection.from;
+
+    // create payload with required fields
+    const payload: TripPostPayload = {
+      trip_date: routeItem.date,
+      direction,
+      commuteMode: routeItem.transport,
+      distanceMeters: Number(routeItem.distance), // TODO: Convert distance string to meters
+      sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
+    };
+
+    return payload;
   },
 };

--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -63,16 +63,11 @@ export const tripsAdapter = {
         : TripDirection.from;
 
     /**
-     * Distance can come either in the format with decimal point,
-     * or without a decimal point (due to the function of masked input).
-     * Example input distance: "12.50" or "1250"
-     * To handle both cases we remove the decimal point or comma from string,
-     * internally convert distance to km units (by dividing by 100),
-     * and then multiply by 1000 to get meters.
+     * `routeItem.distance` value is in km unit as localized number string
+     * (with ',' or '.' decimal point)
      */
     const distanceMeters =
-      (Number(routeItem.distance.replace('.', '').replace(',', '')) / 100) *
-      1000;
+      parseFloat(routeItem.distance.replace(',', '.')) * 1000;
 
     // create payload with required fields
     const payload: TripPostPayload = {

--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -59,12 +59,17 @@ export const tripsAdapter = {
         ? TripDirection.to
         : TripDirection.from;
 
+    // TODO: Cleanup the conversion of distance to meters
+    const distance =
+      (Number(routeItem.distance.replace('.', '').replace(',', '')) / 100) *
+      1000;
+
     // create payload with required fields
     const payload: TripPostPayload = {
       trip_date: routeItem.date,
       direction,
       commuteMode: routeItem.transport,
-      distanceMeters: Number(routeItem.distance), // TODO: Convert distance string to meters
+      distanceMeters: distance,
       sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
     };
 

--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -62,8 +62,15 @@ export const tripsAdapter = {
         ? TripDirection.to
         : TripDirection.from;
 
-    // TODO: Cleanup the conversion of distance to meters
-    const distance =
+    /**
+     * Distance can come either in the format with decimal point,
+     * or without a decimal point (due to the function of masked input).
+     * Example input distance: "12.50" or "1250"
+     * To handle both cases we remove the decimal point or comma from string,
+     * internally convert distance to km units (by dividing by 100),
+     * and then multiply by 1000 to get meters.
+     */
+    const distanceMeters =
       (Number(routeItem.distance.replace('.', '').replace(',', '')) / 100) *
       1000;
 
@@ -72,7 +79,9 @@ export const tripsAdapter = {
       trip_date: routeItem.date,
       direction,
       commuteMode: routeItem.transport,
-      distanceMeters: hasTransportDistance(routeItem.transport) ? distance : 0,
+      distanceMeters: hasTransportDistance(routeItem.transport)
+        ? distanceMeters
+        : 0,
       sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
     };
 

--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -15,6 +15,9 @@ import type {
   RouteFeature,
 } from '../components/types/Route';
 
+// utils
+import { hasTransportDistance } from '../utils/has_transport_distance';
+
 /**
  * Adapter for converting between API and component trip data formats
  */
@@ -69,7 +72,7 @@ export const tripsAdapter = {
       trip_date: routeItem.date,
       direction,
       commuteMode: routeItem.transport,
-      distanceMeters: distance,
+      distanceMeters: hasTransportDistance(routeItem.transport) ? distance : 0,
       sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
     };
 

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -5,7 +5,6 @@ import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import testData from '../../../test/cypress/fixtures/routeCalendarPanelInputTest.json';
-
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
 
@@ -151,10 +150,7 @@ describe('<RouteCalendarPanel>', () => {
       it(`${testKey}: ${testCase.description}`, () => {
         // intercept API call with response matching the payload
         const responseBody = {
-          count: testCase.apiPayload.length,
-          next: null,
-          previous: null,
-          results: testCase.apiPayload.trips.map((trip, index) => ({
+          trips: testCase.apiPayload.trips.map((trip, index) => ({
             id: index + 1,
             ...trip,
             durationSeconds: null,

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -146,6 +146,7 @@ describe('<RouteCalendarPanel>', () => {
       cy.viewport('macbook-16');
     });
 
+    // generate tests based on fixture routeCalendarPanelInputTest.json
     Object.entries(testData).forEach(([testKey, testCase]) => {
       it(`${testKey}: ${testCase.description}`, () => {
         // intercept API call with response matching the payload

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -3,6 +3,8 @@ import { colors } from 'quasar';
 import RouteCalendarPanel from 'components/routes/RouteCalendarPanel.vue';
 import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
+import testData from '../../../test/cypress/fixtures/routeCalendarPanelInputTest.json';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
@@ -137,6 +139,61 @@ describe('<RouteCalendarPanel>', () => {
     coreTests();
     mobileTests();
     unloggedRouteTests();
+  });
+
+  context('API payloads for route entry', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.viewport('macbook-16');
+    });
+
+    Object.entries(testData).forEach(([testKey, testCase]) => {
+      it(`${testKey}: ${testCase.description}`, () => {
+        // intercept API call with response matching the payload
+        const responseBody = {
+          count: testCase.apiPayload.length,
+          next: null,
+          previous: null,
+          results: testCase.apiPayload.trips.map((trip, index) => ({
+            id: index + 1,
+            ...trip,
+            durationSeconds: null,
+            sourceId: null,
+            file: null,
+            description: '',
+            track: null,
+          })),
+        };
+        cy.interceptPostTripsApi(rideToWorkByBikeConfig, i18n, responseBody);
+        // mount component with test data
+        cy.mount(RouteCalendarPanel, {
+          props: {
+            modelValue: true,
+            routes: testCase.propRoutes,
+          },
+        });
+        cy.setupTripsStoreWithCommuteModes(useTripsStore);
+        // input transport type if provided
+        if (testCase.inputValues.transport) {
+          cy.dataCy('button-toggle-transport').should('be.visible');
+          cy.dataCy(selectorRouteInputTransportType)
+            .find(`[data-value="${testCase.inputValues.transport}"]`)
+            .click();
+        }
+        // input distance if provided
+        if (testCase.inputValues.distance) {
+          cy.dataCy('section-input-number').should('be.visible');
+          cy.dataCy('section-input-number').find('input').clear();
+          cy.dataCy('section-input-number')
+            .find('input')
+            .type(testCase.inputValues.distance);
+        }
+        // click save button
+        cy.dataCy(selectorDialogSaveButton).click();
+        // wait for API call and verify payload
+        cy.waitForPostTripsApi(testCase.apiPayload);
+      });
+    });
   });
 });
 

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -24,6 +24,11 @@ describe('<RouteCalendarPanel>', () => {
       'routes',
       i18n,
     );
+    cy.testLanguageStringsInContext(
+      ['apiMessageError', 'apiMessageErrorWithMessage', 'apiMessageSuccess'],
+      'postTrips',
+      i18n,
+    );
   });
 
   context('desktop - logged route', () => {

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -252,7 +252,7 @@ function coreTests() {
       .blur();
     cy.dataCy(selectorButtonSave).should(
       'contain',
-      i18n.global.tc('routes.buttonSaveChangesCount', 0, { count: 0 }),
+      i18n.global.tc('routes.buttonSaveChangesCount', 1, { count: 1 }),
     );
   });
 

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -4,6 +4,7 @@ import RoutesCalendar from 'components/routes/RoutesCalendar.vue';
 import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
 import { useChallengeStore } from 'src/stores/challenge';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // selectors
 const classSelectorCurrentDay = '.q-current-day';
@@ -499,50 +500,62 @@ function coreTests() {
   });
 
   it('renders inputs and allows saving when value is entered', () => {
-    cy.get(classSelectorCurrentDay).find(dataSelectorItemToWork).click();
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorDialogHeader)
-      .should('be.visible')
-      .and(
-        'contain',
-        i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
-          count: routeCountSingle,
-        }),
+    cy.fixture('routeCalendarInputTest.json').then((testData) => {
+      cy.get(`[data-date="${testData.test_1.inputValues.date}"]`)
+        .find(dataSelectorItemToWork)
+        .click();
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorDialogHeader)
+        .should('be.visible')
+        .and(
+          'contain',
+          i18n.global.t('routes.titleBottomPanel', routeCountSingle, {
+            count: routeCountSingle,
+          }),
+        );
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorInputTransportType)
+        .should('be.visible');
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorRouteInputDistance)
+        .should('be.visible');
+      // save disabed
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorButtonSave)
+        .should('be.visible')
+        .and('be.disabled');
+      // fill in distance
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorInputDistance)
+        .should('be.visible')
+        .focus();
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorInputDistance)
+        .should('be.visible')
+        .clear();
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorInputDistance)
+        .should('be.visible')
+        .type(testData.test_1.inputValues.distance);
+      // save enabled
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorButtonSave)
+        .should('not.be.disabled');
+      // intercept API call with response matching the payload
+      cy.interceptPostTripsApi(
+        rideToWorkByBikeConfig,
+        i18n,
+        testData.test_1.responseBody,
       );
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorInputTransportType)
-      .should('be.visible');
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorRouteInputDistance)
-      .should('be.visible');
-    // save disabed
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorButtonSave)
-      .should('be.visible')
-      .and('be.disabled');
-    // fill in distance
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorInputDistance)
-      .should('be.visible')
-      .focus();
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorInputDistance)
-      .should('be.visible')
-      .clear();
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorInputDistance)
-      .should('be.visible')
-      .type('10');
-    // save enabled
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorButtonSave)
-      .should('not.be.disabled');
-    // save
-    cy.dataCy(selectorRouteCalendarPanel).find(dataSelectorButtonSave).click();
-    // panel is closed
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorDialogHeader)
-      .should('not.be.visible');
+      // save
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorButtonSave)
+        .click();
+      // panel is closed
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(dataSelectorDialogHeader)
+        .should('not.be.visible');
+    });
   });
 
   it('allows to manually close panel and reopen on interaction', () => {

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -127,7 +127,7 @@ export default defineComponent({
         response.data?.trips &&
         response.data.trips.length > 0
       ) {
-        logger?.info('Routes saved successfully');
+        logger?.info('Routes saved successfully.');
         logger?.debug(
           `Saved trips <${JSON.stringify(response.data.trips, null, 2)}>.`,
         );
@@ -135,7 +135,7 @@ export default defineComponent({
         const savedRouteItems = response.data.trips.map((trip) =>
           tripsAdapter.toRouteItem(trip),
         );
-        logger?.debug('Saving new routes to store.');
+        logger?.info('Saving new routes to store.');
         // update store with new route items
         tripsStore.updateRouteItems(savedRouteItems);
         logger?.debug(

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -124,15 +124,23 @@ export default defineComponent({
         const response = await postTrips(tripPayload);
         // handle success
         if (response.success && response.data?.length) {
+          logger?.info('Routes saved successfully');
+          logger?.debug(
+            `Saved routes <${JSON.stringify(response.data, null, 2)}>.`,
+          );
           // convert saved trips to route items
           const savedRouteItems = response.data.map((trip) =>
             tripsAdapter.toRouteItem(trip),
           );
+          logger?.debug('Saving new routes to store.');
           // update store with new route items
           tripsStore.setRouteItems([
             ...tripsStore.getRouteItems,
             ...savedRouteItems,
           ]);
+          logger?.debug(
+            `Updated store route items <${JSON.stringify(tripsStore.getRouteItems, null, 2)}>.`,
+          );
           // emit save event
           emit('save');
         }

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -122,22 +122,25 @@ export default defineComponent({
         );
         // send to API
         const response = await postTrips(tripPayload);
+        console.log('response', response);
+        console.log('response.data', response.data);
         // handle success
-        if (response.success && response.data?.length) {
+        if (
+          response.success &&
+          response.data?.trips &&
+          response.data.trips.length > 0
+        ) {
           logger?.info('Routes saved successfully');
           logger?.debug(
-            `Saved routes <${JSON.stringify(response.data, null, 2)}>.`,
+            `Saved trips <${JSON.stringify(response.data.trips, null, 2)}>.`,
           );
           // convert saved trips to route items
-          const savedRouteItems = response.data.map((trip) =>
+          const savedRouteItems = response.data.trips.map((trip) =>
             tripsAdapter.toRouteItem(trip),
           );
           logger?.debug('Saving new routes to store.');
           // update store with new route items
-          tripsStore.setRouteItems([
-            ...tripsStore.getRouteItems,
-            ...savedRouteItems,
-          ]);
+          tripsStore.updateRouteItems(savedRouteItems);
           logger?.debug(
             `Updated store route items <${JSON.stringify(tripsStore.getRouteItems, null, 2)}>.`,
           );

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -109,45 +109,40 @@ export default defineComponent({
      * If successful, closes panel.
      */
     const onSave = async (): Promise<void> => {
-      try {
-        // create route items with settings from panel
-        const routeItems: RouteItem[] = routes.value.map((route) => ({
-          ...route,
-          transport: transportType.value,
-          distance: isShownDistance.value ? distance.value : route.distance,
-        }));
-        // convert route items to trip payload
-        const tripPayload = routeItems.map((route) =>
-          tripsAdapter.toTripPostPayload(route),
+      // create route items with settings from panel
+      const routeItems: RouteItem[] = routes.value.map((route) => ({
+        ...route,
+        transport: transportType.value,
+        distance: isShownDistance.value ? distance.value : route.distance,
+      }));
+      // convert route items to trip payload
+      const tripPayload = routeItems.map((route) =>
+        tripsAdapter.toTripPostPayload(route),
+      );
+      // send to API
+      const response = await postTrips(tripPayload);
+      // handle success
+      if (
+        response.success &&
+        response.data?.trips &&
+        response.data.trips.length > 0
+      ) {
+        logger?.info('Routes saved successfully');
+        logger?.debug(
+          `Saved trips <${JSON.stringify(response.data.trips, null, 2)}>.`,
         );
-        // send to API
-        const response = await postTrips(tripPayload);
-        // handle success
-        if (
-          response.success &&
-          response.data?.trips &&
-          response.data.trips.length > 0
-        ) {
-          logger?.info('Routes saved successfully');
-          logger?.debug(
-            `Saved trips <${JSON.stringify(response.data.trips, null, 2)}>.`,
-          );
-          // convert saved trips to route items
-          const savedRouteItems = response.data.trips.map((trip) =>
-            tripsAdapter.toRouteItem(trip),
-          );
-          logger?.debug('Saving new routes to store.');
-          // update store with new route items
-          tripsStore.updateRouteItems(savedRouteItems);
-          logger?.debug(
-            `Updated store route items <${JSON.stringify(tripsStore.getRouteItems, null, 2)}>.`,
-          );
-          // emit save event
-          emit('save');
-        }
-      } catch (error) {
-        // TODO: handle error
-        console.error('Failed to save routes:', error);
+        // convert saved trips to route items
+        const savedRouteItems = response.data.trips.map((trip) =>
+          tripsAdapter.toRouteItem(trip),
+        );
+        logger?.debug('Saving new routes to store.');
+        // update store with new route items
+        tripsStore.updateRouteItems(savedRouteItems);
+        logger?.debug(
+          `Updated store route items <${JSON.stringify(tripsStore.getRouteItems, null, 2)}>.`,
+        );
+        // emit save event
+        emit('save');
       }
     };
 

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -122,8 +122,6 @@ export default defineComponent({
         );
         // send to API
         const response = await postTrips(tripPayload);
-        console.log('response', response);
-        console.log('response.data', response.data);
         // handle success
         if (
           response.success &&

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -28,7 +28,7 @@
  */
 
 // libraries
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, inject } from 'vue';
 
 // components
 import RouteInputDistance from './RouteInputDistance.vue';
@@ -36,12 +36,20 @@ import RouteInputTransportType from './RouteInputTransportType.vue';
 
 // composables
 import { useLogRoutes } from '../../composables/useLogRoutes';
+import { useApiPostTrips } from '../../composables/useApiPostTrips';
+
+// adapters
+import { tripsAdapter } from '../../adapters/tripsAdapter';
+
+// stores
+import { useTripsStore } from '../../stores/trips';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // types
 import type { RouteItem } from '../types/Route';
+import type { Logger } from '../types/Logger';
 
 export default defineComponent({
   name: 'RouteCalendarPanel',
@@ -61,6 +69,7 @@ export default defineComponent({
   },
   emits: ['save', 'update:modelValue'],
   setup(props, { emit }) {
+    const logger = inject('vuejs3-logger') as Logger | null;
     // styles
     const minWidth = '65vw';
 
@@ -79,12 +88,18 @@ export default defineComponent({
     const { action, distance, routesCount, transportType, isShownDistance } =
       useLogRoutes(routes);
 
+    // Initialize API composable
+    const { postTrips, isLoading } = useApiPostTrips(logger);
+
+    // Initialize trips store
+    const tripsStore = useTripsStore();
+
     // Determines if save button should be disabled.
     const isSaveBtnDisabled = computed((): boolean => {
       const noRoutes = routesCount.value === 0;
       const noDistance =
         isShownDistance.value && distance.value === defaultDistanceZero;
-      return noRoutes || noDistance;
+      return noRoutes || noDistance || isLoading.value;
     });
 
     /**
@@ -93,9 +108,38 @@ export default defineComponent({
      * If unsuccessful, it shows error message.
      * If successful, closes panel.
      */
-    const onSave = (): void => {
-      // TODO: send API request
-      emit('save');
+    const onSave = async (): Promise<void> => {
+      try {
+        // create route items with settings from panel
+        const routeItems: RouteItem[] = routes.value.map((route) => ({
+          ...route,
+          transport: transportType.value,
+          distance: isShownDistance.value ? distance.value : route.distance,
+        }));
+        // convert route items to trip payload
+        const tripPayload = routeItems.map((route) =>
+          tripsAdapter.toTripPostPayload(route),
+        );
+        // send to API
+        const response = await postTrips(tripPayload);
+        // handle success
+        if (response.success && response.data?.length) {
+          // convert saved trips to route items
+          const savedRouteItems = response.data.map((trip) =>
+            tripsAdapter.toRouteItem(trip),
+          );
+          // update store with new route items
+          tripsStore.setRouteItems([
+            ...tripsStore.getRouteItems,
+            ...savedRouteItems,
+          ]);
+          // emit save event
+          emit('save');
+        }
+      } catch (error) {
+        // TODO: handle error
+        console.error('Failed to save routes:', error);
+      }
     };
 
     return {

--- a/src/components/routes/RouteInputDistance.vue
+++ b/src/components/routes/RouteInputDistance.vue
@@ -34,6 +34,9 @@ import { useValidation } from '../../composables/useValidation';
 // types
 import type { FormOption } from '../types/Form';
 
+// utils
+import { localizedFloatNumStrToFloatNumber } from 'src/utils';
+
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 const { defaultDistanceZero } = rideToWorkByBikeConfig;
@@ -100,6 +103,7 @@ export default defineComponent({
       i18n,
       isFilled,
       isAboveZero,
+      localizedFloatNumStrToFloatNumber,
     };
   },
 });
@@ -133,16 +137,22 @@ export default defineComponent({
           class="col-auto items-center"
           data-cy="section-input-number"
         >
-          <!-- Input: Distance -->
+          <!-- Input: Distance
+               with maxlength="6" max. allowed value is 999.99
+               according backend Trip DB model distance field max.
+               validator value
+          -->
           <q-input
             dense
             outlined
             reverse-fill-mask
-            unmasked-value
             v-model="distance"
             :mask="
               i18n.global
-                .n(parseFloat(distance), 'routeDistanceDecimalNumber')
+                .n(
+                  localizedFloatNumStrToFloatNumber(distance),
+                  'routeDistanceDecimalNumber',
+                )
                 .includes(',')
                 ? '#,##'
                 : '#.##'
@@ -150,17 +160,12 @@ export default defineComponent({
             fill-mask="0"
             :rules="[
               (val) =>
-                isFilled(val) ||
-                !hasValidation ||
-                $t('form.messageFieldRequired', {
-                  fieldName: $t('routes.labelValidationDistance'),
-                }),
-              (val) =>
-                isAboveZero(val) ||
+                isAboveZero(localizedFloatNumStrToFloatNumber(val)) ||
                 !hasValidation ||
                 $t('form.messageFieldAboveZero'),
             ]"
             data-cy="input-distance"
+            maxlength="6"
           >
             <template v-slot:append>
               <span

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -242,7 +242,12 @@ export default defineComponent({
       >
         <template #day="{ scope: { timestamp, outside } }">
           <!-- TODO: make the empty slots display only on the challenge days -->
-          <div v-if="!timestamp.future" class="q-my-sm" data-cy="calendar-day">
+          <div
+            v-if="!timestamp.future"
+            :data-date="timestamp.date"
+            class="q-my-sm"
+            data-cy="calendar-day"
+          >
             <!-- Route to work -->
             <calendar-item-display
               :active="

--- a/src/components/types/Config.ts
+++ b/src/components/types/Config.ts
@@ -54,6 +54,7 @@ export interface ConfigGlobal {
   feedRefreshCachedPostsIntervalHours: number;
   apiFeedMaxOffersNumber: number;
   apiFeedMaxPrizesNumber: number;
+  apiTripsSourceApplicationId: string;
   iDontWantMerchandiseItemCode: string;
   notifyMessagePosition: string;
   mobileBottomPanelVisibleItems: number;

--- a/src/components/types/Trip.ts
+++ b/src/components/types/Trip.ts
@@ -26,11 +26,11 @@ export interface TripPostPayload {
   commuteMode: string;
   distanceMeters: number;
   sourceApplication: string;
-  file: string | null;
-  track: string | null;
-  durationSeconds: number | null;
-  sourceId: string;
-  description: string;
+  file?: string | null;
+  track?: string | null;
+  durationSeconds?: number | null;
+  sourceId?: string;
+  description?: string;
 }
 
 export interface GetTripsResponse {

--- a/src/components/types/Trip.ts
+++ b/src/components/types/Trip.ts
@@ -20,6 +20,19 @@ export interface Trip {
   track: string | null;
 }
 
+export interface TripPostPayload {
+  trip_date: string;
+  direction: string;
+  commuteMode: string;
+  distanceMeters: number;
+  sourceApplication: string;
+  file: string | null;
+  track: string | null;
+  durationSeconds: number | null;
+  sourceId: string;
+  description: string;
+}
+
 export interface GetTripsResponse {
   count: number;
   next: string | null;

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -18,7 +18,7 @@ const { apiDefaultLang, apiBase, apiBaseRtwbbFeed, apiBaseIpAddress } =
 import type { AxiosRequestHeaders, Method } from 'axios';
 import type { Logger } from '../components/types/Logger';
 
-interface ApiResponse<T> {
+export interface ApiResponse<T> {
   data: T | null;
   success: boolean;
 }

--- a/src/composables/useApiPostTrips.ts
+++ b/src/composables/useApiPostTrips.ts
@@ -21,7 +21,9 @@ import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
 interface UseApiPostTripsReturn {
   isLoading: Ref<boolean>;
-  postTrips: (trips: TripPostPayload[]) => Promise<ApiResponse<Trip[]>>;
+  postTrips: (
+    trips: TripPostPayload[],
+  ) => Promise<ApiResponse<{ trips: Trip[] }>>;
 }
 
 /**
@@ -44,7 +46,7 @@ export const useApiPostTrips = (
    */
   const postTrips = async (
     trips: TripPostPayload[],
-  ): Promise<ApiResponse<Trip[]>> => {
+  ): Promise<ApiResponse<{ trips: Trip[] }>> => {
     logger?.debug(`Creating trips <${JSON.stringify(trips)}>.`);
     isLoading.value = true;
 
@@ -60,7 +62,7 @@ export const useApiPostTrips = (
     );
 
     // create trips
-    const response = await apiFetch<Trip[]>({
+    const response = await apiFetch<{ trips: Trip[] }>({
       endpoint: rideToWorkByBikeConfig.urlApiTrips,
       method: 'post',
       translationKey: 'postTrips',

--- a/src/composables/useApiPostTrips.ts
+++ b/src/composables/useApiPostTrips.ts
@@ -14,13 +14,14 @@ import { useLoginStore } from '../stores/login';
 import type { Ref } from 'vue';
 import type { Logger } from '../components/types/Logger';
 import type { Trip, TripPostPayload } from '../components/types/Trip';
+import type { ApiResponse } from './useApi';
 
 // utils
 import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
 interface UseApiPostTripsReturn {
   isLoading: Ref<boolean>;
-  postTrips: (trips: TripPostPayload[]) => Promise<void>;
+  postTrips: (trips: TripPostPayload[]) => Promise<ApiResponse<Trip[]>>;
 }
 
 /**
@@ -41,7 +42,9 @@ export const useApiPostTrips = (
    * Creates multiple trips in a single request
    * @param {TripPostPayload[]} trips - Array of trips to create
    */
-  const postTrips = async (trips: TripPostPayload[]): Promise<void> => {
+  const postTrips = async (
+    trips: TripPostPayload[],
+  ): Promise<ApiResponse<Trip[]>> => {
     logger?.debug(`Creating trips <${JSON.stringify(trips)}>.`);
     isLoading.value = true;
 
@@ -57,7 +60,7 @@ export const useApiPostTrips = (
     );
 
     // create trips
-    await apiFetch<Trip[]>({
+    const response = await apiFetch<Trip[]>({
       endpoint: rideToWorkByBikeConfig.urlApiTrips,
       method: 'post',
       translationKey: 'postTrips',
@@ -67,6 +70,8 @@ export const useApiPostTrips = (
     });
 
     isLoading.value = false;
+
+    return response;
   };
 
   return {

--- a/src/composables/useApiPostTrips.ts
+++ b/src/composables/useApiPostTrips.ts
@@ -28,7 +28,7 @@ interface UseApiPostTripsReturn {
 
 /**
  * Post trips composable
- * Used to create new trips
+ * Used to create new trips or update existing trips
  * @param logger - Logger
  * @returns {UseApiPostTripsReturn}
  */
@@ -40,9 +40,9 @@ export const useApiPostTrips = (
   const { apiFetch } = useApi();
 
   /**
-   * Create new trips
-   * Creates multiple trips in a single request
-   * @param {TripPostPayload[]} trips - Array of trips to create
+   * Create new trips or update existing trips
+   * Can create or update multiple trips in a single request
+   * @param {TripPostPayload[]} trips - Array of trips to create or update
    */
   const postTrips = async (
     trips: TripPostPayload[],
@@ -61,7 +61,7 @@ export const useApiPostTrips = (
       requestTokenHeader_,
     );
 
-    // create trips
+    // post trips
     const response = await apiFetch<{ trips: Trip[] }>({
       endpoint: rideToWorkByBikeConfig.urlApiTrips,
       method: 'post',

--- a/src/composables/useApiPostTrips.ts
+++ b/src/composables/useApiPostTrips.ts
@@ -1,0 +1,76 @@
+// libraries
+import { ref } from 'vue';
+
+// composables
+import { useApi } from './useApi';
+
+// config
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
+
+// stores
+import { useLoginStore } from '../stores/login';
+
+// types
+import type { Ref } from 'vue';
+import type { Logger } from '../components/types/Logger';
+import type { Trip, TripPostPayload } from '../components/types/Trip';
+
+// utils
+import { requestDefaultHeader, requestTokenHeader } from '../utils';
+
+interface UseApiPostTripsReturn {
+  isLoading: Ref<boolean>;
+  postTrips: (trips: TripPostPayload[]) => Promise<void>;
+}
+
+/**
+ * Post trips composable
+ * Used to create new trips
+ * @param logger - Logger
+ * @returns {UseApiPostTripsReturn}
+ */
+export const useApiPostTrips = (
+  logger: Logger | null,
+): UseApiPostTripsReturn => {
+  const isLoading = ref<boolean>(false);
+  const loginStore = useLoginStore();
+  const { apiFetch } = useApi();
+
+  /**
+   * Create new trips
+   * Creates multiple trips in a single request
+   * @param {TripPostPayload[]} trips - Array of trips to create
+   */
+  const postTrips = async (trips: TripPostPayload[]): Promise<void> => {
+    logger?.debug(`Creating trips <${JSON.stringify(trips)}>.`);
+    isLoading.value = true;
+
+    // append access token into HTTP header
+    const requestTokenHeader_ = { ...requestTokenHeader };
+    requestTokenHeader_.Authorization +=
+      await loginStore.getAccessTokenWithRefresh();
+
+    // prepare headers with version
+    const headers = Object.assign(
+      requestDefaultHeader(rideToWorkByBikeConfig.apiVersion2),
+      requestTokenHeader_,
+    );
+
+    // create trips
+    await apiFetch<Trip[]>({
+      endpoint: rideToWorkByBikeConfig.urlApiTrips,
+      method: 'post',
+      translationKey: 'postTrips',
+      headers,
+      payload: { trips },
+      logger,
+    });
+
+    isLoading.value = false;
+  };
+
+  return {
+    isLoading,
+    postTrips,
+  };
+};

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -71,6 +71,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
             transport: TransportType.bike,
             distance: defaultDistanceZero,
             inputType: 'input-number',
+            routeFeature: null,
           });
         }
       }

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -8,10 +8,13 @@ import { rideToWorkByBikeConfig } from '../boot/global_vars';
 import { TransportType } from 'src/components/types/Route';
 
 // types
-import type { ComputedRef } from 'vue';
+import type { Ref } from 'vue';
 import type { RouteInputType, RouteItem } from 'src/components/types/Route';
 
-export const useLogRoutes = (routes: ComputedRef<RouteItem[]>) => {
+// utils
+import { hasTransportDistance } from '../utils/has_transport_distance';
+
+export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
   const { defaultDistanceZero } = rideToWorkByBikeConfig;
   const routesCount = computed((): number => routes.value.length);
 
@@ -46,25 +49,11 @@ export const useLogRoutes = (routes: ComputedRef<RouteItem[]>) => {
     return hasTransportDistance(transportType.value);
   });
 
-  /**
-   * Checks if the given transport type has distance.
-   * @param {TransportType} transport - The transport type to check.
-   * @return {boolean} Whether the transport has distance.
-   */
-  const hasTransportDistance = (transport: TransportType): boolean => {
-    return (
-      transport === TransportType.bike ||
-      transport === TransportType.walk ||
-      transport === TransportType.bus
-    );
-  };
-
   return {
     action,
     distance,
     routesCount,
     transportType,
     isShownDistance,
-    hasTransportDistance,
   };
 };

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -703,6 +703,11 @@ apiMessageSuccess = "Stav registrace byl úspěšně uložen."
 messageTeamMaxMembersUnavailable = "Nepodařilo se zjistit počet členů týmu. Zkuste to znovu později."
 messageTeamMaxMembersReached = "Tým je plný. Nemůžete přidat další členy."
 
+[postTrips]
+apiMessageError = "Chyba při ukládání jízd."
+apiMessageErrorWithMessage = "Chyba při ukládání jízd. Chyba: {error}"
+apiMessageSuccess = "Jízdy byly úspěšně uloženy."
+
 [profile]
 buttonDeleteAccount = "Smazat"
 buttonDownloadInvoice = "Stáhnout potvrzení o platbě"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -700,6 +700,12 @@ apiMessageSuccess = "Registration status was successfully saved."
 messageTeamMaxMembersUnavailable = "Failed to get team members count. Please try again later."
 messageTeamMaxMembersReached = "Team is full. You cannot add more members."
 
+[postTrips]
+apiMessageError = "Error saving trips."
+apiMessageErrorWithMessage = "Error saving trips. Error: {error}"
+apiMessageSuccess = "Trips were successfully saved."
+
+
 [profile]
 buttonAddEmailField = "Add another email"
 buttonDeleteAccount = "Delete"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -702,6 +702,11 @@ apiMessageSuccess = "Stav registrácie bol úspešne uložený."
 messageTeamMaxMembersUnavailable = "Nepodarilo sa zistiť počet členov tímu. Skúste to znovu později."
 messageTeamMaxMembersReached = "Tím je plný. Nemôžete pridať ďalšie členov."
 
+[postTrips]
+apiMessageError = "Chyba pri ukladaní jázd."
+apiMessageErrorWithMessage = "Chyba pri ukladaní jázd. Chyba: {error}"
+apiMessageSuccess = "Jázdy boli úspešne uložené."
+
 [profile]
 buttonDeleteAccount = "Zmazať"
 buttonDownloadInvoice = "Stiahnutie potvrzenia o platbe"

--- a/src/stores/trips.ts
+++ b/src/stores/trips.ts
@@ -86,6 +86,27 @@ export const useTripsStore = defineStore('trips', {
       this.routeItems = routeItems;
     },
     /**
+     * Update route items by merging new items with existing ones
+     * Routes are identified by date and direction combination
+     * @param {RouteItem[]} newRouteItems - Array of new route items to merge
+     * @returns {void}
+     */
+    updateRouteItems(newRouteItems: RouteItem[]): void {
+      // create a map of existing routes for easy lookup
+      const existingRoutesMap = new Map<string, RouteItem>();
+      this.routeItems.forEach((route) => {
+        const key = `${route.date}-${route.direction}`;
+        existingRoutesMap.set(key, route as RouteItem);
+      });
+      // update or add new routes
+      newRouteItems.forEach((newRoute) => {
+        const key = `${newRoute.date}-${newRoute.direction}`;
+        existingRoutesMap.set(key, newRoute as RouteItem);
+      });
+      // convert map back to array
+      this.routeItems = Array.from(existingRoutesMap.values());
+    },
+    /**
      * Load commute modes from API
      * @returns {Promise<void>}
      */

--- a/src/utils/has_transport_distance.ts
+++ b/src/utils/has_transport_distance.ts
@@ -1,0 +1,14 @@
+import { TransportType } from '../components/types/Route';
+
+/**
+ * Checks if the given transport type has distance.
+ * @param {TransportType} transport - The transport type to check.
+ * @return {boolean} Whether the transport has distance.
+ */
+export const hasTransportDistance = (transport: TransportType): boolean => {
+  return (
+    transport === TransportType.bike ||
+    transport === TransportType.walk ||
+    transport === TransportType.bus
+  );
+};

--- a/src/utils/has_transport_distance.ts
+++ b/src/utils/has_transport_distance.ts
@@ -3,7 +3,7 @@ import { TransportType } from '../components/types/Route';
 /**
  * Checks if the given transport type has distance.
  * @param {TransportType} transport - The transport type to check.
- * @return {boolean} Whether the transport has distance.
+ * @return {boolean} - Whether the transport has distance.
  */
 export const hasTransportDistance = (transport: TransportType): boolean => {
   return (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -165,6 +165,19 @@ const getAbsoluteUrlpath = (inputUrl: string): string => {
   return new URL(inputUrl, getAppConfig().urlBaseBackend).href;
 };
 
+/**
+ * Convert localized float number string into float number
+ *
+ * @param {string} numberStr - Localized float number sting e.g 6.10 or 6,10
+ *
+ * @returns {number} - Float number value
+ */
+
+const localizedFloatNumStrToFloatNumber = (numberStr: string): number => {
+  console.log('NUM STR', numberStr, typeof numberStr);
+  return parseFloat(numberStr.replace(',', '.'));
+};
+
 export {
   calculateCountdownIntervals,
   bearerTokeAuth,
@@ -172,6 +185,7 @@ export {
   getAbsoluteUrlpath,
   getCurrentDateTimeAccordingTimezone,
   formFieldCustomValidationErrCssClass,
+  localizedFloatNumStrToFloatNumber,
   requestDefaultHeader,
   requestTokenHeader,
   rgbaColorObjectToString,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -174,7 +174,6 @@ const getAbsoluteUrlpath = (inputUrl: string): string => {
  */
 
 const localizedFloatNumStrToFloatNumber = (numberStr: string): number => {
-  console.log('NUM STR', numberStr, typeof numberStr);
   return parseFloat(numberStr.replace(',', '.'));
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -168,7 +168,8 @@ const getAbsoluteUrlpath = (inputUrl: string): string => {
 /**
  * Convert localized float number string into float number
  *
- * @param {string} numberStr - Localized float number sting e.g 6.10 or 6,10
+ * @param {string} numberStr - Localized float number string
+ *                             e.g '6.10' or '6,10'
  *
  * @returns {number} - Float number value
  */

--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -2,29 +2,257 @@ import { routesConf } from '../../../src/router/routes_conf';
 import { testDesktopSidebar } from '../support/commonTests';
 import { defLocale } from '../../../src/i18n/def_locale';
 
+const dateWithLoggedRoute = new Date(2025, 4, 26);
+
 describe('Routes calendar page', () => {
-  context('desktop', () => {
+  beforeEach(() => {
+    cy.viewport('macbook-16');
+    cy.clock(new Date(dateWithLoggedRoute), ['Date']);
+    // load config an i18n objects as aliases
+    cy.task('getAppConfig', process).then((config) => {
+      // alias config
+      cy.wrap(config).as('config');
+      cy.fixture('apiGetThisCampaignMay.json').then((campaign) => {
+        cy.interceptThisCampaignGetApi(config, defLocale, campaign);
+        cy.visit('#' + routesConf['challenge_inactive']['path']);
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          // alias i18n
+          cy.wrap(win.i18n).as('i18n');
+        });
+        cy.waitForThisCampaignApi(campaign);
+      });
+    });
+  });
+
+  context('desktop - no logged routes', () => {
     beforeEach(() => {
-      cy.viewport('macbook-16');
-      // load config an i18n objects as aliases
-      cy.task('getAppConfig', process).then((config) => {
-        // alias config
-        cy.wrap(config).as('config');
+      cy.get('@config').then((config) => {
         cy.interceptCommuteModeGetApi(config, defLocale);
         cy.interceptTripsGetApi(config, defLocale);
+        cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
+        cy.waitForCommuteModeApi();
+        cy.waitForTripsApi();
       });
-      cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
-      cy.window().should('have.property', 'i18n');
-      cy.window().then((win) => {
-        // alias i18n
-        cy.wrap(win.i18n).as('i18n');
-      });
-      cy.waitForCommuteModeApi();
-      cy.waitForTripsApi();
     });
 
     coreTests();
     testDesktopSidebar();
+
+    it('allows to enter a new route and save it', () => {
+      cy.get('@i18n').then((i18n) => {
+        cy.get('@config').then((config) => {
+          cy.fixture('routeCalendarPanelInputTest.json').then((testCases) => {
+            // intercept API call with response matching the payload
+            const responseBody = {
+              trips: testCases.test_1.apiPayload.trips.map((trip, index) => ({
+                id: index + 1,
+                ...trip,
+                durationSeconds: null,
+                sourceId: null,
+                file: null,
+                description: '',
+                track: null,
+              })),
+            };
+            cy.interceptPostTripsApi(config, i18n, responseBody);
+            const testCaseDate = testCases.test_1.propRoutes[0].date;
+            const testCaseTransport = testCases.test_1.inputValues.transport;
+            const testCaseDistance = testCases.test_1.inputValues.distance;
+            // wait for routes calendar to be visible
+            cy.dataCy('routes-calendar').should('be.visible');
+            // click on the calendar item
+            cy.get(`[data-date="${testCaseDate}"]`)
+              .find('[data-cy="calendar-item-icon-towork-empty"]')
+              .click({ force: true });
+            // route calendar panel should be open
+            cy.dataCy('route-calendar-panel').should('exist');
+            // input transport type
+            cy.dataCy('button-toggle-transport').should('be.visible');
+            cy.dataCy('route-input-transport-type')
+              .find(`[data-value="${testCaseTransport}"]`)
+              .click({ force: true });
+            // input distance
+            cy.dataCy('section-input-number').should('be.visible');
+            cy.dataCy('section-input-number').find('input').clear();
+            cy.dataCy('section-input-number')
+              .find('input')
+              .type(testCaseDistance);
+            // click save button
+            cy.dataCy('dialog-save-button').click();
+            // wait for API call and verify payload
+            cy.waitForPostTripsApi(testCases.test_1.apiPayload);
+            // verify that the route is saved and updated in the UI (depending on the direction)
+            cy.get(`[data-date="${testCaseDate}"]`).find(
+              '[data-cy="calendar-item-icon-towork-logged"]',
+            );
+            cy.get(`[data-date="${testCaseDate}"]`).should(
+              'contain',
+              i18n.global.n(
+                testCases.test_1.apiPayload.trips[0].distanceMeters / 1000.0,
+                'routeDistanceDecimalNumber',
+                defLocale,
+              ),
+            );
+          });
+        });
+      });
+    });
+
+    it('allows to enter multiple new routes', () => {
+      cy.get('@i18n').then((i18n) => {
+        cy.get('@config').then((config) => {
+          cy.fixture('routeCalendarPanelInputTest.json').then((testCases) => {
+            // intercept API call with response matching the payload
+            const responseBody = {
+              trips: testCases.test_17.apiPayload.trips.map((trip, index) => ({
+                id: index + 1,
+                ...trip,
+                durationSeconds: null,
+                sourceId: null,
+                file: null,
+                description: '',
+                track: null,
+              })),
+            };
+            cy.interceptPostTripsApi(config, i18n, responseBody);
+            const testCaseDate = testCases.test_17.propRoutes[0].date;
+            const testCaseTransport = testCases.test_17.inputValues.transport;
+            const testCaseDistance = testCases.test_17.inputValues.distance;
+            cy.dataCy('routes-calendar').should('be.visible');
+            // click on the first calendar route
+            cy.get(`[data-date="${testCaseDate}"]`)
+              .find('[data-cy="calendar-item-icon-towork-empty"]')
+              .click({ force: true });
+            // click on the second calendar route
+            cy.get(`[data-date="${testCaseDate}"]`)
+              .find('[data-cy="calendar-item-icon-fromwork-empty"]')
+              .click({ force: true });
+            // route calendar panel should be open
+            cy.dataCy('route-calendar-panel').should('exist');
+            // input transport type
+            cy.dataCy('button-toggle-transport').should('be.visible');
+            cy.dataCy('route-input-transport-type')
+              .find(`[data-value="${testCaseTransport}"]`)
+              .click({ force: true });
+            // input distance
+            cy.dataCy('section-input-number').should('be.visible');
+            cy.dataCy('section-input-number').find('input').clear();
+            cy.dataCy('section-input-number')
+              .find('input')
+              .type(testCaseDistance);
+            // click save button
+            cy.dataCy('dialog-save-button').click();
+            // wait for API call and verify payload
+            cy.waitForPostTripsApi(testCases.test_17.apiPayload);
+            // verify that the first route is saved and updated in the UI
+            cy.get(`[data-date="${testCaseDate}"]`).find(
+              '[data-cy="calendar-item-icon-towork-logged"]',
+            );
+            cy.get(`[data-date="${testCaseDate}"]`).should(
+              'contain',
+              i18n.global.n(
+                testCases.test_17.apiPayload.trips[0].distanceMeters / 1000.0,
+                'routeDistanceDecimalNumber',
+                defLocale,
+              ),
+            );
+            // verify that the second route is saved and updated in the UI
+            cy.get(`[data-date="${testCaseDate}"]`).find(
+              '[data-cy="calendar-item-icon-fromwork-logged"]',
+            );
+            cy.get(`[data-date="${testCaseDate}"]`).should(
+              'contain',
+              i18n.global.n(
+                testCases.test_17.apiPayload.trips[1].distanceMeters / 1000.0,
+                'routeDistanceDecimalNumber',
+                defLocale,
+              ),
+            );
+          });
+        });
+      });
+    });
+  });
+
+  context('desktop - with logged routes', () => {
+    beforeEach(() => {
+      cy.get('@config').then((config) => {
+        cy.interceptCommuteModeGetApi(config, defLocale);
+        cy.fixture('apiGetTripsResponseCalendar.json').then((trips) => {
+          cy.fixture('apiGetTripsResponseCalendarNext.json').then(
+            (tripsNext) => {
+              cy.interceptTripsGetApi(config, defLocale, trips, tripsNext);
+              cy.visit(
+                '#' + routesConf['routes_calendar']['children']['fullPath'],
+              );
+              cy.waitForCommuteModeApi();
+              cy.waitForTripsApi(trips, tripsNext);
+            },
+          );
+        });
+      });
+    });
+
+    it('allows to update an existing route', () => {
+      cy.get('@i18n').then((i18n) => {
+        cy.get('@config').then((config) => {
+          cy.fixture('routeCalendarPanelInputTest.json').then((testCases) => {
+            // intercept API call with response matching the payload
+            const responseBody = {
+              trips: testCases.test_1.apiPayload.trips.map((trip, index) => ({
+                id: index + 1,
+                ...trip,
+                durationSeconds: null,
+                sourceId: null,
+                file: null,
+                description: '',
+                track: null,
+              })),
+            };
+            cy.interceptPostTripsApi(config, i18n, responseBody);
+            const testCaseDate = testCases.test_1.propRoutes[0].date;
+            const testCaseTransport = testCases.test_1.inputValues.transport;
+            const testCaseDistance = testCases.test_1.inputValues.distance;
+            // wait for routes calendar to be visible
+            cy.dataCy('routes-calendar').should('be.visible');
+            // click on the calendar item
+            cy.get(`[data-date="${testCaseDate}"]`)
+              .find('[data-cy="calendar-item-icon-towork-logged"]')
+              .click({ force: true });
+            // route calendar panel should be open
+            cy.dataCy('route-calendar-panel').should('exist');
+            // input transport type
+            cy.dataCy('button-toggle-transport').should('be.visible');
+            cy.dataCy('route-input-transport-type')
+              .find(`[data-value="${testCaseTransport}"]`)
+              .click({ force: true });
+            // input distance
+            cy.dataCy('section-input-number').should('be.visible');
+            cy.dataCy('section-input-number').find('input').clear();
+            cy.dataCy('section-input-number')
+              .find('input')
+              .type(testCaseDistance);
+            // click save button
+            cy.dataCy('dialog-save-button').click();
+            // wait for API call and verify payload
+            cy.waitForPostTripsApi(testCases.test_1.apiPayload);
+            // verify that the route is saved and updated in the UI (depending on the direction)
+            cy.get(`[data-date="${testCaseDate}"]`).find(
+              '[data-cy="calendar-item-icon-towork-logged"]',
+            );
+            cy.get(`[data-date="${testCaseDate}"]`).should(
+              'contain',
+              i18n.global.n(
+                testCases.test_1.apiPayload.trips[0].distanceMeters / 1000.0,
+                'routeDistanceDecimalNumber',
+                defLocale,
+              ),
+            );
+          });
+        });
+      });
+    });
   });
 });
 

--- a/test/cypress/fixtures/apiGetTripsResponseCalendar.json
+++ b/test/cypress/fixtures/apiGetTripsResponseCalendar.json
@@ -1,0 +1,20 @@
+{
+  "count": 2,
+  "next": "https://test.dopracenakole.cz/rest/trips/?limit=1&offset=1",
+  "previous": null,
+  "results": [
+    {
+      "distanceMeters": 5000,
+      "durationSeconds": 1200,
+      "commuteMode": "by_foot",
+      "sourceApplication": "app",
+      "trip_date": "2025-05-25",
+      "sourceId": null,
+      "file": null,
+      "description": "Morning walk",
+      "id": 1771208,
+      "direction": "trip_to",
+      "track": null
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetTripsResponseCalendarNext.json
+++ b/test/cypress/fixtures/apiGetTripsResponseCalendarNext.json
@@ -1,0 +1,20 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": "https://test.dopracenakole.cz/rest/trips/?limit=1&offset=0",
+  "results": [
+    {
+      "distanceMeters": 5000,
+      "durationSeconds": 1200,
+      "commuteMode": "by_foot",
+      "sourceApplication": "app",
+      "trip_date": "2025-05-24",
+      "sourceId": null,
+      "file": null,
+      "description": "Morning walk",
+      "id": 1771206,
+      "direction": "trip_to",
+      "track": null
+    }
+  ]
+}

--- a/test/cypress/fixtures/routeCalendarInputTest.json
+++ b/test/cypress/fixtures/routeCalendarInputTest.json
@@ -1,0 +1,28 @@
+{
+  "test_1": {
+    "description": "log route to work (bicycle)",
+    "inputValues": {
+      "date": "2025-05-27",
+      "direction": "toWork",
+      "distance": "10",
+      "transport": "bicycle"
+    },
+    "responseBody": {
+      "trips": [
+        {
+          "id": 1,
+          "trip_date": "2025-05-27",
+          "direction": "trip_to",
+          "commuteMode": "bicycle",
+          "sourceApplication": "RTWBB",
+          "distanceMeters": 100,
+          "durationSeconds": null,
+          "sourceId": null,
+          "file": null,
+          "description": "",
+          "track": null
+        }
+      ]
+    }
+  }
+}

--- a/test/cypress/fixtures/routeCalendarPanelInputTest.json
+++ b/test/cypress/fixtures/routeCalendarPanelInputTest.json
@@ -1,0 +1,511 @@
+{
+  "test_1": {
+    "description": "empty route - Bike to work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "bicycle",
+      "distance": "10.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "bicycle",
+          "distanceMeters": 10000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_2": {
+    "description": "empty route - Bike from work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "bicycle",
+      "distance": "10.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "bicycle",
+          "distanceMeters": 10000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_3": {
+    "description": "empty route - Walk to work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "5.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_foot",
+          "distanceMeters": 5000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_4": {
+    "description": "empty route - Walk from work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "5.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "by_foot",
+          "distanceMeters": 5000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_5": {
+    "description": "empty route - Bus to work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "hromadna",
+      "distance": "8.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "hromadna",
+          "distanceMeters": 8000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_6": {
+    "description": "empty route - Bus from work (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "hromadna",
+      "distance": "8.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "hromadna",
+          "distanceMeters": 8000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_7": {
+    "description": "empty route - Telecommute to work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "telecommute",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "telecommute",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_8": {
+    "description": "empty route - Telecommute from work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "telecommute",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "telecommute",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_9": {
+    "description": "empty route - Car to work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_other_vehicle",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_other_vehicle",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_10": {
+    "description": "empty route - Car from work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_other_vehicle",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "by_other_vehicle",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_11": {
+    "description": "empty route - No work to work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "no_work",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "no_work",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_12": {
+    "description": "empty route - No work from work (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "no_work",
+      "distance": null
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "no_work",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_13": {
+    "description": "modify existing route - Bike -> Car - (does not use distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "10.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_other_vehicle",
+      "distance": false
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_other_vehicle",
+          "distanceMeters": 0,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_14": {
+    "description": "modify existing route - Bike -> Walk - (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "10.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "15.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_foot",
+          "distanceMeters": 15000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_15": {
+    "description": "modify existing route - Car -> Walk - (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "by_other_vehicle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "15.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_foot",
+          "distanceMeters": 15000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_16": {
+    "description": "modify existing route - Walk -> Walk - (uses distance)",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "14.00",
+        "transport": "by_foot",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "5.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_foot",
+          "distanceMeters": 5000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  },
+  "test_17": {
+    "description": "multiple routes - update both routes",
+    "propRoutes": [
+      {
+        "id": "1",
+        "date": "2025-3-28",
+        "direction": "toWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      },
+      {
+        "id": "2",
+        "date": "2025-3-28",
+        "direction": "fromWork",
+        "distance": "0.00",
+        "transport": "bicycle",
+        "inputType": "input-number",
+        "routeFeature": null
+      }
+    ],
+    "inputValues": {
+      "transport": "by_foot",
+      "distance": "15.00"
+    },
+    "apiPayload": {
+      "trips": [
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_to",
+          "commuteMode": "by_foot",
+          "distanceMeters": 15000,
+          "sourceApplication": "RTWBB"
+        },
+        {
+          "trip_date": "2025-3-28",
+          "direction": "trip_from",
+          "commuteMode": "by_foot",
+          "distanceMeters": 15000,
+          "sourceApplication": "RTWBB"
+        }
+      ]
+    }
+  }
+}

--- a/test/cypress/fixtures/routeCalendarPanelInputTest.json
+++ b/test/cypress/fixtures/routeCalendarPanelInputTest.json
@@ -4,7 +4,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -19,7 +19,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "bicycle",
           "distanceMeters": 10000,
@@ -33,7 +33,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -48,7 +48,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "bicycle",
           "distanceMeters": 10000,
@@ -62,7 +62,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -77,7 +77,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
@@ -91,7 +91,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -106,7 +106,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
@@ -120,7 +120,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -135,7 +135,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "hromadna",
           "distanceMeters": 8000,
@@ -149,7 +149,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -164,7 +164,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "hromadna",
           "distanceMeters": 8000,
@@ -178,7 +178,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -193,7 +193,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "telecommute",
           "distanceMeters": 0,
@@ -207,7 +207,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -222,7 +222,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "telecommute",
           "distanceMeters": 0,
@@ -236,7 +236,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -251,7 +251,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
@@ -265,7 +265,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -280,7 +280,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
@@ -294,7 +294,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -309,7 +309,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "no_work",
           "distanceMeters": 0,
@@ -323,7 +323,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -338,7 +338,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "no_work",
           "distanceMeters": 0,
@@ -352,7 +352,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "10.00",
         "transport": "bicycle",
@@ -367,7 +367,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
@@ -381,7 +381,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "10.00",
         "transport": "bicycle",
@@ -396,7 +396,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
@@ -410,7 +410,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "by_other_vehicle",
@@ -425,7 +425,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
@@ -439,7 +439,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "14.00",
         "transport": "by_foot",
@@ -454,7 +454,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
@@ -468,7 +468,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "toWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -477,7 +477,7 @@
       },
       {
         "id": "2",
-        "date": "2025-3-28",
+        "date": "2025-05-25",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -492,14 +492,14 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
           "sourceApplication": "RTWBB"
         },
         {
-          "trip_date": "2025-3-28",
+          "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -3470,3 +3470,52 @@ Cypress.Commands.add(
     });
   },
 );
+
+/**
+ * Intercept post trips API
+ * Provides `@postTrips` alias
+ * @param {Config} config - App global config
+ * @param {I18n|String} i18n - i18n instance or locale lang string e.g. en
+ * @param {Object} responseBody - Override default response body
+ * @param {Number} responseStatusCode - Override default response HTTP status code
+ */
+Cypress.Commands.add(
+  'interceptPostTripsApi',
+  (config, i18n, responseBody, responseStatusCode = null) => {
+    const { apiBase, apiDefaultLang, urlApiTrips } = config;
+    const apiBaseUrl = getApiBaseUrlWithLang(
+      null,
+      apiBase,
+      apiDefaultLang,
+      i18n,
+    );
+    const urlApiTripsLocalized = `${apiBaseUrl}${urlApiTrips}`;
+
+    cy.intercept('POST', urlApiTripsLocalized, {
+      statusCode: responseStatusCode || httpSuccessfullStatus,
+      body: responseBody,
+    }).as('postTrips');
+  },
+);
+
+/**
+ * Wait for post trips API call and compare request/response object
+ * Wait for `@postTrips` intercept
+ * @param {Object} requestBody - Expected request body to compare against
+ * @param {Object} responseBody - Expected response body to compare against
+ */
+Cypress.Commands.add(
+  'waitForPostTripsApi',
+  (requestBody, responseBody = null) => {
+    cy.wait('@postTrips').then(({ request, response }) => {
+      // verify authorization header
+      expect(request.headers.authorization).to.include(bearerTokeAuth);
+      // verify request body
+      expect(request.body).to.deep.equal(requestBody);
+      // verify response body
+      if (responseBody) {
+        expect(response.body).to.deep.equal(responseBody);
+      }
+    });
+  },
+);


### PR DESCRIPTION
Add ability to log routes from Calendar view with useApiPostTrips composable.

* Add `data-date="timestamp.date"` attribute to calendar dates for easier targeting in tests.
* Add convert function from `RouteItem[]` to `TripPostPayload` in `tripsAdapter`.
* Add composable function for logging routes.
* Use the new composable function in `RouteCalendarPanel.vue` to log routes with the `'input-number'` method.
* Add `trips` store action to merge saved routes from API response with currently loaded routes.
* Add `RouteCalendarPanel` component tests for different configurations of inputs.
* Add E2E test to check that routes are updated in UI after saving.