### PR TITLE
src/composables: set default transport type for routes in list view to null (do not use default value)

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
+      // https: true
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true
+      https: true,
       open: true, // opens browser window automatically
     },
 

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -54,7 +54,7 @@ describe('<RouteCalendarPanel>', () => {
     coreTests();
   });
 
-  context('desktop - empty route', () => {
+  context('desktop - route to work with empty data (default)', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       cy.fixture('routeCalendarEmptyToWork').then((routeEmptyToWork) => {
@@ -76,7 +76,7 @@ describe('<RouteCalendarPanel>', () => {
     unloggedRouteTests();
   });
 
-  context('desktop - empty route', () => {
+  context('desktop - route from work with empty data (default)', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       cy.fixture('routeCalendarEmptyFromWork').then((routeEmptyFromWork) => {

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -54,7 +54,7 @@ describe('<RouteCalendarPanel>', () => {
     coreTests();
   });
 
-  context('desktop - route to work with empty data (default)', () => {
+  context('desktop - route to work unlogged (default data)', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       cy.fixture('routeCalendarEmptyToWork').then((routeEmptyToWork) => {
@@ -76,7 +76,7 @@ describe('<RouteCalendarPanel>', () => {
     unloggedRouteTests();
   });
 
-  context('desktop - route from work with empty data (default)', () => {
+  context('desktop - route from work unlogged (default data)', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
       cy.fixture('routeCalendarEmptyFromWork').then((routeEmptyFromWork) => {

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -5,6 +5,8 @@ import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import testData from '../../../test/cypress/fixtures/routeCalendarPanelInputTest.json';
+import { TransportType } from 'src/components/types/Route';
+
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
 
@@ -211,6 +213,9 @@ function coreTests() {
         );
       cy.dataCy(selectorSectionDistance).should('be.visible');
       cy.dataCy(selectorSectionTransport).should('be.visible');
+      cy.dataCy(selectorRouteCalendarPanel)
+        .find(`[data-value="${TransportType.bike}"]`)
+        .click();
       cy.dataCy(selectorRouteInputDistance).should('be.visible');
       cy.dataCy(selectorRouteInputTransportType).should('be.visible');
     });

--- a/src/components/__tests__/RouteCalendarPanel.cy.js
+++ b/src/components/__tests__/RouteCalendarPanel.cy.js
@@ -5,7 +5,6 @@ import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import testData from '../../../test/cypress/fixtures/routeCalendarPanelInputTest.json';
-import { TransportType } from 'src/components/types/Route';
 
 const { getPaletteColor } = colors;
 const grey10 = getPaletteColor('grey-10');
@@ -58,8 +57,30 @@ describe('<RouteCalendarPanel>', () => {
   context('desktop - empty route', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
-      cy.fixture('routeEmptyToWork').then((routeEmptyToWork) => {
+      cy.fixture('routeCalendarEmptyToWork').then((routeEmptyToWork) => {
         const routes = [routeEmptyToWork];
+        cy.wrap(routes).as('routes');
+        cy.mount(RouteCalendarPanel, {
+          props: {
+            modelValue: true,
+            routes,
+          },
+        });
+      });
+      // setup store with commute modes
+      cy.setupTripsStoreWithCommuteModes(useTripsStore);
+      cy.viewport('macbook-16');
+    });
+
+    coreTests();
+    unloggedRouteTests();
+  });
+
+  context('desktop - empty route', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.fixture('routeCalendarEmptyFromWork').then((routeEmptyFromWork) => {
+        const routes = [routeEmptyFromWork];
         cy.wrap(routes).as('routes');
         cy.mount(RouteCalendarPanel, {
           props: {
@@ -213,9 +234,6 @@ function coreTests() {
         );
       cy.dataCy(selectorSectionDistance).should('be.visible');
       cy.dataCy(selectorSectionTransport).should('be.visible');
-      cy.dataCy(selectorRouteCalendarPanel)
-        .find(`[data-value="${TransportType.bike}"]`)
-        .click();
       cy.dataCy(selectorRouteInputDistance).should('be.visible');
       cy.dataCy(selectorRouteInputTransportType).should('be.visible');
     });

--- a/src/components/__tests__/RouteItemEdit.cy.js
+++ b/src/components/__tests__/RouteItemEdit.cy.js
@@ -102,6 +102,83 @@ describe('<RouteItemEdit>', () => {
     testLabelFromWork();
   });
 
+  context('route to work - unlogged', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.fixture('routeListItemEmpty').then((routes) => {
+        cy.mount(RouteItemEdit, {
+          props: {
+            route: routes.toWork,
+            displayLabel: true,
+          },
+        });
+        // setup store with commute modes
+        cy.setupTripsStoreWithCommuteModes(useTripsStore);
+        cy.viewport('macbook-16');
+      });
+    });
+
+    it('renders route with direction label', () => {
+      cy.dataCy('label-direction')
+        .should('be.visible')
+        .and('contain', i18n.global.t('routes.labelDirectionToWork'));
+    });
+
+    it('renders the transport type input', () => {
+      cy.dataCy('section-transport')
+        .should('be.visible')
+        .and('contain', i18n.global.t('routes.transport.unknown'))
+        .within(() => {
+          cy.fixture('apiGetCommuteMode').then((commuteModes) => {
+            cy.dataCy('button-toggle-transport')
+              .should('be.visible')
+              .and('have.length', commuteModes.results.length);
+          });
+        });
+    });
+  });
+
+  context('route from work - unlogged', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia());
+      cy.fixture('routeListItemEmpty').then((routes) => {
+        cy.mount(RouteItemEdit, {
+          props: {
+            route: routes.fromWork,
+            displayLabel: true,
+          },
+        });
+        // setup store with commute modes
+        cy.setupTripsStoreWithCommuteModes(useTripsStore);
+        cy.viewport('macbook-16');
+      });
+    });
+
+    it('renders route with direction label', () => {
+      cy.dataCy('label-direction')
+        .should('be.visible')
+        .and('contain', i18n.global.t('routes.labelDirectionFromWork'));
+    });
+
+    it('renders the transport type input - no selected transport type', () => {
+      cy.dataCy('section-transport')
+        .should('be.visible')
+        .and('contain', i18n.global.t('routes.transport.unknown'))
+        .within(() => {
+          cy.fixture('apiGetCommuteMode').then((commuteModes) => {
+            // all buttons are rendered
+            cy.dataCy('button-toggle-transport')
+              .should('be.visible')
+              .and('have.length', commuteModes.results.length);
+            // no button is selected
+            cy.dataCy('button-toggle-transport')
+              .find('.q-avatar')
+              .should('not.have.class', 'bg-secondary');
+          });
+        });
+    });
+  });
+
   context('mobile', () => {
     beforeEach(() => {
       setActivePinia(createPinia());

--- a/src/components/__tests__/RouteItemEdit.cy.js
+++ b/src/components/__tests__/RouteItemEdit.cy.js
@@ -124,15 +124,20 @@ describe('<RouteItemEdit>', () => {
         .and('contain', i18n.global.t('routes.labelDirectionToWork'));
     });
 
-    it('renders the transport type input', () => {
+    it('renders the transport type input - no selected transport type', () => {
       cy.dataCy('section-transport')
         .should('be.visible')
         .and('contain', i18n.global.t('routes.transport.unknown'))
         .within(() => {
           cy.fixture('apiGetCommuteMode').then((commuteModes) => {
+            // all buttons are rendered
             cy.dataCy('button-toggle-transport')
               .should('be.visible')
               .and('have.length', commuteModes.results.length);
+            // no button is selected
+            cy.dataCy('button-toggle-transport')
+              .find('.q-avatar')
+              .should('not.have.class', 'bg-secondary');
           });
         });
     });

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -176,9 +176,12 @@ function coreTests() {
     // check initial state for 2nd route
     cy.dataCy(selectorRouteListItem)
       .eq(1)
-      .find(`[data-value="${TransportType.none}"]`)
-      .find('.q-avatar')
-      .should('have.class', 'bg-secondary');
+      .within(() => {
+        // no button is selected
+        cy.dataCy('button-toggle-transport')
+          .find('.q-avatar')
+          .should('not.have.class', 'bg-secondary');
+      });
     // introduce a change
     cy.dataCy(selectorRouteListItem)
       .first()
@@ -215,18 +218,14 @@ function coreTests() {
       'contain',
       i18n.global.tc('routes.buttonSaveChangesCount', 2, { count: 2 }),
     );
-    // revert changes
+    // revert 1 change (other change cannot be reverted)
     cy.dataCy(selectorRouteListItem)
       .first()
       .find(`[data-value="${TransportType.bike}"]`)
       .click();
-    cy.dataCy(selectorRouteListItem)
-      .eq(1)
-      .find(`[data-value="${TransportType.none}"]`)
-      .click();
     cy.dataCy(selectorButtonSave).should(
       'contain',
-      i18n.global.tc('routes.buttonSaveChangesCount', 0, { count: 0 }),
+      i18n.global.tc('routes.buttonSaveChangesCount', 1, { count: 1 }),
     );
     // test changing distance value by deleting '0'
     cy.dataCy(selectorRouteListItem)
@@ -239,7 +238,7 @@ function coreTests() {
       .blur();
     cy.dataCy(selectorButtonSave).should(
       'contain',
-      i18n.global.tc('routes.buttonSaveChangesCount', 1, { count: 1 }),
+      i18n.global.tc('routes.buttonSaveChangesCount', 2, { count: 2 }),
     );
     // reset distance value
     cy.dataCy(selectorRouteListItem)

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -3,7 +3,6 @@ import { date } from 'quasar';
 import RoutesCalendar from 'components/routes/RoutesCalendar.vue';
 import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
-import { TransportType } from 'src/components/types/Route';
 import { useChallengeStore } from 'src/stores/challenge';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -3,6 +3,7 @@ import { date } from 'quasar';
 import RoutesCalendar from 'components/routes/RoutesCalendar.vue';
 import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
+import { TransportType } from 'src/components/types/Route';
 import { useChallengeStore } from 'src/stores/challenge';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
@@ -478,9 +479,6 @@ function coreTests() {
       );
     cy.dataCy(selectorRouteCalendarPanel)
       .find(dataSelectorInputTransportType)
-      .should('be.visible');
-    cy.dataCy(selectorRouteCalendarPanel)
-      .find(dataSelectorRouteInputDistance)
       .should('be.visible');
     cy.get(classSelectorCurrentDay).find(dataSelectorItemFromWork).click();
     cy.dataCy(selectorRouteCalendarPanel)

--- a/src/components/routes/CalendarItemDisplay.vue
+++ b/src/components/routes/CalendarItemDisplay.vue
@@ -90,7 +90,7 @@ export default defineComponent({
      * Routes with transport type `none` are displayed as empty.
      */
     const isLogged = computed((): boolean => {
-      return !!route.value?.id && route.value?.transport !== TransportType.none;
+      return !!route.value?.id && route.value?.transport !== null;
     });
 
     const { getRouteDistance, getRouteIcon } = useRoutes();

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -96,10 +96,11 @@ export default defineComponent({
 
     // Determines if save button should be disabled.
     const isSaveBtnDisabled = computed((): boolean => {
+      const noTransport = transportType.value === null;
       const noRoutes = routesCount.value === 0;
       const noDistance =
         isShownDistance.value && distance.value === defaultDistanceZero;
-      return noRoutes || noDistance || isLoading.value;
+      return noRoutes || noDistance ||  noTransport || isLoading.value;
     });
 
     /**

--- a/src/components/routes/RouteInputTransportType.vue
+++ b/src/components/routes/RouteInputTransportType.vue
@@ -22,7 +22,7 @@
  */
 
 // libraries
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, PropType } from 'vue';
 
 // composables
 import { useRoutes } from '../../composables/useRoutes';
@@ -40,7 +40,7 @@ export default defineComponent({
   name: 'RouteInputTransportType',
   props: {
     modelValue: {
-      type: String as () => TransportType | null,
+      type: [String, null] as PropType<TransportType | null>,
       required: true,
     },
     horizontal: {
@@ -65,9 +65,6 @@ export default defineComponent({
 
     const transport = computed<TransportType | null>({
       get: (): TransportType | null => {
-        if (!props.modelValue) {
-          return null;
-        }
         return props.modelValue;
       },
       set: (value: TransportType | null): void => {

--- a/src/components/routes/RouteInputTransportType.vue
+++ b/src/components/routes/RouteInputTransportType.vue
@@ -63,14 +63,14 @@ export default defineComponent({
       }));
     });
 
-    const transport = computed({
-      get: (): TransportType => {
+    const transport = computed<TransportType | null>({
+      get: (): TransportType | null => {
         if (!props.modelValue) {
-          return TransportType.bike;
+          return null;
         }
         return props.modelValue;
       },
-      set: (value: TransportType): void => {
+      set: (value: TransportType | null): void => {
         emit('update:modelValue', value);
       },
     });

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -120,8 +120,19 @@ export default defineComponent({
       const distanceNewFormatted =
         localizedFloatNumStrToFloatNumber(distanceNew);
 
+      // initial distance is string so we need to parse it to float
+      let distanceInitialFormattedFloat = 0;
+      try {
+        distanceInitialFormattedFloat = parseFloat(
+          routeStateDefault.value?.distance,
+        );
+      } catch (error) {
+        logger?.error(
+          `Error in parseFloat distance <${routeStateDefault.value?.distance}>, ${error}`,
+        );
+      }
       // compare new distance with the distance from the store
-      const dirty = String(distanceNewFormatted) !== routeStateDefault.value?.distance;
+      const dirty = distanceNewFormatted !== distanceInitialFormattedFloat;
       emit('update:route', {
         ...props.route,
         distance: distanceNew,

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -36,7 +36,11 @@ import { useLogRoutes } from '../../composables/useLogRoutes';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // enums
-import { TransportDirection, TransportType } from '../types/Route';
+import {
+  TransportDirection,
+  TransportType,
+  RouteInputType,
+} from '../types/Route';
 
 // stores
 import { useTripsStore } from 'src/stores/trips';
@@ -78,7 +82,7 @@ export default defineComponent({
       );
       if (!storeRoute) {
         return {
-          transport: TransportType.none,
+          transport: null,
           distance: defaultDistanceZero,
           inputType: 'input-number',
         };
@@ -97,7 +101,7 @@ export default defineComponent({
     const { action, distance, transportType, isShownDistance } =
       useLogRoutes(routes);
 
-    const onUpdateAction = (actionNew: string): void => {
+    const onUpdateAction = (actionNew: RouteInputType): void => {
       action.value = actionNew;
     };
 
@@ -117,7 +121,7 @@ export default defineComponent({
         localizedFloatNumStrToFloatNumber(distanceNew);
 
       // compare new distance with the distance from the store
-      const dirty = distanceNewFormatted !== routeStateDefault.value?.distance;
+      const dirty = String(distanceNewFormatted) !== routeStateDefault.value?.distance;
       emit('update:route', {
         ...props.route,
         distance: distanceNew,

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -130,7 +130,7 @@ export default defineComponent({
        *  `tripsAdapter` object `toRouteItem()` func,
        *   inner `distance()` func which convert route distance (REST API)
        *   INTEGER NUMBER type (meter unit) into FLOAT NUMBER STRING (km unit)
-       *   1500 (m) to '1.50' (km), according localized number format var
+       *   1500 (m) to '1.50' (km), according localized (en lang) number format var
        *   numberFormatsAllLocales, routeDistanceDecimalNumber key inside
        *   app global config ride_to_work_by_bike_config.toml file.
        * )

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -120,19 +120,22 @@ export default defineComponent({
       const distanceNewFormatted =
         localizedFloatNumStrToFloatNumber(distanceNew);
 
-      // initial distance is string so we need to parse it to float
-      let distanceInitialFormattedFloat = 0;
-      try {
-        distanceInitialFormattedFloat = parseFloat(
-          routeStateDefault.value?.distance,
-        );
-      } catch (error) {
-        logger?.error(
-          `Error in parseFloat distance <${routeStateDefault.value?.distance}>, ${error}`,
-        );
-      }
-      // compare new distance with the distance from the store
-      const dirty = distanceNewFormatted !== distanceInitialFormattedFloat;
+      /**
+       * Compare new distance with FLOAT NUMBER TYPE with
+       * the distance from the store with FLOAT NUMBER STRING TYPE
+       *
+       * Usage '!=' provide type conversion
+       *
+       * (see ./src/components/adapters/tripsAdapter.ts
+       *  `tripsAdapter` object `toRouteItem()` func,
+       *   inner `distance()` func which convert route distance (REST API)
+       *   INTEGER NUMBER type (meter unit) into FLOAT NUMBER STRING (km unit)
+       *   1500 (m) to '1.50' (km), according localized number format var
+       *   numberFormatsAllLocales, routeDistanceDecimalNumber key inside
+       *   app global config ride_to_work_by_bike_config.toml file.
+       * )
+       */
+      const dirty = distanceNewFormatted != routeStateDefault.value?.distance;
       emit('update:route', {
         ...props.route,
         distance: distanceNew,

--- a/src/components/types/Route.ts
+++ b/src/components/types/Route.ts
@@ -29,7 +29,7 @@ export type RouteItem = {
   direction: TransportDirection;
   dirty?: boolean;
   distance: string;
-  transport: TransportType;
+  transport: TransportType | null;
   inputType?: RouteInputType;
   routeFeature: RouteFeature | null;
 };

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -114,7 +114,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
    * @return {boolean}
    */
   function dayHasToWorkRoute(day: RouteDay | null): boolean {
-    return !!day?.toWork && day?.toWork?.transport !== TransportType.none;
+    return !!day?.toWork && day?.toWork?.transport !== null;
   }
 
   /**
@@ -123,7 +123,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
    * @return {boolean}
    */
   function dayHasFromWorkRoute(day: RouteDay | null): boolean {
-    return !!day?.fromWork && day?.fromWork?.transport !== TransportType.none;
+    return !!day?.fromWork && day?.fromWork?.transport !== null;
   }
 
   /**

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -5,7 +5,7 @@ import { computed, ref } from 'vue';
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // enums
-import { TransportDirection, TransportType } from '../components/types/Route';
+import { TransportDirection } from '../components/types/Route';
 
 // types
 import type { Ref } from 'vue';
@@ -68,7 +68,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
             id: '',
             date: activeRoute.timestamp.date,
             direction: activeRoute.direction,
-            transport: TransportType.bike,
+            transport: null,
             distance: defaultDistanceZero,
             inputType: 'input-number',
             routeFeature: null,

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -5,7 +5,7 @@ import { computed, ref } from 'vue';
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // enums
-import { TransportDirection } from '../components/types/Route';
+import { TransportDirection, TransportType } from '../components/types/Route';
 
 // types
 import type { Ref } from 'vue';
@@ -68,7 +68,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
             id: '',
             date: activeRoute.timestamp.date,
             direction: activeRoute.direction,
-            transport: null,
+            transport: TransportType.bike,
             distance: defaultDistanceZero,
             inputType: 'input-number',
             routeFeature: null,

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -33,6 +33,7 @@ export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
       distance.value = routes[0].distance || defaultDistanceZero;
       transportType.value = routes[0].transport || null;
     } else {
+      // multiple routes = unlogged - set default entry values
       action.value = 'input-number';
       distance.value = defaultDistanceZero;
       transportType.value = TransportType.bike;

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -35,7 +35,7 @@ export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
     } else {
       action.value = 'input-number';
       distance.value = defaultDistanceZero;
-      transportType.value = null;
+      transportType.value = TransportType.bike;
     }
   };
 

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -20,7 +20,7 @@ export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
 
   const action = ref<RouteInputType>('input-number');
   const distance = ref<string>(defaultDistanceZero);
-  const transportType = ref<TransportType>(TransportType.bike);
+  const transportType = ref<TransportType | null>(null);
 
   /**
    * Sets the panel input data based on the provided routes.
@@ -31,11 +31,11 @@ export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
     if (routes.length === 1) {
       action.value = routes[0].inputType || 'input-number';
       distance.value = routes[0].distance || defaultDistanceZero;
-      transportType.value = routes[0].transport || TransportType.bike;
+      transportType.value = routes[0].transport || null;
     } else {
       action.value = 'input-number';
       distance.value = defaultDistanceZero;
-      transportType.value = TransportType.bike;
+      transportType.value = null;
     }
   };
 

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -52,7 +52,7 @@ export const useRoutes = () => {
    * @param {TransportType} transport - The transport type.
    * @return {string} - The transport label.
    */
-  const getTransportLabel = (transport: TransportType): string => {
+  const getTransportLabel = (transport: TransportType | null): string => {
     if (!transport) {
       return i18n.global.t('routes.transport.unknown');
     }

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -256,7 +256,7 @@ export const useRoutes = () => {
             : ({
                 id: `${date.formatDate(currentDate, routeDateFormat)}-${TransportDirection.fromWork}`,
                 date: date.formatDate(currentDate, routeDateFormat),
-                transport: TransportType.none,
+                transport: null,
                 distance: defaultDistanceZero,
                 direction: TransportDirection.fromWork,
                 dirty: false,
@@ -267,7 +267,7 @@ export const useRoutes = () => {
             : ({
                 id: `${date.formatDate(currentDate, routeDateFormat)}-${TransportDirection.toWork}`,
                 date: date.formatDate(currentDate, routeDateFormat),
-                transport: TransportType.none,
+                transport: null,
                 distance: defaultDistanceZero,
                 direction: TransportDirection.toWork,
                 dirty: false,

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -28,7 +28,7 @@ export const useRoutes = () => {
    * @param {TransportType} transport - The transport type.
    * @return {string} - The icon name.
    */
-  const getRouteIcon = (transport: TransportType): string => {
+  const getRouteIcon = (transport: TransportType | null): string => {
     switch (transport) {
       case TransportType.car:
         return `svguse:${customSVGIconsFilePath}#lucide-car-front`;

--- a/test/cypress/fixtures/routeCalendarEmptyFromWork.json
+++ b/test/cypress/fixtures/routeCalendarEmptyFromWork.json
@@ -1,0 +1,8 @@
+{
+  "id": "2024-08-14-fromWork",
+  "date": "2024-08-14",
+  "transport": "bicycle",
+  "distance": "0.00",
+  "direction": "fromWork",
+  "dirty": false
+}

--- a/test/cypress/fixtures/routeCalendarEmptyToWork.json
+++ b/test/cypress/fixtures/routeCalendarEmptyToWork.json
@@ -1,0 +1,8 @@
+{
+  "id": "2024-08-14-toWork",
+  "date": "2024-08-14",
+  "transport": "bicycle",
+  "distance": "0.00",
+  "direction": "toWork",
+  "dirty": false
+}

--- a/test/cypress/fixtures/routeCalendarInputTest.json
+++ b/test/cypress/fixtures/routeCalendarInputTest.json
@@ -14,7 +14,7 @@
           "trip_date": "2025-05-27",
           "direction": "trip_to",
           "commuteMode": "bicycle",
-          "sourceApplication": "RTWBB",
+          "sourceApplication": "RTWBB web app",
           "distanceMeters": 100,
           "durationSeconds": null,
           "sourceId": null,

--- a/test/cypress/fixtures/routeCalendarPanelInputTest.json
+++ b/test/cypress/fixtures/routeCalendarPanelInputTest.json
@@ -23,7 +23,7 @@
           "direction": "trip_to",
           "commuteMode": "bicycle",
           "distanceMeters": 10000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -52,7 +52,7 @@
           "direction": "trip_from",
           "commuteMode": "bicycle",
           "distanceMeters": 10000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -81,7 +81,7 @@
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -110,7 +110,7 @@
           "direction": "trip_from",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -139,7 +139,7 @@
           "direction": "trip_to",
           "commuteMode": "hromadna",
           "distanceMeters": 8000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -168,7 +168,7 @@
           "direction": "trip_from",
           "commuteMode": "hromadna",
           "distanceMeters": 8000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -197,7 +197,7 @@
           "direction": "trip_to",
           "commuteMode": "telecommute",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -226,7 +226,7 @@
           "direction": "trip_from",
           "commuteMode": "telecommute",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -255,7 +255,7 @@
           "direction": "trip_to",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -284,7 +284,7 @@
           "direction": "trip_from",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -313,7 +313,7 @@
           "direction": "trip_to",
           "commuteMode": "no_work",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -342,7 +342,7 @@
           "direction": "trip_from",
           "commuteMode": "no_work",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -371,7 +371,7 @@
           "direction": "trip_to",
           "commuteMode": "by_other_vehicle",
           "distanceMeters": 0,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -400,7 +400,7 @@
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -429,7 +429,7 @@
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -458,7 +458,7 @@
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 5000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }
@@ -496,14 +496,14 @@
           "direction": "trip_to",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         },
         {
           "trip_date": "2025-05-25",
           "direction": "trip_from",
           "commuteMode": "by_foot",
           "distanceMeters": 15000,
-          "sourceApplication": "RTWBB"
+          "sourceApplication": "RTWBB web app"
         }
       ]
     }

--- a/test/cypress/fixtures/routeEmptyFromWork.json
+++ b/test/cypress/fixtures/routeEmptyFromWork.json
@@ -1,7 +1,7 @@
 {
   "id": "2024-08-14-fromWork",
   "date": "2024-08-14",
-  "transport": "bicycle",
+  "transport": null,
   "distance": "0.00",
   "direction": "fromWork",
   "dirty": false

--- a/test/cypress/fixtures/routeEmptyToWork.json
+++ b/test/cypress/fixtures/routeEmptyToWork.json
@@ -1,7 +1,7 @@
 {
   "id": "2024-08-14-toWork",
   "date": "2024-08-14",
-  "transport": "bicycle",
+  "transport": null,
   "distance": "0.00",
   "direction": "toWork",
   "dirty": false

--- a/test/cypress/fixtures/routeListItemEmpty.json
+++ b/test/cypress/fixtures/routeListItemEmpty.json
@@ -1,0 +1,16 @@
+{
+  "toWork": {
+    "id": "",
+    "date": "2024-10-01",
+    "transport": null,
+    "distance": "0",
+    "direction": "toWork"
+  },
+  "fromWork": {
+    "id": "",
+    "date": "2024-10-01",
+    "transport": null,
+    "distance": "0",
+    "direction": "fromWork"
+  }
+}


### PR DESCRIPTION
Set default transport type for routes in list view to null (do not use default value `no_work`).

Issue: Currently, there is no distinguishing feature between logged `no_work` route, and unlogged route.

Set default `transport` for empty routes depending on the view:
- Calendar: unlogged routes in calendar have value `null` (visually empty box with "+" sign). For active routes that are passed to `RouteCalendarPanel`, set default to `bicycle` if not already logged (for easier entry - better UX).
- List: unlogged routes in list have value `null` (no selected transport button). In display list, this is signaled by "?" icon and "Not logged" label.

Additional changes:
- Update test fixtures to match the inputs for different route related components.
- Fix TS type errors where needed.