### PR TITLE
src/composables: enable Routes menu item when competition or entry phase starts

### DIFF
--- a/src/components/__tests__/DrawerMenu.cy.js
+++ b/src/components/__tests__/DrawerMenu.cy.js
@@ -209,7 +209,7 @@ describe('DrawerMenu', () => {
     it('renders routes item as disabled', () => {
       cy.dataCy(selectorDrawerMenuItem)
         .contains(i18n.global.t('drawerMenu.routes'))
-        .should('have.attr', 'disabled');
+        .should('have.class', 'disabled');
     });
   });
 
@@ -241,7 +241,7 @@ describe('DrawerMenu', () => {
     it('renders routes item as disabled', () => {
       cy.dataCy(selectorDrawerMenuItem)
         .contains(i18n.global.t('drawerMenu.routes'))
-        .should('not.have.attr', 'disabled');
+        .should('not.have.class', 'disabled');
     });
   });
 

--- a/src/components/__tests__/DrawerMenu.cy.js
+++ b/src/components/__tests__/DrawerMenu.cy.js
@@ -43,6 +43,7 @@ describe('DrawerMenu', () => {
           isUserOrganizationAdmin: false,
           isUserStaff: false,
           urlAdmin: rtwbbOldFrontendDjangoAdminUrl,
+          isEntryEnabled: true,
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -80,6 +81,7 @@ describe('DrawerMenu', () => {
           isUserOrganizationAdmin: true,
           isUserStaff: false,
           urlAdmin: rtwbbOldFrontendDjangoAdminUrl,
+          isEntryEnabled: true,
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -123,6 +125,7 @@ describe('DrawerMenu', () => {
           isUserOrganizationAdmin: false,
           isUserStaff: true,
           urlAdmin,
+          isEntryEnabled: true,
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -175,6 +178,70 @@ describe('DrawerMenu', () => {
             expect(resp.status).to.eq(httpSuccessfullStatus);
           });
         });
+    });
+  });
+
+  context('menu top - entry disabled', () => {
+    beforeEach(() => {
+      const urlAdmin = getApiBaseUrlWithLang(
+        null,
+        rtwbbOldFrontendDjangoAdminUrl,
+        defaultLocale,
+        i18n,
+      );
+      cy.wrap(
+        getMenuTop({
+          isUserOrganizationAdmin: false,
+          isUserStaff: true,
+          urlAdmin,
+          isEntryEnabled: false,
+        }),
+      ).then((menuTop) => {
+        cy.mount(DrawerMenu, {
+          props: {
+            items: menuTop,
+          },
+        });
+        cy.wrap(menuTop).as('menu');
+      });
+    });
+
+    it('renders routes item as disabled', () => {
+      cy.dataCy(selectorDrawerMenuItem)
+        .contains(i18n.global.t('drawerMenu.routes'))
+        .should('have.attr', 'disabled');
+    });
+  });
+
+  context('menu top - entry enabled', () => {
+    beforeEach(() => {
+      const urlAdmin = getApiBaseUrlWithLang(
+        null,
+        rtwbbOldFrontendDjangoAdminUrl,
+        defaultLocale,
+        i18n,
+      );
+      cy.wrap(
+        getMenuTop({
+          isUserOrganizationAdmin: false,
+          isUserStaff: true,
+          urlAdmin,
+          isEntryEnabled: true,
+        }),
+      ).then((menuTop) => {
+        cy.mount(DrawerMenu, {
+          props: {
+            items: menuTop,
+          },
+        });
+        cy.wrap(menuTop).as('menu');
+      });
+    });
+
+    it('renders routes item as disabled', () => {
+      cy.dataCy(selectorDrawerMenuItem)
+        .contains(i18n.global.t('drawerMenu.routes'))
+        .should('not.have.attr', 'disabled');
     });
   });
 

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -29,7 +29,11 @@ import { useMenu } from 'src/composables/useMenu';
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
+// enums
+import { PhaseType } from 'src/components/types/Challenge';
+
 // stores
+import { useChallengeStore } from 'src/stores/challenge';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
@@ -43,10 +47,20 @@ export default defineComponent({
   name: 'MobileBottomPanel',
   setup() {
     const registerChallengeStore = useRegisterChallengeStore();
+    const challengeStore = useChallengeStore();
     const isUserOrganizationAdmin = computed(
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
     const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
+    const isEntryPhase = computed(() => {
+      return challengeStore.getIsChallengeInPhase(PhaseType.entryEnabled);
+    });
+    const isCompetitionPhase = computed(() => {
+      return challengeStore.getIsChallengeInPhase(PhaseType.competition);
+    });
+    const isEntryEnabled = computed(() => {
+      return isEntryPhase.value || isCompetitionPhase.value;
+    });
     const { getMenuTop, getMenuBottom } = useMenu();
 
     const { mobileBottomPanelVisibleItems } = rideToWorkByBikeConfig;
@@ -71,6 +85,7 @@ export default defineComponent({
         isUserOrganizationAdmin: isUserOrganizationAdmin,
         isUserStaff,
         urlAdmin,
+        isEntryEnabled,
       });
     });
     const menuPanel = computed((): Link[] => {

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -17,16 +17,20 @@ export const useMenu = () => {
    *   isUserStaff - Whether the user is staff member
    * @param {ComputedRef<string> | string } urlAdmin - RTWBB old Django frontend
    *                                                   app admin URL
+   * @param {ComputedRef<boolean | null> | boolean | null}
+   *   isEntryEnabled - Whether the entry is enabled
    * @returns {Link[]} - Array of top menu items
    */
   const getMenuTop = ({
     isUserOrganizationAdmin,
     isUserStaff,
     urlAdmin,
+    isEntryEnabled,
   }: {
     isUserOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
     isUserStaff: ComputedRef<boolean | null> | boolean | null;
     urlAdmin: ComputedRef<string> | string;
+    isEntryEnabled: ComputedRef<boolean | null> | boolean | null;
   }): Link[] => {
     let menuTop: Link[] = [
       {
@@ -40,7 +44,7 @@ export const useMenu = () => {
         icon: 'svguse:icons/drawer_menu/icons.svg#lucide-route',
         name: 'routes',
         title: 'routes',
-        disabled: true,
+        disabled: !unref(isEntryEnabled),
       },
       {
         url: routesConf['results']['children']['fullPath'],

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -13,20 +13,22 @@ import FooterBar from 'components/global/FooterBar.vue';
 import MobileBottomPanel from 'components/global/MobileBottomPanel.vue';
 import UserSelect from 'components/global/UserSelect.vue';
 
-// routes config
-import { routesConf } from '../router/routes_conf';
-
 // composables
 import { useMenu } from 'src/composables/useMenu';
 
 // config
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
+import { routesConf } from '../router/routes_conf';
+
+// enums
+import { PhaseType } from '../components/types/Challenge';
 
 // types
 import type { Link } from 'components/types';
 import type { Logger } from 'components/types/Logger';
 
 // stores
+import { useChallengeStore } from 'src/stores/challenge';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // utils
@@ -57,6 +59,7 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     const route = useRoute();
     const registerChallengeStore = useRegisterChallengeStore();
+    const challengeStore = useChallengeStore();
 
     const isHomePage = computed(
       () => route.path === routesConf['home']['path'],
@@ -84,6 +87,15 @@ export default defineComponent({
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
     const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
+    const isEntryPhase = computed(() => {
+      return challengeStore.getIsChallengeInPhase(PhaseType.entryEnabled);
+    });
+    const isCompetitionPhase = computed(() => {
+      return challengeStore.getIsChallengeInPhase(PhaseType.competition);
+    });
+    const isEntryEnabled = computed(() => {
+      return isEntryPhase.value || isCompetitionPhase.value;
+    });
 
     const {
       urlRideToWorkByBikeOldFrontendDjangoApp,
@@ -104,6 +116,7 @@ export default defineComponent({
         isUserOrganizationAdmin,
         isUserStaff,
         urlAdmin,
+        isEntryEnabled,
       });
     });
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -121,20 +121,12 @@ const routes: RouteRecordRaw[] = [
     path: routesConf['routes']['path'],
     component: () => import('layouts/MainLayout.vue'),
     name: routesConf['routes']['children']['name'],
-    beforeEnter: (to, from, next) => {
-      // redirect going to the root routes path
-      if (to.path === routesConf['routes']['path']) {
-        const isLargeScreen = Screen.gt.sm;
-        if (isLargeScreen) {
-          // go to calendar view on large screens
-          next({ name: routesConf['routes_calendar']['children']['name'] });
-        } else {
-          // go to list view on mobile
-          next({ name: routesConf['routes_list']['children']['name'] });
-        }
-      } else {
-        next();
+    redirect: () => {
+      const isLargeScreen = Screen.gt.sm;
+      if (isLargeScreen) {
+        return { name: routesConf['routes_calendar']['children']['name'] };
       }
+      return { name: routesConf['routes_list']['children']['name'] };
     },
     children: [
       {

--- a/test/cypress/e2e/main_menu.spec.cy.js
+++ b/test/cypress/e2e/main_menu.spec.cy.js
@@ -24,8 +24,8 @@ describe('Profile page', () => {
         // alias i18n
         cy.window().should('have.property', 'i18n');
         cy.window().then((win) => {
+          // check if correct items are disabled
           test.menuItems.forEach((item) => {
-            // check if correct items are disabled
             cy.dataCy('q-drawer').within(() => {
               if (item.disabled) {
                 cy.dataCy('drawer-menu-item')
@@ -65,8 +65,8 @@ describe('Profile page', () => {
         // alias i18n
         cy.window().should('have.property', 'i18n');
         cy.window().then((win) => {
+          // check if correct items are disabled
           test.menuItems.forEach((item) => {
-            // check if correct items are disabled
             cy.dataCy('footer-panel').within(() => {
               if (item.disabled) {
                 cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))
@@ -81,7 +81,9 @@ describe('Profile page', () => {
               }
             });
           });
+          // open pop up menu
           cy.dataCy('footer-panel-menu-hamburger').click();
+          // check if correct items are disabled
           test.popUpItems.forEach((item) => {
             if (item.disabled) {
               cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))

--- a/test/cypress/e2e/main_menu.spec.cy.js
+++ b/test/cypress/e2e/main_menu.spec.cy.js
@@ -1,0 +1,102 @@
+import { routesConf } from '../../../src/router/routes_conf';
+import { defLocale } from '../../../src/i18n/def_locale';
+import testData from '../fixtures/mainMenuDisplayTest.json';
+import mobileTestData from '../fixtures/mobileMenuDisplayTest.json';
+
+describe('Profile page', () => {
+  context('desktop - challenge may', () => {
+    beforeEach(() => {
+      cy.viewport('macbook-16');
+      cy.task('getAppConfig', process).then((config) => {
+        // intercept this campaign API
+        cy.fixture('apiGetThisCampaignMay.json').then((campaign) => {
+          cy.interceptThisCampaignGetApi(config, defLocale, campaign);
+        });
+      });
+    });
+
+    testData.forEach((test) => {
+      it(`renders main menu - ${test.description}`, () => {
+        // set clock to entry enabled phase start date
+        cy.clock(new Date(test.currentDate), ['Date']);
+        // visit home page
+        cy.visit('#' + routesConf['home']['children']['fullPath']);
+        // alias i18n
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          test.menuItems.forEach((item) => {
+            // check if correct items are disabled
+            cy.dataCy('q-drawer').within(() => {
+              if (item.disabled) {
+                cy.dataCy('drawer-menu-item')
+                  .contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                  .should('be.visible')
+                  .and('have.class', 'disabled');
+              } else {
+                cy.dataCy('drawer-menu-item')
+                  .contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                  .should('be.visible')
+                  .and('not.have.class', 'disabled');
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+
+  context('mobile - challenge may', () => {
+    beforeEach(() => {
+      cy.viewport('iphone-6');
+      cy.task('getAppConfig', process).then((config) => {
+        // intercept this campaign API
+        cy.fixture('apiGetThisCampaignMay.json').then((campaign) => {
+          cy.interceptThisCampaignGetApi(config, defLocale, campaign);
+        });
+      });
+    });
+
+    mobileTestData.forEach((test) => {
+      it(`renders main menu - ${test.description}`, () => {
+        // set clock to entry enabled phase start date
+        cy.clock(new Date(test.currentDate), ['Date']);
+        // visit home page
+        cy.visit('#' + routesConf['home']['children']['fullPath']);
+        // alias i18n
+        cy.window().should('have.property', 'i18n');
+        cy.window().then((win) => {
+          test.menuItems.forEach((item) => {
+            // check if correct items are disabled
+            cy.dataCy('footer-panel').within(() => {
+              if (item.disabled) {
+                cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                  .closest('.q-item')
+                  .should('be.visible')
+                  .and('have.class', 'disabled');
+              } else {
+                cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                  .closest('.q-item')
+                  .should('be.visible')
+                  .and('not.have.class', 'disabled');
+              }
+            });
+          });
+          cy.dataCy('footer-panel-menu-hamburger').click();
+          test.popUpItems.forEach((item) => {
+            if (item.disabled) {
+              cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                .closest('.q-item')
+                .should('exist')
+                .and('have.class', 'disabled');
+            } else {
+              cy.contains(win.i18n.global.t(`drawerMenu.${item.title}`))
+                .closest('.q-item')
+                .should('exist')
+                .and('not.have.class', 'disabled');
+            }
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/cypress/fixtures/apiGetThisCampaignMay.json
+++ b/test/cypress/fixtures/apiGetThisCampaignMay.json
@@ -13,7 +13,7 @@
         {
           "phase_type": "competition",
           "date_from": "2025-05-01",
-          "date_to": "2025-05-31"
+          "date_to": "2025-06-01"
         },
         {
           "phase_type": "entry_enabled",

--- a/test/cypress/fixtures/mainMenuDisplayTest.json
+++ b/test/cypress/fixtures/mainMenuDisplayTest.json
@@ -1,0 +1,152 @@
+[
+  {
+    "description": "challenge may - before entry enabled phase",
+    "currentDate": "2025-04-30",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": true
+      },
+      {
+        "title": "results",
+        "disabled": true
+      },
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - entry enabled phase 1st day",
+    "currentDate": "2025-05-01",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      },
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - competition phase last day",
+    "currentDate": "2025-06-01",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      },
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - entry enabled phase last day",
+    "currentDate": "2025-06-03",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      },
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - after entry enabled phase",
+    "currentDate": "2025-06-04",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": true
+      },
+      {
+        "title": "results",
+        "disabled": true
+      },
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  }
+]

--- a/test/cypress/fixtures/mobileMenuDisplayTest.json
+++ b/test/cypress/fixtures/mobileMenuDisplayTest.json
@@ -1,0 +1,162 @@
+[
+  {
+    "description": "challenge may - before entry enabled phase",
+    "currentDate": "2025-04-30",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": true
+      },
+      {
+        "title": "results",
+        "disabled": true
+      }
+    ],
+    "popUpItems": [
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - entry enabled phase 1st day",
+    "currentDate": "2025-05-01",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      }
+    ],
+    "popUpItems": [
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - competition phase last day",
+    "currentDate": "2025-06-01",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      }
+    ],
+    "popUpItems": [
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - entry enabled phase last day",
+    "currentDate": "2025-06-03",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": false
+      },
+      {
+        "title": "results",
+        "disabled": true
+      }
+    ],
+    "popUpItems": [
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  },
+  {
+    "description": "challenge may - after entry enabled phase",
+    "currentDate": "2025-06-04",
+    "menuItems": [
+      {
+        "title": "home",
+        "disabled": false
+      },
+      {
+        "title": "routes",
+        "disabled": true
+      },
+      {
+        "title": "results",
+        "disabled": true
+      }
+    ],
+    "popUpItems": [
+      {
+        "title": "discounts",
+        "disabled": false
+      },
+      {
+        "title": "profile",
+        "disabled": false
+      },
+      {
+        "title": "donate",
+        "disabled": false
+      }
+    ]
+  }
+]

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2797,6 +2797,7 @@ Cypress.Commands.add(
         isUserOrganizationAdmin,
         isUserStaff,
         urlAdmin,
+        isEntryEnabled: true,
       }),
     ).then((menuTop) => {
       cy.wrap(getMenuBottom(urlDonate)).then((menuBottom) => {

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -156,6 +156,7 @@ export const testDesktopSidebar = (): void => {
           isUserOrganizationAdmin: false,
           isUserStaff: false,
           urlAdmin,
+          isEntryEnabled: true,
         }).length > 0
       ) {
         cy.dataCy(selectorDrawerMenuTop).should('be.visible');


### PR DESCRIPTION
Programmatically enable Routes menu item when `competition` or `entry_enabled` phase starts.

* Add `isEntryEnabled` as a parameter for `getMenuTop` function.
* Use the parameter in `DrawerMenu` and `MobileBottomPanel`.
* Add E2E test which checks the disabled state of menu items depending on active phase.

Additionally, update the setup for `routes.ts` route redirect:
Issue: In current state, 1st click on "Routes" menu item redirects to calendar, but second click goes to the empty `/routes` page.
The `redirect` setting ensure that user is always redirected to one of the children pages.