### PR TITLE
test/cypress/fixtures: remove mobile app link from the home page panel

### DIFF
--- a/test/cypress/fixtures/usefulLinks.json
+++ b/test/cypress/fixtures/usefulLinks.json
@@ -13,10 +13,5 @@
     "id": "project-code",
     "title": "index.menuLinks.projectCode",
     "icon": "mdi-github"
-  },
-  {
-    "id": "mobile-app",
-    "title": "index.menuLinks.mobileApp",
-    "icon": "smartphone"
   }
 ]

--- a/test/cypress/fixtures/usefulLinksMobileApp.json
+++ b/test/cypress/fixtures/usefulLinksMobileApp.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "auto-mat",
+    "title": "index.menuLinks.autoMat",
+    "icon": "link"
+  },
+  {
+    "id": "support",
+    "title": "index.menuLinks.support",
+    "icon": "volunteer_activism"
+  },
+  {
+    "id": "project-code",
+    "title": "index.menuLinks.projectCode",
+    "icon": "mdi-github"
+  },
+  {
+    "id": "mobile-app",
+    "title": "index.menuLinks.mobileApp",
+    "icon": "smartphone"
+  }
+]


### PR DESCRIPTION
Since RTWBB mobile app has been removed from the store, link no longer returns OK response as needed for tests.

* Remove link to mobile app from `MenuLinks` data.

Component is currently not displayed in front-end app.