### PR TITLE
src/components: enable logging routes outside current month in RoutesCalendar

### DIFF
--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -37,11 +37,13 @@ const selectorRoutesCalendar = 'routes-calendar';
 // variables
 const routeCountSingle = 1;
 const routeCountMultiple = 2;
-const dateWithNoLoggedRoute = new Date(2025, 4, 27);
-const dateWithLoggedRoute = new Date(2025, 4, 26);
-const dateFirstDayOfCompetition = new Date(2025, 4, 1);
-const lastDayOfCompetition = new Date(2025, 4, 31);
-const lastDayOfEntryPhase = new Date(2025, 5, 1);
+const dateSeptemberWithNoLoggedRoute = new Date(2024, 8, 27);
+// see apiGetThisCampaignMay.json for phase dates
+const dateMayWithNoLoggedRoute = new Date(2025, 4, 27);
+const dateMayWithLoggedRoute = new Date(2025, 4, 26);
+const dateMayFirstDayOfCompetition = new Date(2025, 4, 1);
+const dateMayLastDayOfCompetition = new Date(2025, 5, 1);
+const lastMayDayOfEntryPhase = new Date(2025, 5, 3);
 
 const dayNames = [
   i18n.global.t('time.mondayShort'),
@@ -64,7 +66,7 @@ describe('<RoutesCalendar>', () => {
 
   context('desktop - full logging window', () => {
     beforeEach(() => {
-      const now = dateWithNoLoggedRoute;
+      const now = dateMayWithNoLoggedRoute;
       cy.clock(new Date(now), ['Date']);
       cy.wrap(now).as('now');
       cy.mount(RoutesCalendar, {
@@ -96,7 +98,7 @@ describe('<RoutesCalendar>', () => {
       beforeEach(() => {
         setActivePinia(createPinia());
         // set default date
-        const now = dateWithLoggedRoute;
+        const now = dateMayWithLoggedRoute;
         cy.clock(new Date(now), ['Date']);
         cy.wrap(now).as('now');
         cy.fixture('routeListCalendar.json').then((response) => {
@@ -186,7 +188,7 @@ describe('<RoutesCalendar>', () => {
 
   context('desktop - first day of competition - no routes', () => {
     beforeEach(() => {
-      cy.clock(new Date(dateFirstDayOfCompetition), ['Date']);
+      cy.clock(new Date(dateMayFirstDayOfCompetition), ['Date']);
       cy.mount(RoutesCalendar, {
         props: {
           routes: [],
@@ -227,9 +229,9 @@ describe('<RoutesCalendar>', () => {
     });
   });
 
-  context('desktop - last day of competition - no routes', () => {
+  context('desktop - last day of competition (september) - no routes', () => {
     beforeEach(() => {
-      cy.clock(new Date(lastDayOfCompetition), ['Date']);
+      cy.clock(new Date(dateSeptemberWithNoLoggedRoute), ['Date']);
       cy.mount(RoutesCalendar, {
         props: {
           routes: [],
@@ -238,7 +240,7 @@ describe('<RoutesCalendar>', () => {
       // setup store with commute modes
       cy.setupTripsStoreWithCommuteModes(useTripsStore);
       // setup store with challenge data
-      cy.fixture('apiGetThisCampaignMay.json').then((response) => {
+      cy.fixture('apiGetThisCampaign.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
           store.setDaysActive(response.results[0].days_active);
           store.setPhaseSet(response.results[0].phase_set);
@@ -248,7 +250,7 @@ describe('<RoutesCalendar>', () => {
     });
 
     it('it allows to select max number of logged routes (not limited by last day)', () => {
-      cy.fixture('apiGetThisCampaignMay.json').then((response) => {
+      cy.fixture('apiGetThisCampaign.json').then((response) => {
         // click on all routes to work
         cy.dataCy(selectorRoutesCalendar)
           .find(dataSelectorItemToWorkEmpty)
@@ -274,7 +276,7 @@ describe('<RoutesCalendar>', () => {
 
   context('desktop - last day of entry phase - no routes', () => {
     beforeEach(() => {
-      cy.clock(new Date(lastDayOfEntryPhase), ['Date']);
+      cy.clock(new Date(lastMayDayOfEntryPhase), ['Date']);
       cy.mount(RoutesCalendar, {
         props: {
           routes: [],
@@ -292,12 +294,12 @@ describe('<RoutesCalendar>', () => {
       cy.viewport('macbook-16');
     });
 
-    it('it allows to select days within the intersection of entry phase and logging window', () => {
+    it('allows to select days within the intersection of entry phase and logging window', () => {
       cy.fixture('apiGetThisCampaignMay.json').then((response) => {
         // click on all routes to work
         const dateDiff = date.getDateDiff(
-          lastDayOfEntryPhase,
-          lastDayOfCompetition,
+          lastMayDayOfEntryPhase,
+          dateMayLastDayOfCompetition,
           'days',
         );
         const maxRoutes = response.results[0].days_active - dateDiff;

--- a/src/components/__tests__/RoutesCalendar.cy.js
+++ b/src/components/__tests__/RoutesCalendar.cy.js
@@ -5,6 +5,7 @@ import { i18n } from '../../boot/i18n';
 import { useTripsStore } from 'src/stores/trips';
 import { useChallengeStore } from 'src/stores/challenge';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
+import { systemTimeLastDayOfCompetitionMay } from '../../../test/cypress/support/commonTests';
 
 // selectors
 const classSelectorCurrentDay = '.q-current-day';
@@ -42,7 +43,6 @@ const dateSeptemberWithNoLoggedRoute = new Date(2024, 8, 27);
 const dateMayWithNoLoggedRoute = new Date(2025, 4, 27);
 const dateMayWithLoggedRoute = new Date(2025, 4, 26);
 const dateMayFirstDayOfCompetition = new Date(2025, 4, 1);
-const dateMayLastDayOfCompetition = new Date(2025, 5, 1);
 const lastMayDayOfEntryPhase = new Date(2025, 5, 3);
 
 const dayNames = [
@@ -299,7 +299,7 @@ describe('<RoutesCalendar>', () => {
         // click on all routes to work
         const dateDiff = date.getDateDiff(
           lastMayDayOfEntryPhase,
-          dateMayLastDayOfCompetition,
+          systemTimeLastDayOfCompetitionMay,
           'days',
         );
         const maxRoutes = response.results[0].days_active - dateDiff;

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -259,6 +259,7 @@ export default defineComponent({
         animated
         bordered
         hoverable
+        enable-outside-days
         no-active-date
         use-navigation
         short-weekday-label
@@ -273,7 +274,7 @@ export default defineComponent({
         date-type="rounded"
         :day-min-height="100"
       >
-        <template #day="{ scope: { timestamp, outside } }">
+        <template #day="{ scope: { timestamp } }">
           <div
             v-if="isTimestampInCompetitionPhase(timestamp)"
             :data-date="timestamp.date"
@@ -285,7 +286,7 @@ export default defineComponent({
               :active="
                 isActive({ timestamp, direction: TransportDirection.toWork })
               "
-              :disabled="outside || timestamp.disabled"
+              :disabled="timestamp.disabled"
               :direction="TransportDirection.toWork"
               :day="routesMap[timestamp.date]"
               :timestamp="timestamp"
@@ -297,7 +298,7 @@ export default defineComponent({
               :active="
                 isActive({ timestamp, direction: TransportDirection.fromWork })
               "
-              :disabled="outside || timestamp.disabled"
+              :disabled="timestamp.disabled"
               :direction="TransportDirection.fromWork"
               :day="routesMap[timestamp.date]"
               :timestamp="timestamp"

--- a/test/cypress/fixtures/routeCalendarPanelInputTest.json
+++ b/test/cypress/fixtures/routeCalendarPanelInputTest.json
@@ -33,7 +33,7 @@
     "propRoutes": [
       {
         "id": "1",
-        "date": "2025-05-25",
+        "date": "2025-05-26",
         "direction": "fromWork",
         "distance": "0.00",
         "transport": "bicycle",
@@ -48,7 +48,7 @@
     "apiPayload": {
       "trips": [
         {
-          "trip_date": "2025-05-25",
+          "trip_date": "2025-05-26",
           "direction": "trip_from",
           "commuteMode": "bicycle",
           "distanceMeters": 10000,

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -692,3 +692,9 @@ export const systemTimeOffersValid = new Date('2025-05-05T00:00:00.000Z');
  * Date in the middle of the May campaign when routes can be logged
  */
 export const systemTimeLoggingRoutes = new Date('2025-05-26T00:00:00.000Z');
+/**
+ * Last day of the competition phase in May campaign
+ */
+export const systemTimeLastDayOfCompetitionMay = new Date(
+  '2025-06-01T00:00:00.000Z',
+);


### PR DESCRIPTION
Enable logging routes outside current month in `RoutesCalendar`.

It makes for better UX, if user is able to log all available routes which are currently in view, instead of being limited by current month.

* Enable feature in calendar
* Update some component test and test data: 1) update end of challenge date to correspond to fixture, 2) for test that should work within a single month, choose September campaign data, 3) update variable names to reflect this.
* Add E2E test for logging route outside current month.