### PR TITLE
src/composables: add isEntryEnabled variable to control sending route logging request

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      https: true,
+      // https: true
       open: true, // opens browser window automatically
     },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -115,7 +115,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
-      // https: true
+      https: true,
       open: true, // opens browser window automatically
     },
 

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -325,6 +325,33 @@ function coreTests() {
     );
   });
 
+  it('shows notification when entry is not enabled', () => {
+    // pick one editable route
+    cy.get('[data-date="2025-05-12"]')
+      .should('be.visible')
+      .find('[data-direction="fromWork"]')
+      .should('be.visible')
+      .within(() => {
+        // input transport type if provided
+        cy.dataCy('button-toggle-transport').should('be.visible');
+        cy.dataCy('section-transport')
+          .find(`[data-value="${TransportType.bike}"]`)
+          .click();
+        // input distance if provided
+        cy.dataCy('section-input-number').should('be.visible');
+        cy.dataCy('section-input-number').find('input').clear();
+        cy.dataCy('section-input-number').find('input').type('10');
+      });
+    // wait 9 days (to get to a day when entry is not enabled)
+    cy.tick(9 * 24 * 60 * 60 * 1000);
+    // click save button
+    cy.dataCy(selectorButtonSave).click();
+    // check notification
+    cy.contains(i18n.global.t('postTrips.messageEntryNotEnabled')).should(
+      'be.visible',
+    );
+  });
+
   it.skip('tracks dirty state when input type changes (currently not used)', () => {
     // test changing input type
     cy.dataCy(selectorRouteListItem)

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -25,15 +25,12 @@ import { defaultLocale } from '../../i18n/def_locale';
 
 // composables
 import { useMenu } from 'src/composables/useMenu';
+import { useRoutes } from 'src/composables/useRoutes';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
-// enums
-import { PhaseType } from 'src/components/types/Challenge';
-
 // stores
-import { useChallengeStore } from 'src/stores/challenge';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // types
@@ -47,20 +44,11 @@ export default defineComponent({
   name: 'MobileBottomPanel',
   setup() {
     const registerChallengeStore = useRegisterChallengeStore();
-    const challengeStore = useChallengeStore();
     const isUserOrganizationAdmin = computed(
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
     const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
-    const isEntryPhase = computed(() => {
-      return challengeStore.getIsChallengeInPhase(PhaseType.entryEnabled);
-    });
-    const isCompetitionPhase = computed(() => {
-      return challengeStore.getIsChallengeInPhase(PhaseType.competition);
-    });
-    const isEntryEnabled = computed(() => {
-      return isEntryPhase.value || isCompetitionPhase.value;
-    });
+    const { isEntryEnabled } = useRoutes();
     const { getMenuTop, getMenuBottom } = useMenu();
 
     const { mobileBottomPanelVisibleItems } = rideToWorkByBikeConfig;

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -115,8 +115,6 @@ export default defineComponent({
      * If successful, closes panel.
      */
     const onSave = async (): Promise<void> => {
-      console.log('isEntryEnabled', isEntryEnabled.value);
-      console.log('date', new Date());
       // if entry is not enabled, show notification
       if (!isEntryEnabled.value) {
         Notify.create({

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -28,6 +28,7 @@
  */
 
 // libraries
+import { Notify } from 'quasar';
 import { computed, defineComponent, inject } from 'vue';
 
 // components
@@ -35,6 +36,8 @@ import RouteInputDistance from './RouteInputDistance.vue';
 import RouteInputTransportType from './RouteInputTransportType.vue';
 
 // composables
+import { i18n } from '../../boot/i18n';
+import { useRoutes } from 'src/composables/useRoutes';
 import { useLogRoutes } from '../../composables/useLogRoutes';
 import { useApiPostTrips } from '../../composables/useApiPostTrips';
 
@@ -94,6 +97,8 @@ export default defineComponent({
     // Initialize trips store
     const tripsStore = useTripsStore();
 
+    const { isEntryEnabled } = useRoutes();
+
     // Determines if save button should be disabled.
     const isSaveBtnDisabled = computed((): boolean => {
       const noTransport = transportType.value === null;
@@ -110,6 +115,14 @@ export default defineComponent({
      * If successful, closes panel.
      */
     const onSave = async (): Promise<void> => {
+      // if entry is not enabled, show notification
+      if (!isEntryEnabled.value) {
+        Notify.create({
+          type: 'negative',
+          message: i18n.global.t('postTrips.messageEntryNotEnabled'),
+        });
+        return;
+      }
       // create route items with settings from panel
       const routeItems: RouteItem[] = routes.value.map((route) => ({
         ...route,

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -105,7 +105,7 @@ export default defineComponent({
       const noRoutes = routesCount.value === 0;
       const noDistance =
         isShownDistance.value && distance.value === defaultDistanceZero;
-      return noRoutes || noDistance ||  noTransport || isLoading.value;
+      return noRoutes || noDistance || noTransport || isLoading.value;
     });
 
     /**
@@ -115,6 +115,8 @@ export default defineComponent({
      * If successful, closes panel.
      */
     const onSave = async (): Promise<void> => {
+      console.log('isEntryEnabled', isEntryEnabled.value);
+      console.log('date', new Date());
       // if entry is not enabled, show notification
       if (!isEntryEnabled.value) {
         Notify.create({

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -20,6 +20,7 @@
  */
 
 // libraries
+import { Notify } from 'quasar';
 import { computed, defineComponent, inject, ref, watch } from 'vue';
 
 // adapters
@@ -29,6 +30,7 @@ import { tripsAdapter } from '../../adapters/tripsAdapter';
 import RouteItemEdit from './RouteItemEdit.vue';
 
 // composables
+import { i18n } from '../../boot/i18n';
 import { useApiPostTrips } from '../../composables/useApiPostTrips';
 import { useRoutes } from 'src/composables/useRoutes';
 
@@ -51,8 +53,12 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     const tripsStore = useTripsStore();
     // route composables
-    const { getLoggableDaysWithRoutes, formatDate, formatDateName } =
-      useRoutes();
+    const {
+      isEntryEnabled,
+      getLoggableDaysWithRoutes,
+      formatDate,
+      formatDateName,
+    } = useRoutes();
 
     // initialize API composable
     const { postTrips, isLoading: isLoadingPostTrips } =
@@ -82,6 +88,14 @@ export default defineComponent({
     const dirtyCount = computed((): number => routeItemsDirty.value.length);
 
     const onSave = async (): Promise<void> => {
+      // if entry is not enabled, show notification
+      if (!isEntryEnabled.value) {
+        Notify.create({
+          type: 'negative',
+          message: i18n.global.t('postTrips.messageEntryNotEnabled'),
+        });
+        return;
+      }
       // convert route items to trip payload
       const tripPayload = routeItemsDirty.value.map((route) =>
         tripsAdapter.toTripPostPayload(route),

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -87,6 +87,21 @@ export const useRoutes = () => {
     );
   };
 
+  /**
+   * Checks whether user is currently allowed to log routes.
+   * @return {boolean} - True if logging is allowed, false otherwise.
+   */
+  const isEntryEnabled = computed((): boolean => {
+    const challengeStore = useChallengeStore();
+    const isEntryPhase = challengeStore.getIsChallengeInPhase(
+      PhaseType.entryEnabled,
+    );
+    const isCompetitionPhase = challengeStore.getIsChallengeInPhase(
+      PhaseType.competition,
+    );
+    return isEntryPhase || isCompetitionPhase;
+  });
+
   const dateCompetitionPhaseFrom = computed((): Date | null => {
     const challengeStore = useChallengeStore();
     const dateString = challengeStore.getPhaseFromSet(
@@ -345,6 +360,7 @@ export const useRoutes = () => {
     dateLoggingEnd,
     dateCompetitionPhaseFrom,
     dateCompetitionPhaseTo,
+    isEntryEnabled,
     getLoggableDaysWithRoutes,
     getUnloggableDaysWithRoutes,
     getCompetitionDaysWithRoutes,

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -707,6 +707,7 @@ messageTeamMaxMembersReached = "Tým je plný. Nemůžete přidat další členy
 apiMessageError = "Chyba při ukládání jízd."
 apiMessageErrorWithMessage = "Chyba při ukládání jízd. Chyba: {error}"
 apiMessageSuccess = "Jízdy byly úspěšně uloženy."
+messageEntryNotEnabled = "Zapisování jízd není v tuto chvíli povoleno."
 
 [profile]
 buttonDeleteAccount = "Smazat"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -704,7 +704,7 @@ messageTeamMaxMembersReached = "Team is full. You cannot add more members."
 apiMessageError = "Error saving trips."
 apiMessageErrorWithMessage = "Error saving trips. Error: {error}"
 apiMessageSuccess = "Trips were successfully saved."
-
+messageEntryNotEnabled = "Trip logging is not currently allowed."
 
 [profile]
 buttonAddEmailField = "Add another email"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -706,6 +706,7 @@ messageTeamMaxMembersReached = "Tím je plný. Nemôžete pridať ďalšie člen
 apiMessageError = "Chyba pri ukladaní jázd."
 apiMessageErrorWithMessage = "Chyba pri ukladaní jázd. Chyba: {error}"
 apiMessageSuccess = "Jázdy boli úspešne uložené."
+messageEntryNotEnabled = "Zápis jázd nie je v súčasnosti povolený."
 
 [profile]
 buttonDeleteAccount = "Zmazať"

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -15,20 +15,17 @@ import UserSelect from 'components/global/UserSelect.vue';
 
 // composables
 import { useMenu } from 'src/composables/useMenu';
+import { useRoutes } from 'src/composables/useRoutes';
 
 // config
 import { rideToWorkByBikeConfig } from '../boot/global_vars';
 import { routesConf } from '../router/routes_conf';
-
-// enums
-import { PhaseType } from '../components/types/Challenge';
 
 // types
 import type { Link } from 'components/types';
 import type { Logger } from 'components/types/Logger';
 
 // stores
-import { useChallengeStore } from 'src/stores/challenge';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
 
 // utils
@@ -59,7 +56,6 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     const route = useRoute();
     const registerChallengeStore = useRegisterChallengeStore();
-    const challengeStore = useChallengeStore();
 
     const isHomePage = computed(
       () => route.path === routesConf['home']['path'],
@@ -87,15 +83,7 @@ export default defineComponent({
       () => registerChallengeStore.isUserOrganizationAdmin,
     );
     const isUserStaff = computed(() => registerChallengeStore.getIsUserStaff);
-    const isEntryPhase = computed(() => {
-      return challengeStore.getIsChallengeInPhase(PhaseType.entryEnabled);
-    });
-    const isCompetitionPhase = computed(() => {
-      return challengeStore.getIsChallengeInPhase(PhaseType.competition);
-    });
-    const isEntryEnabled = computed(() => {
-      return isEntryPhase.value || isCompetitionPhase.value;
-    });
+    const { isEntryEnabled } = useRoutes();
 
     const {
       urlRideToWorkByBikeOldFrontendDjangoApp,


### PR DESCRIPTION
Add `isEntryEnabled` variable to `useRoutes` to control sending the route logging requests.

* Refactor logic to get `isEntryEnabled` variable to the `useRoutes` file.
* Use it to display notification if user tries to log routes outside the entry-enabled period.
* Add test case to `RouteCalendarPanel` and `RouteListEdit` component tests.