### PR TITLE
src/components: enable list of distance input elements form validation before saving

### DIFF
--- a/src/components/__tests__/RouteItemEdit.cy.js
+++ b/src/components/__tests__/RouteItemEdit.cy.js
@@ -276,7 +276,7 @@ function coreTests() {
       i18n.global.t('routes.transport.car'),
     );
     // distance is not shown
-    cy.dataCy('section-distance').should('not.be.visible');
+    cy.dataCy('section-distance').should('not.exist');
     // change transport type - none
     cy.dataCy('button-toggle-transport')
       .filter(`[data-value="${TransportType.none}"]`)
@@ -286,7 +286,7 @@ function coreTests() {
       i18n.global.t('routes.transport.none'),
     );
     // distance is not shown
-    cy.dataCy('section-distance');
+    cy.dataCy('section-distance').should('not.exist');
     // change transport type -  bike
     cy.dataCy('button-toggle-transport')
       .filter(`[data-value="${TransportType.bike}"]`)

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -49,6 +49,7 @@ import { useTripsStore } from 'src/stores/trips';
 import { localizedFloatNumStrToFloatNumber } from 'src/utils';
 
 // types
+import type { Logger } from '../types/Logger';
 import type { RouteItem } from '../types/Route';
 
 export default defineComponent({
@@ -236,7 +237,7 @@ export default defineComponent({
         />
         <!-- Section: Distance -->
         <route-input-distance
-          v-show="isShownDistance"
+          v-if="isShownDistance"
           :modelValue="distance"
           :modelAction="action"
           @update:modelValue="onUpdateDistance"

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -22,6 +22,7 @@
 // libraries
 import { Notify } from 'quasar';
 import { computed, defineComponent, inject, ref, watch } from 'vue';
+import type { QForm } from 'quasar';
 
 // adapters
 import { tripsAdapter } from '../../adapters/tripsAdapter';
@@ -87,7 +88,19 @@ export default defineComponent({
     // dirty state will be tracked within UI to show change count
     const dirtyCount = computed((): number => routeItemsDirty.value.length);
 
+    const formRef = ref<QForm | null>(null);
+
     const onSave = async (): Promise<void> => {
+      logger?.info('Saving selected routes.');
+      // validate form before submitting
+      const isValid = await formRef.value?.validate();
+      if (!isValid) {
+        Notify.create({
+          type: 'negative',
+          message: i18n.global.t('postTrips.messageFormValidationFailed'),
+        });
+        return;
+      }
       // if entry is not enabled, show notification
       if (!isEntryEnabled.value) {
         Notify.create({
@@ -133,13 +146,14 @@ export default defineComponent({
       isLoadingPostTrips,
       onSave,
       TransportDirection,
+      formRef,
     };
   },
 });
 </script>
 
 <template>
-  <div data-cy="route-list-edit">
+  <q-form data-cy="route-list-edit" ref="formRef" @submit.prevent="onSave">
     <!-- Item: Day -->
     <div
       v-for="day in days"
@@ -182,6 +196,7 @@ export default defineComponent({
       <q-btn
         rounded
         unelevated
+        type="submit"
         color="primary"
         size="16px"
         class="text-weight-bold"
@@ -197,5 +212,5 @@ export default defineComponent({
         }}
       </q-btn>
     </div>
-  </div>
+  </q-form>
 </template>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -153,7 +153,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-form data-cy="route-list-edit" ref="formRef" @submit.prevent="onSave">
+  <q-form ref="formRef" data-cy="route-list-edit" @submit.prevent="onSave">
     <!-- Item: Day -->
     <div
       v-for="day in days"

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -708,6 +708,7 @@ apiMessageError = "Chyba při ukládání jízd."
 apiMessageErrorWithMessage = "Chyba při ukládání jízd. Chyba: {error}"
 apiMessageSuccess = "Jízdy byly úspěšně uloženy."
 messageEntryNotEnabled = "Zapisování jízd není v tuto chvíli povoleno."
+messageFormValidationFailed = "Nemáte správně vyplněnou některou jízdu."
 
 [profile]
 buttonDeleteAccount = "Smazat"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -705,6 +705,7 @@ apiMessageError = "Error saving trips."
 apiMessageErrorWithMessage = "Error saving trips. Error: {error}"
 apiMessageSuccess = "Trips were successfully saved."
 messageEntryNotEnabled = "Trip logging is not currently allowed."
+messageFormValidationFailed = "Some of your trips are not filled in correctly."
 
 [profile]
 buttonAddEmailField = "Add another email"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -707,6 +707,7 @@ apiMessageError = "Chyba pri ukladaní jázd."
 apiMessageErrorWithMessage = "Chyba pri ukladaní jázd. Chyba: {error}"
 apiMessageSuccess = "Jázdy boli úspešne uložené."
 messageEntryNotEnabled = "Zápis jázd nie je v súčasnosti povolený."
+messageFormValidationFailed = "Nemáte správne vyplnenú niektorú jazdu."
 
 [profile]
 buttonDeleteAccount = "Zmazať"

--- a/test/cypress/fixtures/routeItemsCalendar.json
+++ b/test/cypress/fixtures/routeItemsCalendar.json
@@ -19,7 +19,7 @@
     "id": "00001",
     "date": "2025-05-25",
     "direction": "toWork",
-    "distance": "0",
+    "distance": "18.00",
     "transport": "bicycle",
     "routeFeature": null
   },
@@ -37,14 +37,6 @@
     "direction": "toWork",
     "distance": "20.00",
     "transport": "bicycle",
-    "routeFeature": null
-  },
-  {
-    "id": "",
-    "date": "",
-    "direction": "fromWork",
-    "distance": "0.00",
-    "transport": "",
     "routeFeature": null
   }
 ]

--- a/test/cypress/fixtures/routeItemsCalendar.json
+++ b/test/cypress/fixtures/routeItemsCalendar.json
@@ -24,14 +24,6 @@
     "routeFeature": null
   },
   {
-    "id": "00002",
-    "date": "2025-05-25",
-    "direction": "fromWork",
-    "distance": "19.00",
-    "transport": "bicycle",
-    "routeFeature": null
-  },
-  {
     "id": "00001",
     "date": "2025-05-26",
     "direction": "toWork",


### PR DESCRIPTION
Enable automatic QForm validation on save in `RouteListEdit` for distance inputs.

* Use `v-if="isShownDistance"` in `RouteItemEdit` to fix issue with invalid hidden inputs (distance).
* Add validation and notification to `RouteListEdit` `onSave` function.
* Update test fixture not to contain empty routes and to contain empty route slot for test.
* Add component test for validation check.