### PR TITLE
src/components: add save buttons to RouteListEdit

### DIFF
--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -23,7 +23,9 @@ const dataSelectorButtonToggleTransport = '[data-cy="button-toggle-transport"]';
 const dataSelectorInputDistance = '[data-cy="input-distance"]';
 const dataSelectorRouteDistance = '[data-cy="route-distance"]';
 const dataSelectorSelectAction = '[data-cy="select-action"]';
-const selectorButtonSave = 'button-save';
+const selectorButtonSaveBottom = 'button-save-bottom';
+const selectorButtonSaveSticky = 'button-save-sticky';
+const selectorButtonSaveTop = 'button-save-top';
 const selectorRouteListEdit = 'route-list-edit';
 const selectorRouteListItem = 'route-list-item';
 const selectorRouteListItemWrapper = 'route-list-item-wrapper';
@@ -33,6 +35,8 @@ const selectorSectionDirection = 'section-direction';
 const routeListItemWrapperWidthDesktop = 50;
 const routeListItemWrapperWidthMobile = 100;
 const { challengeLoggingWindowDays } = rideToWorkByBikeConfig;
+
+let selectorButtonSave;
 
 describe('<RouteListEdit>', () => {
   it('has translation for all strings', () => {
@@ -46,8 +50,12 @@ describe('<RouteListEdit>', () => {
 
   context('desktop - full logging window', () => {
     beforeEach(() => {
+      // test save button top
+      selectorButtonSave = selectorButtonSaveTop;
       cy.mount(RouteListEdit, {
-        props: {},
+        props: {
+          disableSticky: true,
+        },
       });
       cy.fixture('apiGetThisCampaignMay.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
@@ -77,8 +85,12 @@ describe('<RouteListEdit>', () => {
 
   context('mobile', () => {
     beforeEach(() => {
+      // test save button sticky
+      selectorButtonSave = selectorButtonSaveSticky;
       cy.mount(RouteListEdit, {
-        props: {},
+        props: {
+          disableSticky: true,
+        },
       });
       cy.fixture('apiGetThisCampaignMay.json').then((response) => {
         cy.wrap(useChallengeStore()).then((store) => {
@@ -108,6 +120,8 @@ describe('<RouteListEdit>', () => {
 
   context('API payloads for route entry', () => {
     beforeEach(() => {
+      // test save button bottom
+      selectorButtonSave = selectorButtonSaveBottom;
       cy.viewport('macbook-16');
     });
 
@@ -116,7 +130,9 @@ describe('<RouteListEdit>', () => {
       it(`${testKey}: ${testCase.description}`, () => {
         // mount component with test data
         cy.mount(RouteListEdit, {
-          props: {},
+          props: {
+            disableSticky: true,
+          },
         });
         cy.fixture('apiGetThisCampaignMay.json').then((response) => {
           cy.wrap(useChallengeStore()).then((store) => {

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -7,8 +7,8 @@
  * `challengeLoggingWindowDays`.
  *
  * @props
- * - `routes` (RouteItem, required): The object representing a list of routes.
- *   It should be of type `RouteItem`.
+ * - `disableSticky` (Boolean, optional): If true, q-page-sticky component
+ *   will be rendered as a div.
  *
  * @components
  * - `RouteItemEdit`: Component to render a single route in edit mode.

--- a/src/components/routes/RouteTabs.vue
+++ b/src/components/routes/RouteTabs.vue
@@ -181,7 +181,6 @@ export default defineComponent({
         :name="RouteTab.list"
         data-cy="route-tabs-panel-list"
       >
-        <div class="text-h6">{{ $t('routes.tabList') }}</div>
         <route-list-edit data-cy="route-list-edit" />
         <route-list-display data-cy="route-list-display" />
       </q-tab-panel>

--- a/test/cypress/e2e/routes_list.spec.cy.js
+++ b/test/cypress/e2e/routes_list.spec.cy.js
@@ -84,7 +84,7 @@ describe('Routes list page', () => {
                 }
               });
             // click save button
-            cy.dataCy('button-save').click();
+            cy.dataCy('button-save-bottom').click();
             // wait for API call and verify payload
             cy.waitForPostTripsApi(testCases.test_1.apiPayload);
             // go to calendar page to confirm saving
@@ -176,7 +176,7 @@ describe('Routes list page', () => {
                 }
               });
             // click save button
-            cy.dataCy('button-save').click();
+            cy.dataCy('button-save-bottom').click();
             // wait for API call and verify payload
             cy.waitForPostTripsApi(testCases.test_17.apiPayload);
             // go to calendar page to confirm saving
@@ -280,7 +280,7 @@ describe('Routes list page', () => {
                 }
               });
             // click save button
-            cy.dataCy('button-save').click();
+            cy.dataCy('button-save-bottom').click();
             // wait for API call and verify payload
             cy.waitForPostTripsApi(testCases.test_1.apiPayload);
             // go to calendar page to confirm saving


### PR DESCRIPTION
Add save buttons to `RouteListEdit` for better UX. 

* Add one extra button on top of the list on large screens.
* Hide top and bottom buttons and replace them with floating button on mobile screens.
* Fix issue with `<q-page-sticky>` not working in Cypress component tests by using a dynamic Vue component and a test prop.
* Update tests to validate interactions with all buttons.

Additional change:
Remove the title from list routes tab (not in design - it was historically used as a placeholder).