### PR TITLE
src/composables:  fix day names, month days localization in routes lists 

### DIFF
--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -159,6 +159,9 @@ dateTimeFormatsAllLocales = '''
     "day": "numeric",
     "hour": "numeric",
     "minute": "numeric"
+  },
+  "weekday": {
+    "weekday": "long"
   }
 }
 '''

--- a/ride_to_work_by_bike_config.toml
+++ b/ride_to_work_by_bike_config.toml
@@ -162,6 +162,10 @@ dateTimeFormatsAllLocales = '''
   },
   "weekday": {
     "weekday": "long"
+  },
+  "monthLongStringDay": {
+    "day": "numeric",
+    "month": "long"
   }
 }
 '''

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -69,7 +69,10 @@ export default defineComponent({
       data-cy="route-list-day"
     >
       <!-- Title: Date -->
-      <h3 class="text-18 text-grey-10 q-my-none" data-cy="route-list-day-date">
+      <h3
+        class="text-18 text-grey-10 q-my-none text-capitalize"
+        data-cy="route-list-day-date"
+      >
         {{ formatDateName(day.date) }} ({{ formatDate(day.date) }})
       </h3>
       <div class="q-py-md">

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -352,7 +352,11 @@ export const useRoutes = () => {
       return i18n.global.t('time.yesterday');
     }
 
-    return date.formatDate(timeStamp, 'dddd');
+    const locale = i18n.global.locale;
+    // format date name with Intl API
+    const formatter = new Intl.DateTimeFormat(locale, { weekday: 'long' });
+
+    return formatter.format(timeStamp);
   };
 
   return {

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -321,21 +321,19 @@ export const useRoutes = () => {
   /**
    * Formats a given date string into a specific format.
    *
-   * @param dateString - The date string to be formatted.
-   * @return The formatted date string in the format 'D. MMM'.
+   * @param {string} dateString - The date string to be formatted.
+   * @return {string} - The formatted localized date string
    */
   const formatDate = (dateString: string) => {
-    const timeStamp = new Date(dateString);
-    // using quasar date object
-    return date.formatDate(timeStamp, 'D. MMM');
+    return i18n.global.d(new Date(dateString), 'monthLongStringDay');
   };
 
   /**
    * Returns a text-based label for a day based on the given date.
    * Example: "Today", "Yesterday", "Monday"
    *
-   * @param dateString - The date string to be formatted
-   * @return The formatted date name
+   * @param {string } dateString - The date string to be formatted
+   * @return {string } - The formatted localized date name
    */
   const formatDateName = (dateString: string) => {
     const timeStamp = new Date(dateString);

--- a/src/composables/useRoutes.ts
+++ b/src/composables/useRoutes.ts
@@ -352,11 +352,7 @@ export const useRoutes = () => {
       return i18n.global.t('time.yesterday');
     }
 
-    const locale = i18n.global.locale;
-    // format date name with Intl API
-    const formatter = new Intl.DateTimeFormat(locale, { weekday: 'long' });
-
-    return formatter.format(timeStamp);
+    return i18n.global.d(timeStamp, 'weekday');
   };
 
   return {


### PR DESCRIPTION
Localize day names in route lists via `useRoutes` composable.

* Define `"weekday"` format for i18n plugin.
* Use `i18n.global.d` function instead of Quasar's `date.formatDate` (which needs to be [localized manually](https://quasar.dev/quasar-utils/date-utils#format-for-display)).
* Capitalize first letters with `text-capitalize` class.