### PR TITLE
src/components/routes: add loading spinners to route display components

### DIFF
--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -92,7 +92,7 @@ export default defineComponent({
       useLogRoutes(routes);
 
     // Initialize API composable
-    const { postTrips, isLoading } = useApiPostTrips(logger);
+    const { postTrips } = useApiPostTrips(logger);
 
     // Initialize trips store
     const tripsStore = useTripsStore();
@@ -105,7 +105,7 @@ export default defineComponent({
       const noRoutes = routesCount.value === 0;
       const noDistance =
         isShownDistance.value && distance.value === defaultDistanceZero;
-      return noRoutes || noDistance || noTransport || isLoading.value;
+      return noRoutes || noDistance || noTransport || tripsStore.getIsLoading;
     });
 
     /**

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -40,6 +40,11 @@ export default defineComponent({
   },
   setup() {
     const tripsStore = useTripsStore();
+
+    const isLoadingRoutes = computed((): boolean => {
+      return tripsStore.getIsLoading;
+    });
+
     // get route items from store
     const routeItems = computed<RouteItem[]>(() => tripsStore.getRouteItems);
 
@@ -52,6 +57,7 @@ export default defineComponent({
 
     return {
       days,
+      isLoadingRoutes,
       formatDate,
       formatDateName,
     };
@@ -60,7 +66,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div data-cy="route-list-display">
+  <div class="relative-position" data-cy="route-list-display">
     <!-- Item: Day -->
     <div
       v-for="day in days"
@@ -104,5 +110,11 @@ export default defineComponent({
         </div>
       </div>
     </div>
+    <!-- Loading spinner -->
+    <q-inner-loading
+      :showing="isLoadingRoutes"
+      color="primary"
+      data-cy="spinner-calendar"
+    />
   </div>
 </template>

--- a/src/components/routes/RouteListDisplay.vue
+++ b/src/components/routes/RouteListDisplay.vue
@@ -114,7 +114,7 @@ export default defineComponent({
     <q-inner-loading
       :showing="isLoadingRoutes"
       color="primary"
-      data-cy="spinner-calendar"
+      data-cy="spinner-route-list-display"
     />
   </div>
 </template>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -49,6 +49,11 @@ export default defineComponent({
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
     const tripsStore = useTripsStore();
+
+    const isLoadingRoutes = computed((): boolean => {
+      return tripsStore.getIsLoading;
+    });
+
     // route composables
     const {
       isEntryEnabled,
@@ -145,6 +150,7 @@ export default defineComponent({
       formatDateName,
       isLargeScreen,
       isLoadingPostTrips,
+      isLoadingRoutes,
       onSave,
       TransportDirection,
       formRef,

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -50,7 +50,7 @@ export default defineComponent({
     const logger = inject('vuejs3-logger') as Logger | null;
     const tripsStore = useTripsStore();
 
-    const isLoadingRoutes = computed((): boolean => {
+    const isLoadingTrips = computed((): boolean => {
       return tripsStore.getIsLoading;
     });
 
@@ -63,8 +63,7 @@ export default defineComponent({
     } = useRoutes();
 
     // initialize API composable
-    const { postTrips, isLoading: isLoadingPostTrips } =
-      useApiPostTrips(logger);
+    const { postTrips } = useApiPostTrips(logger);
 
     // get route items from store
     const routeItems = computed<RouteItem[]>(() => tripsStore.getRouteItems);
@@ -149,8 +148,7 @@ export default defineComponent({
       formatDate,
       formatDateName,
       isLargeScreen,
-      isLoadingPostTrips,
-      isLoadingRoutes,
+      isLoadingTrips,
       onSave,
       TransportDirection,
       formRef,
@@ -174,8 +172,8 @@ export default defineComponent({
           color="primary"
           size="16px"
           class="text-weight-bold"
-          :loading="isLoadingPostTrips"
-          :disable="isLoadingPostTrips || dirtyCount === 0"
+          :loading="isLoadingTrips"
+          :disable="isLoadingTrips || dirtyCount === 0"
           data-cy="button-save-top"
           @click.prevent="onSave"
         >
@@ -236,8 +234,8 @@ export default defineComponent({
           color="primary"
           size="16px"
           class="text-weight-bold"
-          :loading="isLoadingPostTrips"
-          :disable="isLoadingPostTrips || dirtyCount === 0"
+          :loading="isLoadingTrips"
+          :disable="isLoadingTrips || dirtyCount === 0"
           data-cy="button-save-bottom"
           @click.prevent="onSave"
         >
@@ -258,8 +256,8 @@ export default defineComponent({
             color="primary"
             size="16px"
             class="text-weight-bold"
-            :loading="isLoadingPostTrips"
-            :disable="isLoadingPostTrips || dirtyCount === 0"
+            :loading="isLoadingTrips"
+            :disable="isLoadingTrips || dirtyCount === 0"
             data-cy="button-save-sticky"
             @click.prevent="onSave"
           >
@@ -274,7 +272,7 @@ export default defineComponent({
     </q-form>
     <!-- Loading spinner -->
     <q-inner-loading
-      :showing="isLoadingRoutes"
+      :showing="isLoadingTrips"
       color="primary"
       data-cy="spinner-route-list-edit"
     />

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -272,5 +272,11 @@ export default defineComponent({
         </div>
       </q-page-sticky>
     </q-form>
+    <!-- Loading spinner -->
+    <q-inner-loading
+      :showing="isLoadingRoutes"
+      color="primary"
+      data-cy="spinner-route-list-edit"
+    />
   </q-layout>
 </template>

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -316,7 +316,7 @@ export default defineComponent({
       <q-inner-loading
         :showing="isLoadingRoutes"
         color="primary"
-        data-cy="spinner-calendar"
+        data-cy="spinner-routes-calendar"
       />
     </div>
     <route-calendar-panel

--- a/src/components/routes/RoutesCalendar.vue
+++ b/src/components/routes/RoutesCalendar.vue
@@ -122,6 +122,9 @@ export default defineComponent({
     const days = computed<RouteDay[]>(() =>
       getCompetitionDaysWithRoutes(tripsStore.getRouteItems),
     );
+    const isLoadingRoutes = computed((): boolean => {
+      return tripsStore.getIsLoading;
+    });
 
     const {
       activeRoutes,
@@ -214,6 +217,7 @@ export default defineComponent({
       disabledBefore,
       isPanelOpen,
       isActiveRouteLogged,
+      isLoadingRoutes,
       locale,
       monthNameAndYear,
       routesMap,
@@ -252,7 +256,7 @@ export default defineComponent({
       />
     </div>
     <!-- Calendar -->
-    <div class="row justify-center q-mt-lg">
+    <div class="relative-position row justify-center q-mt-lg">
       <q-calendar-month
         ref="calendar"
         v-model="selectedDate"
@@ -308,6 +312,12 @@ export default defineComponent({
           </div>
         </template>
       </q-calendar-month>
+      <!-- Loading spinner -->
+      <q-inner-loading
+        :showing="isLoadingRoutes"
+        color="primary"
+        data-cy="spinner-calendar"
+      />
     </div>
     <route-calendar-panel
       v-model="isPanelOpen"

--- a/src/composables/useApiPostTrips.ts
+++ b/src/composables/useApiPostTrips.ts
@@ -1,6 +1,3 @@
-// libraries
-import { ref } from 'vue';
-
 // composables
 import { useApi } from './useApi';
 
@@ -9,9 +6,9 @@ import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // stores
 import { useLoginStore } from '../stores/login';
+import { useTripsStore } from '../stores/trips';
 
 // types
-import type { Ref } from 'vue';
 import type { Logger } from '../components/types/Logger';
 import type { Trip, TripPostPayload } from '../components/types/Trip';
 import type { ApiResponse } from './useApi';
@@ -20,7 +17,6 @@ import type { ApiResponse } from './useApi';
 import { requestDefaultHeader, requestTokenHeader } from '../utils';
 
 interface UseApiPostTripsReturn {
-  isLoading: Ref<boolean>;
   postTrips: (
     trips: TripPostPayload[],
   ) => Promise<ApiResponse<{ trips: Trip[] }>>;
@@ -35,8 +31,8 @@ interface UseApiPostTripsReturn {
 export const useApiPostTrips = (
   logger: Logger | null,
 ): UseApiPostTripsReturn => {
-  const isLoading = ref<boolean>(false);
   const loginStore = useLoginStore();
+  const tripsStore = useTripsStore();
   const { apiFetch } = useApi();
 
   /**
@@ -48,7 +44,7 @@ export const useApiPostTrips = (
     trips: TripPostPayload[],
   ): Promise<ApiResponse<{ trips: Trip[] }>> => {
     logger?.debug(`Creating trips <${JSON.stringify(trips, null, 2)}>.`);
-    isLoading.value = true;
+    tripsStore.setIsLoading(true);
 
     // append access token into HTTP header
     const requestTokenHeader_ = { ...requestTokenHeader };
@@ -71,13 +67,12 @@ export const useApiPostTrips = (
       logger,
     });
 
-    isLoading.value = false;
+    tripsStore.setIsLoading(false);
 
     return response;
   };
 
   return {
-    isLoading,
     postTrips,
   };
 };

--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -33,6 +33,7 @@ describe('Routes calendar page', () => {
         cy.interceptTripsGetApi(config, defLocale);
         cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
         cy.waitForCommuteModeApi();
+        cy.dataCy('spinner-routes-calendar').should('be.visible');
         cy.waitForTripsApi();
       });
     });
@@ -189,6 +190,7 @@ describe('Routes calendar page', () => {
                 '#' + routesConf['routes_calendar']['children']['fullPath'],
               );
               cy.waitForCommuteModeApi();
+              cy.dataCy('spinner-routes-calendar').should('be.visible');
               cy.waitForTripsApi(trips, tripsNext);
             },
           );
@@ -265,6 +267,7 @@ describe('Routes calendar page', () => {
         cy.interceptTripsGetApi(config, defLocale);
         cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
         cy.waitForCommuteModeApi();
+        cy.dataCy('spinner-routes-calendar').should('be.visible');
         cy.waitForTripsApi();
       });
     });

--- a/test/cypress/e2e/routes_list.spec.cy.js
+++ b/test/cypress/e2e/routes_list.spec.cy.js
@@ -32,6 +32,8 @@ describe('Routes list page', () => {
         cy.interceptTripsGetApi(config, defLocale);
         cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
         cy.waitForCommuteModeApi();
+        cy.dataCy('spinner-route-list-edit').should('be.visible');
+        cy.dataCy('spinner-route-list-display').should('be.visible');
         cy.waitForTripsApi();
       });
     });
@@ -228,6 +230,8 @@ describe('Routes list page', () => {
               cy.interceptTripsGetApi(config, defLocale, trips, tripsNext);
               cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
               cy.waitForCommuteModeApi();
+              cy.dataCy('spinner-route-list-edit').should('be.visible');
+              cy.dataCy('spinner-route-list-display').should('be.visible');
               cy.waitForTripsApi(trips, tripsNext);
             },
           );

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -3339,6 +3339,7 @@ Cypress.Commands.add(
       cy.intercept('GET', urlApiTripsLocalized, {
         statusCode: responseStatusCode || httpSuccessfullStatus,
         body: responseBody,
+        delay: interceptedRequestResponseDelay,
       }).as('getTrips');
       // if fixture has next property
       if (responseBody.next) {
@@ -3348,6 +3349,7 @@ Cypress.Commands.add(
           cy.intercept('GET', responseBody.next, {
             statusCode: responseStatusCode || httpSuccessfullStatus,
             body: responseBodyNext,
+            delay: interceptedRequestResponseDelay,
           }).as('getTripsNextPage');
         });
       }


### PR DESCRIPTION
Add loading spinners to route display components.

* Add spinners to `RoutesCalendar` `RouteListDisplay` and `RouteListEdit`.
* Add delay to get-trips intercept to be able to test loaders.
* Add loader checks to E2E tests.