### PR TITLE
test/cypress/e2e: fix comparison translated strings for test notification

### DIFF
--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -223,7 +223,7 @@ describe('Routes calendar page', () => {
           });
           cy.contains(
             i18n.global.t('routes.messageFileTooLarge', {
-              size: `${config.tripMaxFileUploadSizeMegabytes}MB`,
+              size: `${config.tripMaxFileUploadSizeMegabytes} MB`,
             }),
           ).should('be.visible');
           // test valid file

--- a/test/cypress/e2e/routes_list.spec.cy.js
+++ b/test/cypress/e2e/routes_list.spec.cy.js
@@ -267,7 +267,7 @@ describe('Routes list page', () => {
               });
               cy.contains(
                 i18n.global.t('routes.messageFileTooLarge', {
-                  size: `${config.tripMaxFileUploadSizeMegabytes}MB`,
+                  size: `${config.tripMaxFileUploadSizeMegabytes} MB`,
                 }),
               ).should('be.visible');
               // test valid file


### PR DESCRIPTION
Issue: E2E tests fail because they contain incorrect comparison string.

Solution: Update comparison string in `routes_calendar` and `routes_list`.