### PR TITLE
src/stores: add conditions for loading registration and challenge data + clear store on logout

### DIFF
--- a/src/components/homepage/NewsletterFeature.vue
+++ b/src/components/homepage/NewsletterFeature.vue
@@ -63,7 +63,9 @@ export default defineComponent({
     const registerChallengeStore = useRegisterChallengeStore();
 
     onMounted(async () => {
-      await registerChallengeStore.loadRegisterChallengeToStore();
+      if (!registerChallengeStore.getRegistrationId) {
+        await registerChallengeStore.loadRegisterChallengeToStore();
+      }
     });
 
     const getRegistrationId = computed((): number | null => {

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -242,9 +242,9 @@ export default defineComponent({
         await challengeStore.loadPhaseSet();
       }
       // if the information is not set, check if user is coordinator
-      // if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
-      //   await registerChallengeStore.checkIsUserOrganizationAdmin();
-      // }
+      if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
+        await registerChallengeStore.checkIsUserOrganizationAdmin();
+      }
       // load my team data if not available
       if (!registerChallengeStore.getMyTeam) {
         logger?.info('My team data is not available, loading my team data.');

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -242,9 +242,9 @@ export default defineComponent({
         await challengeStore.loadPhaseSet();
       }
       // if the information is not set, check if user is coordinator
-      if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
-        await registerChallengeStore.checkIsUserOrganizationAdmin();
-      }
+      // if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
+      //   await registerChallengeStore.checkIsUserOrganizationAdmin();
+      // }
       // load my team data if not available
       if (!registerChallengeStore.getMyTeam) {
         logger?.info('My team data is not available, loading my team data.');

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -147,9 +147,9 @@ export default defineComponent({
 
     onMounted(async () => {
       // check if user is organization admin
-      // if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
-      //   await registerChallengeStore.checkIsUserOrganizationAdmin();
-      // }
+      if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
+        await registerChallengeStore.checkIsUserOrganizationAdmin();
+      }
       // make sure price level is loaded
       if (!challengeStore.getPriceLevel.length) {
         await challengeStore.loadPhaseSet();

--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -147,8 +147,9 @@ export default defineComponent({
 
     onMounted(async () => {
       // check if user is organization admin
-      registerChallengeStore.checkIsUserOrganizationAdmin();
-
+      // if (registerChallengeStore.getIsUserOrganizationAdmin === null) {
+      //   await registerChallengeStore.checkIsUserOrganizationAdmin();
+      // }
       // make sure price level is loaded
       if (!challengeStore.getPriceLevel.length) {
         await challengeStore.loadPhaseSet();

--- a/src/stores/challenge.ts
+++ b/src/stores/challenge.ts
@@ -176,6 +176,12 @@ export const useChallengeStore = defineStore('challenge', {
         null
       );
     },
+    resetPersistentProperties(): void {
+      this.phaseSet = [];
+      this.daysActive = null;
+      this.maxTeamMembers = null;
+      this.priceLevel = [];
+    },
   },
 
   persist: {

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -192,14 +192,6 @@ export const useLoginStore = defineStore('login', {
 
       await this.processLoginData(data);
 
-      // force load this_campaign
-      const challengeStore = useChallengeStore();
-      await challengeStore.loadPhaseSet();
-
-      // force load register-challenge
-      const registerChallengeStore = useRegisterChallengeStore();
-      await registerChallengeStore.loadRegisterChallengeToStore();
-
       if (data && loginOptions.redirectAfterLogin) {
         await this.redirectHomeAfterLogin();
       }
@@ -324,6 +316,12 @@ export const useLoginStore = defineStore('login', {
       this.$log?.debug(
         `Login was successfull, redirect to <${routesConf['home']['path']}> URL.`,
       );
+      /**
+       * Load register-challenge from the API, to prevent
+       * showing register challenge page.
+       */
+      this.$log?.info('Check the register challenge from the API.');
+      await registerChallengeStore.loadRegisterChallengeToStore();
       /**
        * Load user coordinator status from the API
        * to prevent sending user to the register challenge page

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -192,6 +192,14 @@ export const useLoginStore = defineStore('login', {
 
       await this.processLoginData(data);
 
+      // force load this_campaign
+      const challengeStore = useChallengeStore();
+      await challengeStore.loadPhaseSet();
+
+      // force load register-challenge
+      const registerChallengeStore = useRegisterChallengeStore();
+      await registerChallengeStore.loadRegisterChallengeToStore();
+
       if (data && loginOptions.redirectAfterLogin) {
         await this.redirectHomeAfterLogin();
       }
@@ -353,6 +361,9 @@ export const useLoginStore = defineStore('login', {
       // clear registerChallenge store
       const registerChallengeStore = useRegisterChallengeStore();
       registerChallengeStore.resetPersistentProperties();
+      // clear challenge store
+      const challengeStore = useChallengeStore();
+      challengeStore.resetPersistentProperties();
       // clear feed store on logout
       const feedStore = useFeedStore();
       feedStore.clearStore();

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -10,6 +10,7 @@ import {
 } from '../support/commonTests';
 import { routesConf } from '../../../src/router/routes_conf';
 import { httpSuccessfullStatus } from '../support/commonTests';
+import { defLocale } from '../../../src/i18n/def_locale';
 
 const { hexToRgb } = colors;
 const selectorFormLoginEmail = 'form-login-email';
@@ -198,7 +199,31 @@ describe('Login page', () => {
         cy.window().then((win) => {
           // alias i18n
           cy.wrap(win.i18n).as('i18n');
+          // intercept login API call
           setupApiChallengeActive(config, win.i18n, true);
+          // intercept campaign get API call
+          cy.interceptThisCampaignGetApi(config, defLocale);
+          // intercept register-challenge get API call
+          cy.fixture('apiGetRegisterChallengeIndividualPaid.json').then(
+            (response) => {
+              cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+            },
+          );
+          cy.fixture('apiGetIsUserOrganizationAdminResponseTrue').then(
+            (responseIsUserOrganizationAdmin) => {
+              cy.interceptIsUserOrganizationAdminGetApi(
+                config,
+                defLocale,
+                responseIsUserOrganizationAdmin,
+              );
+            },
+          );
+          // intercept my team API
+          cy.fixture('apiGetMyTeamResponseUndecided.json').then(
+            (responseMyTeam) => {
+              cy.interceptMyTeamGetApi(config, defLocale, responseMyTeam);
+            },
+          );
         });
       });
     });
@@ -224,6 +249,19 @@ describe('Login page', () => {
       cy.dataCy('form-login-password').should('be.visible');
       cy.dataCy('form-login-forgotten-password').should('be.visible');
       cy.dataCy('form-login-submit-login').should('be.visible');
+    });
+
+    it('loads this_campaign and register-challenge after login', () => {
+      // fill in and submit form
+      cy.fillAndSubmitLoginForm();
+      // wait for login API call
+      cy.wait('@loginRequest');
+      // wait for this_campaign
+      cy.wait('@thisCampaignRequest');
+      // wait for register-challenge
+      cy.wait('@getRegisterChallenge');
+      // above requests run while still on login page
+      cy.url().should('include', routesConf['login']['path']);
     });
 
     it('allows user to login and refreshes token 1 min before expiration', () => {

--- a/test/cypress/e2e/login.spec.cy.js
+++ b/test/cypress/e2e/login.spec.cy.js
@@ -260,6 +260,8 @@ describe('Login page', () => {
       cy.wait('@thisCampaignRequest');
       // wait for register-challenge
       cy.wait('@getRegisterChallenge');
+      // wait for is-user-organization-admin
+      cy.wait('@getIsUserOrganizationAdmin');
       // above requests run while still on login page
       cy.url().should('include', routesConf['login']['path']);
     });


### PR DESCRIPTION
Add conditions for loading registration and challenge data + clear store on logout.

* Ensure that `register-challenge` data is loaded after login, before redirecting to homepage (this should bypass going to /#/register-challenge page, to fetch data about register-challenge unless user is not registered).
* Add method `resetPersistentProperties` to challenge store to clear store on logout.
* Add E2E test checking for the sent requests.