### PR TITLE
src/stores: clear trips store after logout to force trips reload on new login

### DIFF
--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -20,6 +20,7 @@ import { useRegisterStore } from './register';
 import { useChallengeStore } from './challenge';
 import { useFeedStore } from './feed';
 import { useRegisterChallengeStore } from './registerChallenge';
+import { useTripsStore } from './trips';
 
 // types
 import type { Logger } from '../components/types/Logger';
@@ -365,6 +366,9 @@ export const useLoginStore = defineStore('login', {
       // clear feed store on logout
       const feedStore = useFeedStore();
       feedStore.clearStore();
+      // clear trips store
+      const tripsStore = useTripsStore();
+      tripsStore.clearRouteItems();
       // redirect to login page
       if (this.$router) {
         this.$log?.debug(

--- a/src/stores/trips.ts
+++ b/src/stores/trips.ts
@@ -184,5 +184,12 @@ export const useTripsStore = defineStore('trips', {
       }
       this.isLoadingOpenAppWithRestToken = false;
     },
+    /**
+     * Clear route items from store
+     * @returns {void}
+     */
+    clearRouteItems(): void {
+      this.routeItems = [];
+    },
   },
 });


### PR DESCRIPTION
Clear trips store after logout to force trips reload on new login.

* Add `clearRouteItems` function to `trips` store.
* Use `clearRouteItems` function on logout.
* Test that trips GET API request is called after logout + login (E2E).