### PR TITLE
src/pages: hide top bar countdown after challenge phase starts

### DIFF
--- a/src/pages/RegisterChallengePage.vue
+++ b/src/pages/RegisterChallengePage.vue
@@ -47,6 +47,7 @@ import RegisterChallengePaymentMessages from '../components/register/RegisterCha
 // composables
 import { useStepperValidation } from 'src/composables/useStepperValidation';
 import { useOrganizations } from 'src/composables/useOrganizations';
+import { useIsBeforeCompetitionPhase } from 'src/composables/useIsBeforeCompetitionPhase';
 
 // enums
 import { OrganizationType } from 'src/components/types/Organization';
@@ -354,6 +355,8 @@ export default defineComponent({
       secondsToWaitDef.value -= 1;
     }, 1000);
 
+    const { isBeforeCompetitionStart } = useIsBeforeCompetitionPhase();
+
     return {
       borderRadius,
       contactEmail,
@@ -389,6 +392,7 @@ export default defineComponent({
       activeIconImgSrcStepper7,
       doneIconImgSrcStepper7,
       merchId,
+      isBeforeCompetitionStart,
       isPaymentAmount,
       isPeriodicCheckInProgress,
       isRegistrationComplete,
@@ -414,6 +418,7 @@ export default defineComponent({
 
 <template>
   <top-bar-countdown
+    v-if="isBeforeCompetitionStart"
     :release-date="competitionStart"
     data-cy="top-bar-countdown"
   />

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -3,7 +3,6 @@ import {
   testLanguageSwitcher,
   testBackgroundImage,
   interceptRegisterCoordinatorApi,
-  systemTimeRegistrationPhaseActive,
   systemTimeChallengeActive,
   systemTimeBeforeCompetitionStart,
   systemTimeRegistrationPhase1May,
@@ -120,7 +119,6 @@ describe('Register Challenge page', () => {
 
   context('desktop', () => {
     beforeEach(() => {
-      cy.clock(systemTimeRegistrationPhaseActive, ['Date']);
       cy.task('getAppConfig', process).then((config) => {
         cy.interceptThisCampaignGetApi(config, defLocale);
         cy.interceptRegisterChallengeGetApi(config, defLocale);
@@ -272,7 +270,6 @@ describe('Register Challenge page', () => {
               'register.challenge.titleRegisterToChallenge.october',
             );
           }
-          cy.dataCy('top-bar-countdown').should('be.visible');
           cy.dataCy('login-register-title')
             .should('be.visible')
             .and('have.color', config.colorWhite)
@@ -4203,7 +4200,7 @@ describe('Register Challenge page', () => {
     });
   });
 
-  context('registration with payment voucher 95% discount', () => {
+  context('Countdown before competition phase', () => {
     beforeEach(() => {
       cy.clock(systemTimeBeforeCompetitionStart, ['Date']);
       cy.task('getAppConfig', process).then((config) => {


### PR DESCRIPTION
Hide `TopBarCountdown` on `RegisterChallengePage` after challenge phase starts.

* Use `useIsBeforeCompetitionPhase` composable to hide `TopBarCountdown` on `RegisterChallengePage`.
* Add `register_challenge` E2E test.