### PR TITLE
test/cypress/e2e: intercept register-challenge get request in register_coordinator e2e test

### DIFF
--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -140,6 +140,7 @@ describe('Login page', () => {
                   );
                   cy.interceptIsUserOrganizationAdminGetApi(config, win.i18n);
                   cy.fillAndSubmitLoginForm(config, win.i18n);
+                  cy.interceptRegisterChallengeGetApi(config, win.i18n);
                   cy.wait([
                     '@loginRequest',
                     '@refreshAuthTokenRequest',


### PR DESCRIPTION
Issue: `register_coordinator` test fails because it is waiting for response from `register-challenge` endpoint.

Solution: Add intercept for `register-challenge` get request.