### PR TITLE
test/cypress/e2e: intercept requests in router_rules e2e test

### DIFF
--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -36,6 +36,24 @@ describe('Router rules', () => {
                   );
                 },
               );
+              cy.fixture('apiGetRegisterChallengeEmpty.json').then(
+                (response) => {
+                  cy.interceptRegisterChallengeGetApi(
+                    config,
+                    win.i18n,
+                    response,
+                  );
+                },
+              );
+              cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+                (response) => {
+                  cy.interceptIsUserOrganizationAdminGetApi(
+                    config,
+                    win.i18n,
+                    response,
+                  );
+                },
+              );
             },
           );
         });
@@ -151,6 +169,18 @@ describe('Router rules', () => {
                     OrganizationType.company,
                   );
                 },
+              );
+            },
+          );
+          cy.fixture('apiGetRegisterChallengeEmpty.json').then((response) => {
+            cy.interceptRegisterChallengeGetApi(config, win.i18n, response);
+          });
+          cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+            (response) => {
+              cy.interceptIsUserOrganizationAdminGetApi(
+                config,
+                win.i18n,
+                response,
               );
             },
           );


### PR DESCRIPTION
Issue: E2E test `router_rules` fails because it is waiting for response from `register-challenge/` and `is-user-organization-admin/` endpoints.

Solution: Add intercepts for `register-challenge/` and `is-user-organization-admin/` endpoints.