### PR TITLE
test/cypress/e2e: intercept requests in register_challenge e2e tests

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -117,6 +117,21 @@ describe('Register Challenge page', () => {
     });
   });
 
+  beforeEach(() => {
+    cy.task('getAppConfig', process).then((config) => {
+      cy.interceptMyTeamGetApi(config, defLocale);
+      cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+        (response) => {
+          cy.interceptIsUserOrganizationAdminGetApi(
+            config,
+            defLocale,
+            response,
+          );
+        },
+      );
+    });
+  });
+
   context('desktop', () => {
     beforeEach(() => {
       cy.task('getAppConfig', process).then((config) => {


### PR DESCRIPTION
Issue: E2E tests `register_challenge` fail because it is waiting for response from `my-team/` and `is-user-organization-admin/` endpoints.

Solution: Add intercepts for `my-team/` and `is-user-organization-admin/` endpoints in section shared for all contexts.