### PR TITLE
src/components: fix footer content covers the save routes button on mobile screen

### DIFF
--- a/src/components/global/FooterBar.vue
+++ b/src/components/global/FooterBar.vue
@@ -22,6 +22,7 @@
 // libraries
 import { colors } from 'quasar';
 import { computed, defineComponent, inject } from 'vue';
+import { useRoute } from 'vue-router';
 
 import { i18n } from '../../boot/i18n';
 import { defaultLocale } from '../../i18n/def_locale';
@@ -36,6 +37,7 @@ import { useSocialLinks } from '../../composables/useSocialLinks';
 
 // config
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
+import { routesConf } from 'src/router/routes_conf';
 
 // types
 import { ConfigAppVersion } from '../types/Config';
@@ -116,12 +118,19 @@ export default defineComponent({
       );
     });
 
+    // Flag to add space for floating button on routes list page
+    const route = useRoute();
+    const pathIsRoutesList = computed(() => {
+      return route.path === routesConf.routes_list.children.fullPath;
+    });
+
     return {
       appInfo,
       deployedAppVersion,
       logoLinkUrl,
       maxWidth,
       primaryOpacity,
+      pathIsRoutesList,
       rideToWorkByBikeDeployedAppVersion,
       socialLinks,
       scrollToTop,
@@ -316,6 +325,13 @@ export default defineComponent({
               <span v-if="index < appInfo.length - 1" class="gt-sm">|</span>
             </div>
           </div>
+
+          <!-- Add space for floating button on routes list page -->
+          <div
+            v-if="pathIsRoutesList"
+            class="lt-md q-pb-xl"
+            data-cy="footer-routes-list-spacer"
+          />
         </div>
       </div>
     </div>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -155,7 +155,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <q-layout>
+  <div>
     <q-form ref="formRef" data-cy="route-list-edit">
       <!-- First save routes button on the large screen -->
       <div
@@ -246,28 +246,32 @@ export default defineComponent({
         </q-btn>
       </div>
       <!-- Sticky save routes button on the mobile screen -->
-      <q-page-sticky v-else position="bottom" :offset="[0, 80]" class="z-top">
-        <div class="bg-white" style="border-radius: 999px">
-          <q-btn
-            rounded
-            unelevated
-            type="submit"
-            color="primary"
-            size="16px"
-            class="text-weight-bold"
-            :loading="isLoadingTrips"
-            :disable="isLoadingTrips || dirtyCount === 0"
-            data-cy="button-save-sticky"
-            @click.prevent="onSave"
-          >
-            {{
-              $t('routes.buttonSaveChangesCount', dirtyCount, {
-                count: dirtyCount,
-              })
-            }}
-          </q-btn>
-        </div>
-      </q-page-sticky>
+      <teleport to="body">
+        <q-layout v-if="!isLargeScreen" style="min-height: 0">
+          <q-page-sticky position="bottom" :offset="[0, 80]" class="z-top">
+            <div class="bg-white" style="border-radius: 999px">
+              <q-btn
+                rounded
+                unelevated
+                type="submit"
+                color="primary"
+                size="16px"
+                class="text-weight-bold"
+                :loading="isLoadingTrips"
+                :disable="isLoadingTrips || dirtyCount === 0"
+                data-cy="button-save-sticky"
+                @click.prevent="onSave"
+              >
+                {{
+                  $t('routes.buttonSaveChangesCount', dirtyCount, {
+                    count: dirtyCount,
+                  })
+                }}
+              </q-btn>
+            </div>
+          </q-page-sticky>
+        </q-layout>
+      </teleport>
     </q-form>
     <!-- Loading spinner -->
     <q-inner-loading
@@ -275,5 +279,5 @@ export default defineComponent({
       color="primary"
       data-cy="spinner-route-list-edit"
     />
-  </q-layout>
+  </div>
 </template>

--- a/src/components/routes/RouteListEdit.vue
+++ b/src/components/routes/RouteListEdit.vue
@@ -248,7 +248,7 @@ export default defineComponent({
       <!-- Sticky save routes button on the mobile screen -->
       <teleport to="body">
         <q-layout v-if="!isLargeScreen" style="min-height: 0">
-          <q-page-sticky position="bottom" :offset="[0, 80]" class="z-top">
+          <q-page-sticky position="bottom" :offset="[0, 80]">
             <div class="bg-white" style="border-radius: 999px">
               <q-btn
                 rounded

--- a/test/cypress/e2e/routes_list.spec.cy.js
+++ b/test/cypress/e2e/routes_list.spec.cy.js
@@ -25,6 +25,29 @@ describe('Routes list page', () => {
         });
         cy.waitForThisCampaignApi(campaign);
       });
+      cy.fixture('apiGetRegisterChallengeIndividualPaidCompleteStaff').then(
+        (responseRegisterChallenge) => {
+          cy.interceptRegisterChallengeGetApi(
+            config,
+            defLocale,
+            responseRegisterChallenge,
+          );
+        },
+      );
+      // intercept is user organization admin API
+      cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+        (response) => {
+          cy.interceptIsUserOrganizationAdminGetApi(
+            config,
+            defLocale,
+            response,
+          );
+        },
+      );
+      // intercept my team GET API
+      cy.fixture('apiGetMyTeamResponseApproved.json').then((responseMyTeam) => {
+        cy.interceptMyTeamGetApi(config, defLocale, responseMyTeam);
+      });
     });
   });
 
@@ -516,6 +539,67 @@ describe('Routes list page', () => {
           });
         });
       });
+    });
+  });
+
+  context('mobile - with logged routes', () => {
+    beforeEach(() => {
+      cy.viewport('iphone-6');
+      cy.get('@config').then((config) => {
+        cy.interceptCommuteModeGetApi(config, defLocale);
+        cy.interceptTripsGetApi(config, defLocale);
+        cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
+        cy.waitForCommuteModeApi();
+        cy.dataCy('spinner-route-list-edit').should('be.visible');
+        cy.dataCy('spinner-route-list-display').should('be.visible');
+        cy.waitForTripsApi();
+      });
+    });
+
+    it('shows floating button that does not overlap with footer', () => {
+      cy.dataCy('button-save-sticky').should('be.visible');
+      // scroll down to bottom of page
+      cy.scrollTo('bottom');
+      // check that floating button is visible
+      cy.dataCy('button-save-sticky').should('be.visible');
+      // spacer element should be visible on the bottom of the page
+      cy.dataCy('footer-routes-list-spacer').should('be.visible');
+      // check that footer content is not covered by floating button
+      cy.dataCy('footer-app-info-mobile').should('be.visible');
+      cy.testElementsNoOverlap('footer-app-info-mobile', 'button-save-sticky');
+      cy.dataCy('footer-social-menu').should('be.visible');
+      cy.testElementsNoOverlap('footer-social-menu', 'button-save-sticky');
+      cy.dataCy('language-switcher-footer').should('be.visible');
+      cy.testElementsNoOverlap(
+        'language-switcher-footer',
+        'button-save-sticky',
+      );
+    });
+
+    it('makes space for floating button in footer on routes list page, but nowhere else', () => {
+      // check that spacer element is visible on the bottom of the page
+      cy.dataCy('footer-routes-list-spacer').should('be.visible');
+      // check that spacer element is not visible on other pages
+      cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
+      cy.visit('#' + routesConf['routes_app']['children']['fullPath']);
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
+      // home
+      cy.visit('#' + routesConf['home']['children']['fullPath']);
+      cy.dataCy('index-title').should('be.visible');
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
+      // results
+      cy.visit('#' + routesConf['results']['children']['fullPath']);
+      cy.dataCy('results-page-title').should('be.visible');
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
+      // prizes
+      cy.visit('#' + routesConf['prizes']['children']['fullPath']);
+      cy.dataCy('prizes-page-title').should('be.visible');
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
+      // profile
+      cy.visit('#' + routesConf['profile_details']['children']['fullPath']);
+      cy.dataCy('profile-page-title').should('be.visible');
+      cy.dataCy('footer-routes-list-spacer').should('not.exist');
     });
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -273,6 +273,24 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'testElementsNoOverlap',
+  (elementSelector, otherElementSelector) => {
+    cy.dataCy(elementSelector).then((element) => {
+      const rect1 = element[0].getBoundingClientRect();
+      cy.dataCy(otherElementSelector).then((otherElement) => {
+        const rect2 = otherElement[0].getBoundingClientRect();
+        const noOverlap =
+          rect1.right < rect2.left ||
+          rect1.left > rect2.right ||
+          rect1.bottom < rect2.top ||
+          rect1.top > rect2.bottom;
+        cy.wrap(noOverlap).should('be.true');
+      });
+    });
+  },
+);
+
 Cypress.Commands.add('testSoacialMediaUrlRequest', (rideToWorkByBikeConfig) => {
   cy.request({
     url: rideToWorkByBikeConfig.urlFacebook,


### PR DESCRIPTION
Fixes [Bug 123](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=123)

Update `RouteListEdit` floating button position with Vue `<teleport>`:

* Teleport the QLayout + QPageSticky wrapper to the bottom of the body to fix the stacking.
* Add conditional spacing element in `FooterBar` for the `routes-list` path to make space for floating button when scrolled to the bottom of the page.
* Add tests.