### PR TITLE
src/components: remove URL parameters after Strava authentication

### DIFF
--- a/src/components/routes/RoutesApps.vue
+++ b/src/components/routes/RoutesApps.vue
@@ -17,7 +17,7 @@
 // libraries
 import { computed, defineComponent, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 // components
 import BannerRoutesApp from './BannerRoutesApp.vue';
@@ -49,6 +49,7 @@ export default defineComponent({
     const urlAppStore = rideToWorkByBikeConfig.urlAppStore;
     const urlGooglePlay = rideToWorkByBikeConfig.urlGooglePlay;
     const route = useRoute();
+    const router = useRouter();
     const stravaStore = useStravaStore();
     const tripsStore = useTripsStore();
     const isLoadingAuthStrava = ref<boolean>(false);
@@ -65,6 +66,8 @@ export default defineComponent({
         isLoadingAuthStrava.value = true;
         await stravaStore.authAccount(code);
         isLoadingAuthStrava.value = false;
+        // remove code parameter from URL
+        router.replace({ query: {} });
       }
 
       // load app URLs if not already loaded

--- a/test/cypress/e2e/strava.spec.cy.js
+++ b/test/cypress/e2e/strava.spec.cy.js
@@ -188,6 +188,8 @@ describe('Strava Integration', () => {
           cy.contains(i18n.global.t('authStravaAccount.apiMessageSuccess'));
           // check component is visible
           cy.dataCy('strava-app').should('be.visible');
+          // check that URL no longer contains code
+          cy.url().should('not.include', `?code=${validCode}`);
           // open expansion item
           cy.dataCy('strava-app-expansion-item-header')
             .should('be.visible')
@@ -232,6 +234,8 @@ describe('Strava Integration', () => {
           cy.contains(
             i18n.global.t('authStravaAccount.apiMessageErrorWithMessage'),
           );
+          // check that URL no longer contains code
+          cy.url().should('not.include', `?code=${invalidCode}`);
         });
       });
     });


### PR DESCRIPTION
Fixes [Bug 125](https://bugzilla.dopracenakole.net/bugzilla/show_bug.cgi?id=125)
Remove URL parameters after Strava account auth.
This prevents a bug where page refresh calls the `authAccount` action again with the same code which is now invalid.