### PR TITLE
test/cypress/e2e: fix routes test by setting exact destination path

### DIFF
--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -128,7 +128,7 @@ describe('Routes page', () => {
 
     it('renders warning banners when user is not approved in team', () => {
       cy.get('@i18n').then((i18n) => {
-        cy.visit('#' + routesConf['routes']['children']['fullPath']);
+        cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
         cy.waitForCommuteModeApi();
         // initial state
         cy.url().should('include', routesConf['routes_calendar'].path);


### PR DESCRIPTION
Issue: `routes.spec.cy.js` tends to fail as it does not reliably redirects from root `routes` path to `calendar`.

Fix this by specifying explicitly the navigation to `routes_calendar` path.