### PR TITLE
src/adapters: fix trips REST API URL endpoint payload distanceMeters field int value type

### DIFF
--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -76,7 +76,7 @@ export const tripsAdapter = {
       direction,
       commuteMode: routeItem.transport,
       distanceMeters: hasTransportDistance(routeItem.transport)
-        ? distanceMeters
+        ? Math.round(distanceMeters)
         : 0,
       sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
     };


### PR DESCRIPTION
Trips REST API URL endpoint `distanceMeters` field require integer value type.