### PR TITLE
src/stores/results: add new tab teamRegularityCity to results page

### DIFF
--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -45,6 +45,7 @@ describe('<ResultsTabs>', () => {
         'performanceOrganization',
         'regularity',
         'septemberJanuary',
+        'teamRegularityCity',
       ],
       'results.reportType',
       i18n,
@@ -76,6 +77,7 @@ describe('<ResultsTabs>', () => {
         resultsByChallengeResponses.forEach((resultsByChallengeResponse) => {
           cy.waitForGetResultsByChallengeApi(
             resultsByChallengeResponse.response,
+            resultsByChallengeResponse.key,
           );
           cy.dataCy(`results-tab-${resultsByChallengeResponse.key}`).should(
             'be.visible',
@@ -98,6 +100,7 @@ describe('<ResultsTabs>', () => {
           resultsByChallengeResponses.forEach((resultsByChallengeResponse) => {
             cy.waitForGetResultsByChallengeApi(
               resultsByChallengeResponse.response,
+              resultsByChallengeResponse.key,
             );
             cy.dataCy(`results-tab-${resultsByChallengeResponse.key}`).should(
               'be.visible',
@@ -110,11 +113,15 @@ describe('<ResultsTabs>', () => {
           if (
             [
               ResultsReportType.regularity,
+              ResultsReportType.teamRegularityCity,
               ResultsReportType.performanceOrganization,
               ResultsReportType.organizationsReview,
             ].includes(resultsResponse.key)
           ) {
-            cy.waitForGetResultsApi(resultsResponse.response);
+            cy.waitForGetResultsApi(
+              resultsResponse.response,
+              resultsResponse.key,
+            );
             cy.dataCy(`results-tab-${resultsResponse.key}`).should(
               'be.visible',
             );
@@ -143,6 +150,7 @@ describe('<ResultsTabs>', () => {
           resultsByChallengeResponses.forEach((resultsByChallengeResponse) => {
             cy.waitForGetResultsByChallengeApi(
               resultsByChallengeResponse.response,
+              resultsByChallengeResponse.key,
             );
             cy.dataCy(`results-tab-${resultsByChallengeResponse.key}`).should(
               'be.visible',
@@ -159,7 +167,10 @@ describe('<ResultsTabs>', () => {
               ResultsReportType.organizationsReview,
             ].includes(resultsResponse.key)
           ) {
-            cy.waitForGetResultsApi(resultsResponse.response);
+            cy.waitForGetResultsApi(
+              resultsResponse.response,
+              resultsResponse.key,
+            );
             cy.dataCy(`results-tab-${resultsResponse.key}`).should(
               'be.visible',
             );
@@ -191,6 +202,7 @@ describe('<ResultsTabs>', () => {
           resultsByChallengeResponses.forEach((resultsByChallengeResponse) => {
             cy.waitForGetResultsByChallengeApi(
               resultsByChallengeResponse.response,
+              resultsByChallengeResponse.key,
             );
             cy.dataCy(`results-tab-${resultsByChallengeResponse.key}`)
               .should('be.visible')
@@ -203,7 +215,10 @@ describe('<ResultsTabs>', () => {
       );
       cy.fixture('apiGetResultsResponses').then((resultsResponses) => {
         resultsResponses.forEach((resultsResponse) => {
-          cy.waitForGetResultsApi(resultsResponse.response);
+          cy.waitForGetResultsApi(
+            resultsResponse.response,
+            resultsResponse.key,
+          );
           cy.dataCy(`results-tab-${resultsResponse.key}`)
             .should('be.visible')
             .click({ force: true });

--- a/src/components/enums/Results.ts
+++ b/src/components/enums/Results.ts
@@ -1,5 +1,6 @@
 export enum ResultsReportType {
   regularity = 'regularity',
+  teamRegularityCity = 'team-regularity-city',
   performanceCity = 'performance-city',
   performanceOrganization = 'performance-organization',
   organizationsReview = 'organizations-review',

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -992,6 +992,7 @@ performanceCity = "Výkonnost ve měste"
 performanceOrganization = "Výkonnost v organizaci"
 regularity = "Pravidelnost v organizaci"
 septemberJanuary = "Zářijová/Lednová výzva"
+teamRegularityCity = "Týmová pravidelnost ve městech"
 
 [routes]
 appStrava = "Strava"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -991,6 +991,7 @@ performanceCity = "Performance in City"
 performanceOrganization = "Performance in Organization"
 regularity = "Regularity in Organization"
 septemberJanuary = "September/January Challenge"
+teamRegularityCity = "Team regularity in cities"
 
 [routes]
 appStrava = "Strava"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -991,6 +991,7 @@ performanceCity = "Výkonnosť v meste"
 performanceOrganization = "Výkonnosť v organizácii"
 regularity = "Pravidelnosť v organizácii"
 septemberJanuary = "Septembrová/Januárová výzva"
+teamRegularityCity = "Tímová pravidelnosť v mestách"
 
 [routes]
 appStrava = "Strava"

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -131,16 +131,16 @@ export const useResultsStore = defineStore('results', {
         // add organization admin report types
         if (isUserOrganizationAdmin) {
           [
-            ResultsReportType.teamRegularityCity,
             ResultsReportType.performanceOrganization,
             ResultsReportType.organizationsReview,
           ].forEach((type) => reportTypesPerRole.add(type));
         }
         // add staff report types
         if (isUserStaff) {
-          [ResultsReportType.organizationsReview].forEach((type) =>
-            reportTypesPerRole.add(type),
-          );
+          [
+            ResultsReportType.teamRegularityCity,
+            ResultsReportType.organizationsReview,
+          ].forEach((type) => reportTypesPerRole.add(type));
         }
         // prepare requests for all role-specific report types
         for (const type of reportTypesPerRole) {

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -52,6 +52,9 @@ export const useResultsStore = defineStore('results', {
         [ResultsReportType.regularity]: i18n.global.t(
           'results.reportType.regularity',
         ),
+        [ResultsReportType.teamRegularityCity]: i18n.global.t(
+          'results.reportType.teamRegularityCity',
+        ),
         [ResultsReportType.performanceCity]: i18n.global.t(
           'results.reportType.performanceCity',
         ),
@@ -128,6 +131,7 @@ export const useResultsStore = defineStore('results', {
         // add organization admin report types
         if (isUserOrganizationAdmin) {
           [
+            ResultsReportType.teamRegularityCity,
             ResultsReportType.performanceOrganization,
             ResultsReportType.organizationsReview,
           ].forEach((type) => reportTypesPerRole.add(type));

--- a/test/cypress/fixtures/apiGetResultsResponses.json
+++ b/test/cypress/fixtures/apiGetResultsResponses.json
@@ -2,31 +2,31 @@
   {
     "key": "regularity",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/3"
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/11d87a37-c391-45fd-8f97-dd2c52b869bc"
     }
   },
   {
     "key": "team-regularity-city",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/7"
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/a017d6b1-b7a3-4744-ad0c-40ebface3476"
     }
   },
   {
     "key": "performance-city",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/4"
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/b431fe05-1dbe-4462-8627-af584e327791"
     }
   },
   {
     "key": "performance-organization",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/5"
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/bdf0c0b6-29ac-4595-84f8-5205e32e7d5a"
     }
   },
   {
     "key": "organizations-review",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/6"
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/4db3c6ac-6e88-4db4-aaca-7b7fa3e1da65"
     }
   }
 ]

--- a/test/cypress/fixtures/apiGetResultsResponses.json
+++ b/test/cypress/fixtures/apiGetResultsResponses.json
@@ -6,6 +6,12 @@
     }
   },
   {
+    "key": "team-regularity-city",
+    "response": {
+      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/7"
+    }
+  },
+  {
     "key": "performance-city",
     "response": {
       "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/4"

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -3830,7 +3830,7 @@ Cypress.Commands.add(
         ? responseStatusCode
         : httpSuccessfullStatus,
       body: responseBody,
-    }).as('getResultsRequest');
+    }).as(`getResultsRequest-${reportType}`);
   },
 );
 
@@ -3839,8 +3839,8 @@ Cypress.Commands.add(
  * Wait for `@getResultsRequest` intercept
  * @param {object} responseBody - Override default response body from fixture
  */
-Cypress.Commands.add('waitForGetResultsApi', (responseBody) => {
-  cy.wait('@getResultsRequest').then((getResultsRequest) => {
+Cypress.Commands.add('waitForGetResultsApi', (responseBody, reportType) => {
+  cy.wait(`@getResultsRequest-${reportType}`).then((getResultsRequest) => {
     if (getResultsRequest.response) {
       expect(getResultsRequest.response.statusCode).to.equal(
         httpSuccessfullStatus,
@@ -3876,7 +3876,7 @@ Cypress.Commands.add(
         ? responseStatusCode
         : httpSuccessfullStatus,
       body: responseBody,
-    }).as('getResultsByChallengeRequest');
+    }).as(`getResultsByChallengeRequest-${reportType}`);
   },
 );
 
@@ -3885,17 +3885,20 @@ Cypress.Commands.add(
  * Wait for `@getResultsByChallengeRequest` intercept
  * @param {object} responseBody - Override default response body from fixture
  */
-Cypress.Commands.add('waitForGetResultsByChallengeApi', (responseBody) => {
-  cy.wait('@getResultsByChallengeRequest').then(
-    (getResultsByChallengeRequest) => {
-      if (getResultsByChallengeRequest.response) {
-        expect(getResultsByChallengeRequest.response.statusCode).to.equal(
-          httpSuccessfullStatus,
-        );
-        expect(getResultsByChallengeRequest.response.body).to.deep.equal(
-          responseBody,
-        );
-      }
-    },
-  );
-});
+Cypress.Commands.add(
+  'waitForGetResultsByChallengeApi',
+  (responseBody, reportType) => {
+    cy.wait(`@getResultsByChallengeRequest-${reportType}`).then(
+      (getResultsByChallengeRequest) => {
+        if (getResultsByChallengeRequest.response) {
+          expect(getResultsByChallengeRequest.response.statusCode).to.equal(
+            httpSuccessfullStatus,
+          );
+          expect(getResultsByChallengeRequest.response.body).to.deep.equal(
+            responseBody,
+          );
+        }
+      },
+    );
+  },
+);


### PR DESCRIPTION
Add new tab `teamRegularityCity` to results page.

* Add key to be fetched (only if user is organization admin).
* Add labels.

Additional change: Fix `ResultsTabs.cy.js` test which sometimes awaited intercepted responses in the wrong order.

* Add unique keys to intercepts and awaits to prevent data mismatch.