### PR TITLE
src/stores/challenge: update checking for phase range with Quasar utils

### DIFF
--- a/src/stores/challenge.ts
+++ b/src/stores/challenge.ts
@@ -1,4 +1,5 @@
 // libraries
+import { date } from 'quasar';
 import { defineStore } from 'pinia';
 import { PhaseType } from '../components/types/Challenge';
 
@@ -156,31 +157,44 @@ export const useChallengeStore = defineStore('challenge', {
       this.$log?.debug(`Checking if challenge is in <${phaseType}> phase.`);
       const phase = this.getPhaseFromSet(phaseType);
       if (phase) {
-        const startDate: number = new Date(phase.date_from).getTime();
+        const startDate: Date = new Date(phase.date_from);
         this.$log?.debug(
-          `<${phaseType}> phase date from <${timestampToDatetimeString(startDate / 1000)}>.`,
+          `<${phaseType}> phase date from <${timestampToDatetimeString(startDate.getTime() / 1000)}>.`,
         );
-        const now: number = new Date().getTime();
+        const now: Date = new Date();
         this.$log?.debug(
-          `Current date and time is <${timestampToDatetimeString(now / 1000)}>.`,
+          `Current date and time is <${timestampToDatetimeString(now.getTime() / 1000)}>.`,
         );
         // if phase has no end date, only check if we're after start date
         if (!phase.date_to) {
           this.$log?.debug(
             `No end date set for phase <${phaseType}>,` +
               ' checking only if current date is after' +
-              ` start date <${now >= startDate}>.`,
+              ` start date <${date.getDateDiff(now, startDate, 'days') >= 0}>.`,
           );
-          return now >= startDate;
+          return date.getDateDiff(now, startDate, 'days') >= 0;
         }
-        const endDate: number = new Date(phase.date_to).getTime();
+        const endDate: Date = new Date(phase.date_to);
         this.$log?.debug(
-          `<${phaseType}> phase date to <${timestampToDatetimeString(endDate / 1000)}>.`,
+          `<${phaseType}> phase date to <${timestampToDatetimeString(endDate.getTime() / 1000)}>.`,
         );
         this.$log?.debug(
-          `Is challenge in phase type <${phaseType}> <${now >= startDate && now <= endDate}>.`,
+          `Is challenge in phase type <${phaseType}> <${date.isBetweenDates(
+            now,
+            startDate,
+            endDate,
+            {
+              inclusiveFrom: true,
+              inclusiveTo: true,
+              onlyDate: true,
+            },
+          )}>.`,
         );
-        return now >= startDate && now <= endDate;
+        return date.isBetweenDates(now, startDate, endDate, {
+          inclusiveFrom: true,
+          inclusiveTo: true,
+          onlyDate: true,
+        });
       }
       this.$log?.debug(`No <${phaseType}> phase type found.`);
       return false;

--- a/test/cypress/e2e/router_rules.cy.js
+++ b/test/cypress/e2e/router_rules.cy.js
@@ -618,6 +618,25 @@ describe('Router rules', () => {
               cy.verifyRouteAccessAllowedFromInitial('prizes', 'home');
               cy.verifyRouteAccessAllowedFromInitial('profile', 'prizes');
             }
+            // test access to routes via checking menu item disabled state
+            if (
+              ['app_full', 'app_full_register-challenge'].includes(test.access)
+            ) {
+              cy.window().should('have.property', 'i18n');
+              cy.window().then((win) => {
+                if (test.accessRoutes) {
+                  cy.dataCy('drawer-menu-item')
+                    .contains(win.i18n.global.t('drawerMenu.routes'))
+                    .should('be.visible')
+                    .and('not.have.class', 'disabled');
+                } else {
+                  cy.dataCy('drawer-menu-item')
+                    .contains(win.i18n.global.t('drawerMenu.routes'))
+                    .should('be.visible')
+                    .and('have.class', 'disabled');
+                }
+              });
+            }
           }
         });
       });

--- a/test/cypress/fixtures/appAccessTestData.json
+++ b/test/cypress/fixtures/appAccessTestData.json
@@ -4,7 +4,7 @@
     "fixtureCampaign": "apiGetThisCampaignMay.json",
     "fixtureRegisterChallenge": "apiGetRegisterChallengeEmpty.json",
     "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseFalse.json",
-    "dates": ["2025-01-27T00:00:00.000Z", "2025-07-01T00:00:00.000Z"],
+    "dates": ["2025-01-27T21:00:00.000Z", "2025-07-01T00:00:00.000Z"],
     "access": "challenge_inactive",
     "accessRoutes": false
   },
@@ -13,7 +13,12 @@
     "fixtureCampaign": "apiGetThisCampaignMay.json",
     "fixtureRegisterChallenge": "apiGetRegisterChallengeIndividualPaidComplete.json",
     "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseFalse.json",
-    "dates": ["2025-01-28T00:00:00.000Z", "2025-06-30T00:00:00.000Z"],
+    "dates": [
+      "2025-01-28T00:00:00.000Z",
+      "2025-04-30T21:00:00.000Z",
+      "2025-06-04T00:00:00.000Z",
+      "2025-06-30T00:00:00.000Z"
+    ],
     "access": "app_full",
     "accessRoutes": false
   },
@@ -22,7 +27,7 @@
     "fixtureCampaign": "apiGetThisCampaignMay.json",
     "fixtureRegisterChallenge": "apiGetRegisterChallengeIndividualPaidComplete.json",
     "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseFalse.json",
-    "dates": ["2025-05-01T00:00:00.000Z", "2025-06-03T00:00:00.000Z"],
+    "dates": ["2025-05-01T00:00:00.000Z", "2025-06-03T21:00:00.000Z"],
     "access": "app_full",
     "accessRoutes": true
   },
@@ -49,7 +54,16 @@
     "fixtureCampaign": "apiGetThisCampaignMay.json",
     "fixtureRegisterChallenge": "apiGetRegisterChallengeEmpty.json",
     "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseTrue.json",
-    "dates": ["2025-01-28T00:00:00.000Z", "2025-06-01T00:00:00.000Z"],
+    "dates": ["2025-01-28T00:00:00.000Z", "2025-04-30T00:00:00.000Z"],
+    "access": "app_full_register-challenge",
+    "accessRoutes": false
+  },
+  {
+    "description": "User logged in and verified - App accessible - Registration not complete - User Admin - Registration active - Entry phase active",
+    "fixtureCampaign": "apiGetThisCampaignMay.json",
+    "fixtureRegisterChallenge": "apiGetRegisterChallengeEmpty.json",
+    "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseTrue.json",
+    "dates": ["2025-05-01T00:00:00.000Z", "2025-06-01T00:00:00.000Z"],
     "access": "app_full_register-challenge",
     "accessRoutes": true
   },
@@ -58,7 +72,7 @@
     "fixtureCampaign": "apiGetThisCampaignMay.json",
     "fixtureRegisterChallenge": "apiGetRegisterChallengeEmpty.json",
     "fixtureOrganizationAdmin": "apiGetIsUserOrganizationAdminResponseTrue.json",
-    "dates": ["2025-06-02T00:00:00.000Z", "2025-06-03T00:00:00.000Z"],
+    "dates": ["2025-06-02T00:00:00.000Z", "2025-06-03T21:00:00.000Z"],
     "access": "app_full",
     "accessRoutes": true
   },

--- a/test/cypress/fixtures/loginTokensTestData.json
+++ b/test/cypress/fixtures/loginTokensTestData.json
@@ -16,6 +16,23 @@
       "access_expiration": "2025-01-27T00:10:00.000"
     }
   },
+  "2025-01-27T21:00:00.000Z": {
+    "loginResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzM4MDIxNTAwLCJqdGkiOiI2ZDdlNjkyZi1hZmNkLTQ3ZDYtOWIwNC0wYTAxMGRiZmFkODQiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_access",
+      "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTczODAyNDgwMCwianRpIjoiYzlkYjE5ZGEtNzA1YS00ZjRiLTljMTUtYzllN2FkMGM3NTMzIiwidXNlcl9pZCI6MTg5NzYxfQ.dummy_signature_refresh",
+      "user": {
+        "pk": 1,
+        "username": "foobar",
+        "email": "foo@bar.org",
+        "first_name": "Foo",
+        "last_name": "Bar"
+      }
+    },
+    "refreshResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzM4MDIxODAwLCJqdGkiOiJhZThlMTc3Zi0xNmExLTRiNDYtYTkwNi01NTM5ODliNDkxMjgiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_refresh_access",
+      "access_expiration": "2025-01-27T21:10:00.000"
+    }
+  },
   "2025-01-28T00:00:00.000Z": {
     "loginResponse": {
       "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoiMTczODAyMjcwMCIsImp0aSI6IjNiNGY1MzM0ZGJmYTQ4ZGE4ZDFmNTRhODY0MDk0MDcwIiwidXNlcl9pZCI6MTg5NzYxfQ.I-d1gJiWk0OtjQvPrEivc6P3qZ_Y6OI-8F8fWDapHDE",
@@ -31,6 +48,23 @@
     "refreshResponse": {
       "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzM4MDIzMDAwLCJqdGkiOiIzYjRmNTMzNGRiZmE0OGRhOGQxZjU0YTg2NDA5NDA3MCIsInVzZXJfaWQiOjE4OTc2MX0.ArE9ugBq8HRfyp1PDwPI2bZL2TSKD4yWrJPTdSJAIZw",
       "access_expiration": "2025-01-28T00:10:00.000"
+    }
+  },
+  "2025-04-30T21:00:00.000Z": {
+    "loginResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzU2NzU1OTAwLCJqdGkiOiI0ZWEyZmYzMi1hNjg5LTQxNGEtOGY3Yi1hZWUwNDNlOGU4YmMiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_access",
+      "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTc1Njc1OTIwMCwianRpIjoiNTU3ZDA1NTYtNDkxMC00Y2M3LWI0MDktN2IxNzFiYjZhZTgwIiwidXNlcl9pZCI6MTg5NzYxfQ.dummy_signature_refresh",
+      "user": {
+        "pk": 1,
+        "username": "foobar",
+        "email": "foo@bar.org",
+        "first_name": "Foo",
+        "last_name": "Bar"
+      }
+    },
+    "refreshResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzU2NzU2MjAwLCJqdGkiOiI3ODZjNTA3NS05NDIxLTQxNmEtODAyNi1hZDcwMzg5NjA3NjgiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_refresh_access",
+      "access_expiration": "2025-04-30T21:10:00.000"
     }
   },
   "2025-05-01T00:00:00.000Z": {
@@ -99,6 +133,23 @@
     "refreshResponse": {
       "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzU5NTE3NDAwLCJqdGkiOiI4ZDU0OTQ3NC0xNTRhLTQzYWItOWU2Mi1lODJlZGM0ZWIwOTgiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_refresh_access",
       "access_expiration": "2025-06-03T00:10:00.000"
+    }
+  },
+  "2025-06-03T21:00:00.000Z": {
+    "loginResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzU5NTU0MzAwLCJqdGkiOiI4YzAzNmEwMy1hYzFlLTQxZWEtYTY3MC00ZThlODMwZmRlNTMiLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_access",
+      "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTc1OTU1NzYwMCwianRpIjoiOGYzZDY0MzAtZTY2NC00YmE5LTliZjEtMDQ0NGIxZmNmNmJlIiwidXNlcl9pZCI6MTg5NzYxfQ.dummy_signature_refresh",
+      "user": {
+        "pk": 1,
+        "username": "foobar",
+        "email": "foo@bar.org",
+        "first_name": "Foo",
+        "last_name": "Bar"
+      }
+    },
+    "refreshResponse": {
+      "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzU5NTU0NjAwLCJqdGkiOiIxODNkMmM5Yi1kZmM1LTRmNzQtOWY0Mi0wNGZjY2Q5NzIxYjciLCJ1c2VyX2lkIjoxODk3NjF9.dummy_signature_refresh_access",
+      "access_expiration": "2025-06-03T21:10:00.000"
     }
   },
   "2025-06-04T00:00:00.000Z": {

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -585,10 +585,12 @@ export const systemTimeLoggedIn =
  * even when `challenge` phase is not yet active.
  * The `challenge` phase overlaps is typically contained within
  * the `registration` phase.
+ * When the tests are run in local environment, they adopt local time.
+ * We set the time to 21:59:00 so in the GMT+2 timezone the time is 23:59:00.
  * @see apiGetThisCampaign.json fixture for example
  */
 export const systemTimeRegistrationPhaseInactive = new Date(
-  '2024-07-14T23:59:00.000Z',
+  '2024-07-14T21:59:00.000Z',
 );
 /**
  * Time after `registration` phase starts

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -579,18 +579,23 @@ export const timeUntilExpiration = timeUntilRefresh * 2;
 // 2 min before JWT expires
 export const systemTimeLoggedIn =
   fixtureTokenExpirationTime - timeUntilExpiration;
+
+// Timezone offset for local environment
+const timeZoneOffset = -2;
 /**
  * Time before `registration` phase starts
  * Registration phase allows users to register for challenge
  * even when `challenge` phase is not yet active.
  * The `challenge` phase overlaps is typically contained within
  * the `registration` phase.
- * When the tests are run in local environment, they adopt local time.
- * We set the time to 21:59:00 so in the GMT+2 timezone the time is 23:59:00.
  * @see apiGetThisCampaign.json fixture for example
+ * TODO: Replace with timezone-agnostic helper in future refactor.
  */
 export const systemTimeRegistrationPhaseInactive = new Date(
-  '2024-07-14T21:59:00.000Z',
+  '2024-07-14T23:59:00.000Z',
+);
+systemTimeRegistrationPhaseInactive.setHours(
+  systemTimeRegistrationPhaseInactive.getHours() + timeZoneOffset,
 );
 /**
  * Time after `registration` phase starts


### PR DESCRIPTION
* Update checking for phase range with Quasar utils.
* Update `systemTimeRegistrationPhaseInactive` timestamp to account for timezone shift in locally run tests.
* Update generative app access tests to also check for route logging availability.