### PR TITLE
test/cypress/e2e: fix routes test by setting exact destination path

### DIFF
--- a/test/cypress/e2e/routes.spec.cy.js
+++ b/test/cypress/e2e/routes.spec.cy.js
@@ -71,7 +71,7 @@ describe('Routes page', () => {
           },
         );
       });
-      cy.visit('#' + routesConf['routes']['children']['fullPath']);
+      cy.visit('#' + routesConf['routes_calendar']['children']['fullPath']);
       cy.waitForCommuteModeApi();
     });
 


### PR DESCRIPTION
Issue: `routes.spec.cy.js` tends to fail as it does not reliably redirects from root `routes` path to `calendar`.

Fix this by specifying explicitly the navigation to `routes_calendar` path.

Similar issue as in #1010