### PR TITLE
test/cypress/e2e: limit cypress-specific code with timeout in StravaApp to component tests

### DIFF
--- a/src/components/routes/StravaApp.vue
+++ b/src/components/routes/StravaApp.vue
@@ -91,7 +91,7 @@ export default defineComponent({
 
     onMounted(async () => {
       // allows Cypress component test to register intercept
-      if (window.Cypress) {
+      if (window.Cypress && window.Cypress.testingType === 'component') {
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
 

--- a/src/components/routes/StravaApp.vue
+++ b/src/components/routes/StravaApp.vue
@@ -91,7 +91,7 @@ export default defineComponent({
 
     onMounted(async () => {
       // allows Cypress component test to register intercept
-      if (window.Cypress && window.Cypress.testingType === 'component') {
+      if (window.Cypress) {
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
 


### PR DESCRIPTION
Issue: `strava.spec.cy.js` test fails on CI (only) awaiting request loading Strava account.

Approach: Remove some non-standard test structure and simplify the beforeEach intercept hooks (solution tested in CI).