### PR TITLE
test/cypress/e2e: add page load check to ensure API request trigger

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -148,6 +148,7 @@ describe('Register Challenge page', () => {
         );
         // visit challenge inactive page to load campaign data
         cy.visit('#' + routesConf['challenge_inactive']['path']);
+        cy.dataCy('challenge-inactive-info').should('be.visible');
         cy.waitForThisCampaignApi();
         // config is defined without hash in the URL
         cy.visit('#' + routesConf['register_challenge']['path']);


### PR DESCRIPTION
Issue: E2E test `register_challenge.spec.cy.js` sometimes fails with the following message:

```
CypressError: Timed out retrying after 12000ms: `cy.wait()` timed out waiting `12000ms` for the 1st request to the route: `thisCampaignRequest`. No request ever occurred.
```

Analysis:

The problem is probably caused by a race condition on these three lines:

```
150: cy.visit('#' + routesConf['challenge_inactive']['path']);
151: cy.waitForThisCampaignApi();
...
153: cy.visit('#' + routesConf['register_challenge']['path']);
```

Redirection happens faster than the request can be fired - therefore it is never registered.

Solution:

Add waiting for page (challenge-inactive) load - this ensures that API request has time to start:

```
151: cy.dataCy('challenge-inactive-info').should('be.visible');
```