### PR TITLE
src/composables: fix miscellaneous Typescript errors 

### DIFF
--- a/src/adapters/tripsAdapter.ts
+++ b/src/adapters/tripsAdapter.ts
@@ -74,10 +74,11 @@ export const tripsAdapter = {
     const payload: TripPostPayload = {
       trip_date: routeItem.date,
       direction,
-      commuteMode: routeItem.transport,
-      distanceMeters: hasTransportDistance(routeItem.transport)
-        ? Math.round(distanceMeters)
-        : 0,
+      commuteMode: routeItem.transport || '',
+      distanceMeters:
+        routeItem.transport && hasTransportDistance(routeItem.transport)
+          ? Math.round(distanceMeters)
+          : 0,
       sourceApplication: rideToWorkByBikeConfig.apiTripsSourceApplicationId,
     };
 

--- a/src/composables/useCalendarRoutes.ts
+++ b/src/composables/useCalendarRoutes.ts
@@ -76,6 +76,7 @@ export const useCalendarRoutes = (days: Ref<RouteDay[]>) => {
             distance: defaultDistanceZero,
             inputType: RouteInputType.inputNumber,
             routeFeature: null,
+            file: null,
           });
         }
       }

--- a/src/composables/useLogRoutes.ts
+++ b/src/composables/useLogRoutes.ts
@@ -50,7 +50,9 @@ export const useLogRoutes = (routes: Ref<RouteItem[]>) => {
   });
 
   const isShownDistance = computed((): boolean => {
-    return hasTransportDistance(transportType.value);
+    return transportType.value
+      ? hasTransportDistance(transportType.value)
+      : false;
   });
 
   return {

--- a/src/composables/useSelectSearch.ts
+++ b/src/composables/useSelectSearch.ts
@@ -16,7 +16,7 @@ import type { Ref } from 'vue';
 export const useSelectSearch = (
   options: Ref<FormSelectOption[] | FormSelectTableOption[]>,
 ) => {
-  const optionsFiltered = ref<FormSelectOption[]>([]);
+  const optionsFiltered = ref<(FormSelectOption | FormSelectTableOption)[]>([]);
 
   /**
    * Filter function for select components

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -61,6 +61,7 @@ export const emptyUser: UserLogin = {
 
 export const defaultLoginOptions: Required<LoginOptions> = {
   showSuccessMessage: true,
+  showErrorMessage: false,
   redirectAfterLogin: true,
 };
 

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -18,6 +18,7 @@ import { deepObjectWithSimplePropsCopy } from './index';
 export const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
   lastName: '',
+  email: '',
   id: null,
   isStaff: false,
   newsletter: [] as NewsletterType[],

--- a/src/utils/get_register_challenge_empty_state.ts
+++ b/src/utils/get_register_challenge_empty_state.ts
@@ -18,7 +18,6 @@ import { deepObjectWithSimplePropsCopy } from './index';
 export const emptyFormPersonalDetails: RegisterChallengePersonalDetailsForm = {
   firstName: '',
   lastName: '',
-  email: '',
   id: null,
   isStaff: false,
   newsletter: [] as NewsletterType[],


### PR DESCRIPTION
This PR fixes some issues discovered by running `npx tsc --noEmit`.

1. `src/utils/get_register_challenge_empty_state.ts` - Added `email: ''` property to `emptyFormPersonalDetails`
2. `src/stores/login.ts` - Added `showErrorMessage: false` property to `defaultLoginOptions`
3. `src/composables/useCalendarRoutes.ts` - Add `file: null` property to the route object
4. `src/composables/useSelectSearch.ts` - Fix typing of `optionsFiltered`
5. `src/adapters/tripsAdapter.ts` - Add null check for `routeItem.transport` and `hasTransportDistance()`
6. `src/composables/useLogRoutes.ts` - Add null check before calling `hasTransportDistance()`