### PR TITLE
test/cypress/e2e: add Cypress command to validate input value after typing

### DIFF
--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -407,12 +407,35 @@ describe('Routes calendar page', () => {
                 );
                 // input distance
                 cy.dataCy('section-input-number').should('be.visible');
-                cy.dataCy('section-input-number').find('input').clear();
+                cy.dataCy('section-input-number')
+                  .find('input')
+                  .should('be.visible')
+                  .clear();
+                cy.dataCy('section-input-number')
+                  .find('input')
+                  .then(($input) => {
+                    expect($input.val().replace(',', '.')).to.equal(
+                      config.defaultDistanceZero,
+                    );
+                  });
                 cy.dataCy('section-input-number')
                   .find('input')
                   .type(inputValue.inputValue);
               }
             });
+            // for number distance input, verify UI state before submitting
+            if (apiPayload.trips[0].distanceMeters) {
+              const expectedInputNumbers =
+                apiPayload.trips[0].distanceMeters / 10;
+              // ensure the distance input contains the expected value
+              cy.dataCy('section-input-number')
+                .find('input')
+                .then(($input) => {
+                  expect($input.val().replace(/[,.]/g, '')).to.equal(
+                    expectedInputNumbers.toString(),
+                  );
+                });
+            }
             // click save button
             cy.dataCy('dialog-save-button').click();
             // wait for API call and verify payload

--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -425,7 +425,8 @@ describe('Routes calendar page', () => {
             });
             // for number distance input, verify UI state before submitting
             if (apiPayload.trips[0].distanceMeters) {
-              // divide meters (e.g 1000) by 10 to get the input number without decimal point (e.g. 1.00 -> 100)
+              // Divide meters e.g. 10000 by 10 to get the input number without decimal point
+              // (e.g. 10.00 -> 1000), because input number use 2 decimal places and length unit is km
               const expectedInputNumbers =
                 apiPayload.trips[0].distanceMeters / 10;
               // ensure the distance input contains the expected value

--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -425,6 +425,7 @@ describe('Routes calendar page', () => {
             });
             // for number distance input, verify UI state before submitting
             if (apiPayload.trips[0].distanceMeters) {
+              // divide meters (e.g 1000) by 10 to get the input number without decimal point (e.g. 1.00 -> 100)
               const expectedInputNumbers =
                 apiPayload.trips[0].distanceMeters / 10;
               // ensure the distance input contains the expected value


### PR DESCRIPTION
Issue: `routes_calendar.cy.js` test sometimes fails with:

```
  1) Routes calendar page
       desktop - with logged routes
         enter distance, upload a file, then log route by entering distance:

      AssertionError: expected [ Array(1) ] to have the same members as [ Array(1) ]
      + expected - actual

       [ { trip_date: '2025-05-20',
           direction: 'trip_to',
           commuteMode: 'bicycle',
      -    distanceMeters: 100,
      +    distanceMeters: 10000,
           sourceApplication: 'RTWBB web app' } ]
      
      at Context.eval (webpack://ride-to-work-by-bike/./test/cypress/support/commands.js:3676:48)
```

Solution: This is likely an issue with entering value into the masked input after switching from file input. Approach is to validate input state in UI when clearing the value and before submitting.