### PR TITLE
test/cypress/e2e/reset_password: add delay to confirmation to have time to check UI

### DIFF
--- a/src/components/register/ResetPassword.vue
+++ b/src/components/register/ResetPassword.vue
@@ -123,6 +123,10 @@ export default defineComponent({
         logger?.debug(
           `Redirect to login page <${routesConf['login']['path']}>.`,
         );
+        // allows Cypress E2E test to test UI before redirecting
+        if (window.Cypress) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
         router.push(routesConf['login']['path']);
       }
     };

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2760,6 +2760,7 @@ Cypress.Commands.add(
           statusCode: responseStatusCode
             ? responseStatusCode
             : httpSuccessfullStatus,
+          delay: interceptedRequestResponseDelay,
           body: responseBody ? responseBody : defaultResponseBody,
         }).as('postResetPasswordConfirm');
       },

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2760,7 +2760,6 @@ Cypress.Commands.add(
           statusCode: responseStatusCode
             ? responseStatusCode
             : httpSuccessfullStatus,
-          delay: interceptedRequestResponseDelay,
           body: responseBody ? responseBody : defaultResponseBody,
         }).as('postResetPasswordConfirm');
       },


### PR DESCRIPTION
Issue: `reset_password.spec.cy.js` test occasionally fails with message:
```
  1) Reset Password
       desktop
         submits form successfully and redirects to login:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-cy=form-reset-password-input]`, but never found it.
```
This suggests a race condition: Successful API request triggers redirect. Test validates API request and then tries to check UI state (cleared inputs). If redirect happens before the UI test, Cypress will not find the required inputs.

Solution: Add an exception-wait time to the component. To allow the tests to execute.