### PR TITLE
test/cypress/support: add command to handle waiting for animation before element visibility testing

### DIFF
--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -220,7 +220,9 @@ export const testUserSelect = (selector: string): void => {
       cy.dataCy(selectorUserSelectInput).should('be.visible').click();
     });
     cy.get(classSelectorMenu)
-      .should('be.visible')
+      .should('exist')
+      .and('not.have.class', 'q-transition--fade-enter-from')
+      .and('be.visible')
       .within(() => {
         menuItems.forEach((item, index) => {
           cy.dataCy(selectorMenuItem)


### PR DESCRIPTION
Issue: [Recent test](https://github.com/auto-mat/ride-to-work-by-bike-frontend/actions/runs/17051099926/job/48338714207?pr=1073) shows error in `community.spec.cy.js` E2E test.
This error originates in checking the select dropdown:
```
checks navigation links in the menu:
     AssertionError: Timed out retrying after 60000ms: expected '<div#f_a13f14dd-f714-4635-9e2c-e33fbcdd630c.q-menu.q-position-engine.scroll.transparent.q-transition--fade-enter-from.q-transition--fade-enter-active>' to be 'visible'

This element `<div#f_a13f14dd-f714-4635-9e2c-e33fbcdd630c.q-menu.q-position-engine.scroll.transparent.q-transition--fade-enter-from.q-transition--fade-enter-active>` is not visible because it has CSS property: `opacity: 0`
      at testUserSelect (webpack://ride-to-work-by-bike/./test/cypress/support/commonTests.ts:223:7)
```
Cause: Since the erroring element shows classes related to animation (q-transition--*), this problem is most likely related to checking the visibility of the element before it animates.

Solution: Introduce 1. existence check, 2. check for animation classes to wait for animation end 3. only then visibility check.