### PR TITLE
test/cypress/e2e: add Cypress check command for async data for dropdown select before interaction

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -2154,7 +2154,7 @@ describe('Register Challenge page', () => {
               );
             },
           );
-          // wait for address to be loaded
+          // wait for addresses to be loaded
           cy.dataCy('form-company-address')
             .find('.q-select')
             .should('not.contain', 'q-spinner');

--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -2154,6 +2154,10 @@ describe('Register Challenge page', () => {
               );
             },
           );
+          // wait for address to be loaded
+          cy.dataCy('form-company-address')
+            .find('.q-select')
+            .should('not.contain', 'q-spinner');
           // select address
           cy.dataCy('form-company-address')
             .find('.q-field__append')


### PR DESCRIPTION
Issue: E2E test `register_challenge.spec.cy.js` occasionally fails with message:
```
1) Register Challenge page
       desktop
         allows to complete registration with voucher payment FULL:
     CypressError: Timed out retrying after 60050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

> <div.q-field__append.q-field__marginal.row.no-wrap.items-center.q-anchor--skip>

We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.
```

Cause: This is likely due to asynchronous loading of the content (.q-field__append which is being clicked contains loader when loading data and switches to dropdown arrow when ready)

Solution: Add `q-spinner` non-existence check before the interaction.