### PR TITLE
test/cypress/e2e: update and reuse command for select paying organization

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -594,25 +594,8 @@ describe('Register Challenge page', () => {
           cy.passToStep2();
           // select company
           cy.dataCy(getRadioOption(OrganizationType.company)).click();
-          // select paying company (required)
-          cy.fixture('formFieldCompany').then((formFieldCompany) => {
-            cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
-              cy.dataCy('form-field-company').find('.q-field__append').click();
-              // select option without coordinator
-              cy.get('.q-item__label')
-                .should('be.visible')
-                .and((opts) => {
-                  expect(
-                    opts.length,
-                    formFieldCompany.results.length +
-                      formFieldCompanyNext.results.length,
-                  );
-                })
-                .eq(1)
-                .click();
-              cy.get('.q-menu').should('not.exist');
-            });
-          });
+          // select paying company
+          cy.selectRegisterChallengePayingOrganization(1);
           cy.fixture('apiGetHasOrganizationAdminResponseFalse').then(
             (response) => {
               cy.waitForHasOrganizationAdminApi(response);

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2315,19 +2315,30 @@ Cypress.Commands.add(
     cy.fixture('formFieldCompany').then((formFieldCompany) => {
       cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
         waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-        cy.dataCy('form-field-company').find('.q-field__append').click();
-        // select option
-        cy.get('.q-item__label')
+        cy.dataCy('form-field-company')
+          .find('.q-select')
+          .should('not.contain', 'q-spinner');
+        cy.dataCy('form-field-company')
+          .find('.q-field__append')
+          .last()
           .should('be.visible')
-          .and((opts) => {
-            expect(
-              opts.length,
-              formFieldCompany.results.length +
-                formFieldCompanyNext.results.length,
-            );
-          })
-          .eq(index)
           .click();
+        // select option
+        cy.get('.q-menu')
+          .should('be.visible')
+          .within(() => {
+            cy.get('.q-item__label')
+              .should('be.visible')
+              .and((opts) => {
+                expect(
+                  opts.length,
+                  formFieldCompany.results.length +
+                    formFieldCompanyNext.results.length,
+                );
+              })
+              .eq(index)
+              .click();
+          });
         cy.get('.q-menu').should('not.exist');
       });
     });


### PR DESCRIPTION
Issue: E2E test `register_challenge.spec.cy.js` occasionally fails with message:
```
  63 passing (12m)
  4 failing

  1) Register Challenge page
       desktop
         allows to post company coordinator registration:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `.q-item__label`, but never found it.
```
Cause: `.q-item__label` is a selector for items in dropdown, so likely cause of error is UI changing after data load.

Solution: Added check for `.q-spinner` element before opening dropdown and `.q-menu` visibility check before select.