### PR TITLE
test/cypress/e2e/register_challenge: update test command for selecting company and subsidiary

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -752,23 +752,20 @@ describe('Register Challenge page', () => {
       cy.dataCy('step-4-continue').should('be.visible').click();
       // not on step 5
       cy.dataCy('step-5').find('.q-stepper__step-content').should('not.exist');
-      // select address
-      cy.dataCy('form-company-address').find('.q-field__append').last().click();
       // select subsidiary from dropdown
       cy.fixture('apiGetSubsidiariesResponse').then((subsidiariesResponse) => {
         cy.fixture('apiGetSubsidiariesResponseNext').then(
           (subsidiariesResponseNext) => {
-            cy.get('.q-item__label')
-              .should('be.visible')
-              .and((opts) => {
-                expect(
-                  opts.length,
-                  subsidiariesResponse.results.length +
-                    subsidiariesResponseNext.results.length,
-                );
-              })
-              .first()
-              .click();
+            cy.waitForSubsidiariesApi(
+              subsidiariesResponse,
+              subsidiariesResponseNext,
+            );
+            cy.selectDropdownMenu(
+              'form-company-address',
+              0,
+              subsidiariesResponse.results.length +
+                subsidiariesResponseNext.results.length,
+            );
           },
         );
       });
@@ -1184,21 +1181,16 @@ describe('Register Challenge page', () => {
                     apiGetSubsidiariesResponse,
                     apiGetSubsidiariesResponseNext,
                   );
+                  cy.selectDropdownMenu(
+                    'form-company-address',
+                    0,
+                    apiGetSubsidiariesResponse.results.length +
+                      apiGetSubsidiariesResponseNext.results.length,
+                  );
                 },
               );
             },
           );
-          // select address
-          cy.dataCy('form-company-address')
-            .find('.q-field__append')
-            .last()
-            .click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item').first().click();
-            });
           // go back to step 3
           cy.dataCy('step-4-back').should('be.visible').click();
           // go back to step 2
@@ -1517,18 +1509,8 @@ describe('Register Challenge page', () => {
             cy.dataCy('step-5-back').should('be.visible').click();
             // organization and address inputs are visible
             cy.dataCy('form-select-table-company').should('be.visible');
-            // open subsidiary select
-            cy.dataCy('form-company-address')
-              .should('be.visible')
-              .find('.q-field__append')
-              .last()
-              .click();
             // select different subsidiary (second one)
-            cy.get('.q-menu')
-              .should('be.visible')
-              .within(() => {
-                cy.get('.q-item').eq(1).click();
-              });
+            cy.selectDropdownMenu('form-company-address', 1);
             cy.dataCy('step-4-continue').should('be.visible').click();
             // wait for teams API refresh
             cy.waitForTeamsGetApi();
@@ -1570,18 +1552,8 @@ describe('Register Challenge page', () => {
                 cy.dataCy('debug-subsidiary-id-value').should('be.empty');
                 cy.dataCy('debug-team-id-value').should('be.empty');
               });
-            // open subsidiary select
-            cy.dataCy('form-company-address')
-              .should('be.visible')
-              .find('.q-field__append')
-              .last()
-              .click();
-            // select first available subsidiary
-            cy.get('.q-menu')
-              .should('be.visible')
-              .within(() => {
-                cy.get('.q-item').first().click();
-              });
+            // select address
+            cy.selectDropdownMenu('form-company-address', 0);
             // go to step 5
             cy.dataCy('step-4-continue').should('be.visible').click();
             // wait for teams API refresh
@@ -1712,16 +1684,7 @@ describe('Register Challenge page', () => {
               );
             },
           );
-          cy.dataCy('form-company-address')
-            .find('.q-field__append')
-            .last()
-            .click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item').first().click();
-            });
+          cy.selectDropdownMenu('form-company-address', 0);
           // go to next step
           cy.dataCy('step-4-continue').should('be.visible').click();
           // select first available team (this is the second team, first is full)
@@ -1800,13 +1763,24 @@ describe('Register Challenge page', () => {
       // participation is preselected - continue
       cy.dataCy('step-3-continue').should('be.visible').click();
       // organization is preselected - select address
-      cy.dataCy('form-company-address').find('.q-field__append').last().click();
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').first().click();
-        });
+      cy.fixture('apiGetSubsidiariesResponse.json').then(
+        (apiGetSubsidiariesResponse) => {
+          cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+            (apiGetSubsidiariesResponseNext) => {
+              cy.waitForSubsidiariesApi(
+                apiGetSubsidiariesResponse,
+                apiGetSubsidiariesResponseNext,
+              );
+              cy.selectDropdownMenu(
+                'form-company-address',
+                0,
+                apiGetSubsidiariesResponse.results.length +
+                  apiGetSubsidiariesResponseNext.results.length,
+              );
+            },
+          );
+        },
+      );
       // go to next step
       cy.dataCy('step-4-continue').should('be.visible').click();
       // select first available team (this is the second team, first is full)
@@ -1883,13 +1857,24 @@ describe('Register Challenge page', () => {
       // participation is preselected - continue
       cy.dataCy('step-3-continue').should('be.visible').click();
       // organization is preselected - select address
-      cy.dataCy('form-company-address').find('.q-field__append').last().click();
-      // select option
-      cy.get('.q-menu')
-        .should('be.visible')
-        .within(() => {
-          cy.get('.q-item').first().click();
-        });
+      cy.fixture('apiGetSubsidiariesResponse.json').then(
+        (apiGetSubsidiariesResponse) => {
+          cy.fixture('apiGetSubsidiariesResponseNext.json').then(
+            (apiGetSubsidiariesResponseNext) => {
+              cy.waitForSubsidiariesApi(
+                apiGetSubsidiariesResponse,
+                apiGetSubsidiariesResponseNext,
+              );
+              cy.selectDropdownMenu(
+                'form-company-address',
+                0,
+                apiGetSubsidiariesResponse.results.length +
+                  apiGetSubsidiariesResponseNext.results.length,
+              );
+            },
+          );
+        },
+      );
       // go to next step
       cy.dataCy('step-4-continue').should('be.visible').click();
       // select first available team (this is the second team, first is full)
@@ -2133,26 +2118,16 @@ describe('Register Challenge page', () => {
                     apiGetSubsidiariesResponse,
                     apiGetSubsidiariesResponseNext,
                   );
+                  cy.selectDropdownMenu(
+                    'form-company-address',
+                    0,
+                    apiGetSubsidiariesResponse.results.length +
+                      apiGetSubsidiariesResponseNext.results.length,
+                  );
                 },
               );
             },
           );
-          // wait for addresses to be loaded
-          cy.dataCy('form-company-address')
-            .find('.q-select')
-            .should('not.contain', 'q-spinner');
-          // select address
-          cy.dataCy('form-company-address')
-            .find('.q-field__append')
-            .last()
-            .should('be.visible')
-            .click();
-          // select option
-          cy.get('.q-menu')
-            .should('be.visible')
-            .within(() => {
-              cy.get('.q-item').first().click();
-            });
           // go to next step
           cy.dataCy('step-4-continue').should('be.visible').click();
           // select first available team (this is the second team, first is full)

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2616,18 +2616,16 @@ Cypress.Commands.add('passToStep5', () => {
             apiGetSubsidiariesResponse,
             apiGetSubsidiariesResponseNext,
           );
+          cy.selectDropdownMenu(
+            'form-company-address',
+            0,
+            apiGetSubsidiariesResponse.results.length +
+              apiGetSubsidiariesResponseNext.results.length,
+          );
         },
       );
     },
   );
-  // select address
-  cy.dataCy('form-company-address').find('.q-field__append').last().click();
-  // select option
-  cy.get('.q-menu')
-    .should('be.visible')
-    .within(() => {
-      cy.get('.q-item').first().click();
-    });
   cy.dataCy('step-4-continue').should('be.visible').click();
   // step 4 skip check for loading spinner (not sending data to API)
   // on step 5

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2307,6 +2307,28 @@ Cypress.Commands.add(
 );
 
 /**
+ * Select element from dropdown menu
+ */
+Cypress.Commands.add('selectDropdownMenu', (dataCy, index = 0, length = 0) => {
+  // ensure dropdown icon is visible
+  cy.dataCy(dataCy)
+    .find('.q-field__append')
+    .last()
+    .find('i')
+    .should('be.visible')
+    .and('have.class', 'q-select__dropdown-icon');
+  // click dropdown icon
+  cy.dataCy(dataCy).find('.q-field__append').last().click();
+  cy.get('.q-menu').should('be.visible');
+  if (length > 0) {
+    cy.get('.q-menu .q-item').should('have.length', length);
+  }
+  // select option
+  cy.get('.q-menu .q-item').eq(index).click();
+  cy.get('.q-menu').should('not.exist');
+});
+
+/**
  * Select paying company
  */
 Cypress.Commands.add(
@@ -2315,31 +2337,11 @@ Cypress.Commands.add(
     cy.fixture('formFieldCompany').then((formFieldCompany) => {
       cy.fixture('formFieldCompanyNext').then((formFieldCompanyNext) => {
         waitForOrganizationsApi(formFieldCompany, formFieldCompanyNext);
-        cy.dataCy('form-field-company')
-          .find('.q-select')
-          .should('not.contain', 'q-spinner');
-        cy.dataCy('form-field-company')
-          .find('.q-field__append')
-          .last()
-          .should('be.visible')
-          .click();
-        // select option
-        cy.get('.q-menu')
-          .should('be.visible')
-          .within(() => {
-            cy.get('.q-item__label')
-              .should('be.visible')
-              .and((opts) => {
-                expect(
-                  opts.length,
-                  formFieldCompany.results.length +
-                    formFieldCompanyNext.results.length,
-                );
-              })
-              .eq(index)
-              .click();
-          });
-        cy.get('.q-menu').should('not.exist');
+        cy.selectDropdownMenu(
+          'form-field-company',
+          index,
+          formFieldCompany.results.length + formFieldCompanyNext.results.length,
+        );
       });
     });
   },


### PR DESCRIPTION
Issue: register_challenge E2E test occasionally fails with message:
```
  1) Register Challenge page
       desktop
         allows to complete registration with voucher payment FULL:
     CypressError: Timed out retrying after 60050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:
```
Cause: This happens when combobox dropdown (selecting address or paying company) is not yet ready when clicked by the test (the dropdown arrow is in loading state, options are not loaded).

Solution: Implement a command awaiting the dropdown icon visibility + waiting for the API request. Use this command in all instances of selection from the dropdown with async options.