### PR TITLE
test/cypress/e2e/profile: set Cypress internal time to fix the login command in before each hook

### DIFF
--- a/test/cypress/e2e/profile.spec.cy.js
+++ b/test/cypress/e2e/profile.spec.cy.js
@@ -2,7 +2,10 @@ import { routesConf } from '../../../src/router/routes_conf';
 import { testDesktopSidebar } from '../support/commonTests';
 import { defLocale } from '../../../src/i18n/def_locale';
 import { getGenderLabel } from '../../../src/utils/get_gender_label';
-import { interceptOrganizationsApi } from '../support/commonTests';
+import {
+  interceptOrganizationsApi,
+  systemTimeChallengeActive,
+} from '../support/commonTests';
 import { OrganizationType } from 'src/components/types/Organization';
 
 // selectors
@@ -121,6 +124,7 @@ describe('Profile page', () => {
           );
         },
       );
+      cy.clock(new Date(systemTimeChallengeActive), ['Date']);
     });
   });
 


### PR DESCRIPTION
Issue: E2E test `profile.spec.cy.js` occasionally fails with message:
```
  1) Profile page
       change email
         "before each" hook for "allows user to change email":
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-cy=index-title]`, but never found it.
```
Cause: This is caused by a state where POST request to auth token is not valid and login (part of the before each step) is not completed. This usually isn't a problem as this test does not have route guards enabled, but it seems it can prevent redirect to homepage.
Solution: To fix this, set the internal Cypress clock time to time before the token expiration.