### PR TITLE
.husky/pre-commit: update pre-commit command to be yarn-version agnostic

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint-staged
+npx lint-staged


### PR DESCRIPTION
Issue: If using Yarn v4 locally, husky pre-commit hook fails.
```
This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
    at kk.getCandidates (/Users/simon/.cache/node/corepack/v1/yarn/4.6.0/yarn.js:205:8149)
    at Pg.getCandidates (/Users/simon/.cache/node/corepack/v1/yarn/4.6.0/yarn.js:141:1311)
    at /Users/simon/.cache/node/corepack/v1/yarn/4.6.0/yarn.js:210:8420
    at zm (/Users/simon/.cache/node/corepack/v1/yarn/4.6.0/yarn.js:140:53873)
    at ht (/Users/simon/.cache/node/corepack/v1/yarn/4.6.0/yarn.js:210:8400)
```
Solution: Use `npx` to bypass yarn version issue.