### PR TITLE
test/cypress/e2e/register_coordinator: wait for HP to load before redirect command

### DIFF
--- a/test/cypress/e2e/register_coordinator.spec.cy.js
+++ b/test/cypress/e2e/register_coordinator.spec.cy.js
@@ -148,6 +148,9 @@ describe('Login page', () => {
                     '@thisCampaignRequest',
                     '@getIsUserOrganizationAdmin',
                   ]);
+                  // confirm we are on home page
+                  cy.dataCy('index-title').should('be.visible');
+                  // visit register coordinator page
                   cy.visit('#' + routesConf['register_coordinator']['path']);
                 },
               );


### PR DESCRIPTION
Issue: register_coordinator E2E test occasionally fails with message:
```
  1) Login page
       desktop with API intercepts
         fills in the form, submits it, and redirects to homepage on success:
     CypressError: Timed out retrying after 12000ms: `cy.wait()` timed out waiting `12000ms` for the 1st request to the route: `getOrganizationsNextPage`. No request ever occurred.
```

Cause: In this scenario, test never navigates to `register_coordinator` route. Stays on HP and therefore does not load appropriate API endpoint.

Solution: Add visibility check for HP title, to make sure page loads before it navigates to `register_coordinator` route.