### PR TITLE
test/cypress/e2e/routes_list: update command order to register spinners

### DIFF
--- a/test/cypress/e2e/routes_list.spec.cy.js
+++ b/test/cypress/e2e/routes_list.spec.cy.js
@@ -54,9 +54,9 @@ describe('Routes list page', () => {
         cy.interceptCommuteModeGetApi(config, defLocale);
         cy.interceptTripsGetApi(config, defLocale);
         cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
-        cy.waitForCommuteModeApi();
         cy.dataCy('spinner-route-list-edit').should('be.visible');
         cy.dataCy('spinner-route-list-display').should('be.visible');
+        cy.waitForCommuteModeApi();
         cy.waitForTripsApi();
       });
     });
@@ -321,9 +321,9 @@ describe('Routes list page', () => {
             (tripsNext) => {
               cy.interceptTripsGetApi(config, defLocale, trips, tripsNext);
               cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
-              cy.waitForCommuteModeApi();
               cy.dataCy('spinner-route-list-edit').should('be.visible');
               cy.dataCy('spinner-route-list-display').should('be.visible');
+              cy.waitForCommuteModeApi();
               cy.waitForTripsApi(trips, tripsNext);
             },
           );
@@ -546,9 +546,9 @@ describe('Routes list page', () => {
         cy.interceptCommuteModeGetApi(config, defLocale);
         cy.interceptTripsGetApi(config, defLocale);
         cy.visit('#' + routesConf['routes_list']['children']['fullPath']);
-        cy.waitForCommuteModeApi();
         cy.dataCy('spinner-route-list-edit').should('be.visible');
         cy.dataCy('spinner-route-list-display').should('be.visible');
+        cy.waitForCommuteModeApi();
         cy.waitForTripsApi();
       });
     });


### PR DESCRIPTION
Issue: routes_list E2E test occasionally fails with message:
```
  1) Routes list page
       desktop - no logged routes
         "before each" hook for "renders left drawer":
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-cy=spinner-route-list-edit]`, but never found it.
```
Cause: Likely cause is that the intercepted API request returns before the test command starts.

Solution: Move commands waiting API request after commands that test UI spinners (API awaiting commands are asynchronous and always register after the appropriate call so they can be issued later).