### PR TITLE
test/cypress/e2e/routes_calendar: switch to should assertion to ensure re-checking the correct input value

### DIFF
--- a/test/cypress/e2e/routes_calendar.cy.js
+++ b/test/cypress/e2e/routes_calendar.cy.js
@@ -408,7 +408,7 @@ describe('Routes calendar page', () => {
                 // input distance
                 cy.dataCy('input-distance').should('be.visible');
                 cy.dataCy('input-distance').clear();
-                cy.dataCy('input-distance').then(($input) => {
+                cy.dataCy('input-distance').should(($input) => {
                   expect($input.val().replace(',', '.')).to.equal(
                     config.defaultDistanceZero,
                   );


### PR DESCRIPTION
Issue: E2E test for `routes_calendar` occasionally fails with message
```
  1) Routes calendar page
       desktop - with logged routes
         enter distance, upload a file, then log route by entering distance:

      AssertionError: expected '10.00' to equal '0.00'
      + expected - actual

      -'10.00'
      +'0.00'
```

Cause: This is likely caused by checking the value before it is fully cleared. We are using `.then` command, which does not recheck the assertion after the first attempt.

Solution: Use `.should` command instead. Additionally, simplify the selectors for the value input.
