### PR TITLE
src/components/form: add ability to register coordinator role for logged-in user from app

### DIFF
--- a/src/components/debug/ShowRegisterChallengeStoreValues.vue
+++ b/src/components/debug/ShowRegisterChallengeStoreValues.vue
@@ -1,0 +1,119 @@
+<script lang="ts">
+/**
+ * Show Register Challenge store values for debugging
+ *
+ * @description Use this component to debug selected values from the Register Challenge store
+ * Note: Only visible in Cypress testing environment. Pass an array of getter names to display specific values.
+ *
+ * @props
+ * - `keys` (Array, required): Array of getter names
+ *
+ * @example
+ * <show-register-challenge-store-values
+ *   :keys="['getOrganizationId', 'getSubsidiaryId', 'getTeamId']"
+ * />
+ *
+ */
+
+// libraries
+import { defineComponent, computed } from 'vue';
+
+// stores
+import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
+
+export default defineComponent({
+  name: 'ShowRegisterChallengeStoreValues',
+  props: {
+    keys: {
+      type: Array as () => string[],
+      required: true,
+    },
+  },
+  setup(props) {
+    const showComponent = computed(() => !!window.Cypress);
+
+    const registerChallengeStore = useRegisterChallengeStore();
+
+    // create keys for data-cy attributes
+    const normalizeKey = (key: string): string => {
+      return key
+        .toLowerCase()
+        .replace(/^get/, '')
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .toLowerCase();
+    };
+
+    // format value for display
+    const formatValue = (value: unknown): string => {
+      if (value === null) return 'null';
+      if (value === undefined) return 'undefined';
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value, null, 2);
+        } catch {
+          return '[Object]';
+        }
+      }
+      return String(value);
+    };
+
+    // function to get the store value
+    const getStoreValue = (key: string): unknown => {
+      try {
+        // access the getter from the store
+        const getter = (
+          registerChallengeStore as unknown as Record<string, unknown>
+        )[key];
+        if (typeof getter === 'function') {
+          return getter();
+        }
+        // if not a function, return the value
+        return getter;
+      } catch (error) {
+        return `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    };
+
+    // create a data object to loop over
+    const displayValues = computed(() => {
+      const values: Record<string, unknown> = {};
+      props.keys.forEach((key) => {
+        const label = key
+          .replace(/^get/, '')
+          .replace(/([a-z])([A-Z])/g, '$1 $2');
+        values[label] = getStoreValue(key);
+      });
+      return values;
+    });
+
+    return {
+      showComponent,
+      normalizeKey,
+      formatValue,
+      displayValues,
+    };
+  },
+});
+</script>
+
+<template>
+  <div v-if="showComponent" data-cy="debug-register-challenge-store">
+    <div class="text-red text-bold">
+      <div
+        v-for="(value, label) in displayValues"
+        :key="label"
+        :data-cy="`debug-${normalizeKey(String(label))}`"
+        class="q-mb-xs"
+      >
+        <span class="text-weight-medium">{{ label }}:</span>
+        <span
+          :data-cy="`debug-${normalizeKey(String(label))}-value`"
+          class="q-ml-sm"
+          style="white-space: pre-wrap"
+        >
+          {{ formatValue(value) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/form/FormCoordinatorApplication.vue
+++ b/src/components/form/FormCoordinatorApplication.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         Notify.create({
           type: 'negative',
           message: i18n.global.t(
-            'form.messageCoordinatorMissingPersonalDetails',
+            'registerCoordinator.messageMissingPersonalDetails',
           ),
         });
         return;
@@ -94,7 +94,9 @@ export default defineComponent({
       if (!formCoordinatorData.organizationId) {
         Notify.create({
           type: 'negative',
-          message: i18n.global.t('form.messageCoordinatorMissingOrganization'),
+          message: i18n.global.t(
+            'registerCoordinator.messageMissingOrganizationId',
+          ),
         });
         return;
       }

--- a/src/components/form/FormCoordinatorApplication.vue
+++ b/src/components/form/FormCoordinatorApplication.vue
@@ -34,6 +34,7 @@ import { useValidation } from '../../composables/useValidation';
 // components
 import FormFieldTextRequired from '../global/FormFieldTextRequired.vue';
 import FormFieldPhone from '../global/FormFieldPhone.vue';
+import ShowRegisterChallengeStoreValues from '../debug/ShowRegisterChallengeStoreValues.vue';
 
 // config
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
@@ -53,6 +54,7 @@ export default defineComponent({
   components: {
     FormFieldTextRequired,
     FormFieldPhone,
+    ShowRegisterChallengeStoreValues,
   },
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
@@ -117,6 +119,16 @@ export default defineComponent({
       }
 
       await registerStore.registerCoordinator(payload, false);
+
+      // reset form
+      formCoordinatorApplicationRef.value?.reset();
+    };
+
+    const onReset = () => {
+      formCoordinatorData.jobTitle = '';
+      formCoordinatorData.phone = '';
+      formCoordinatorData.responsibility = false;
+      formCoordinatorData.terms = true;
     };
 
     return {
@@ -125,6 +137,7 @@ export default defineComponent({
       formCoordinatorData,
       isPhone,
       onSubmit,
+      onReset,
     };
   },
 });
@@ -134,6 +147,7 @@ export default defineComponent({
   <q-form
     autofocus
     @submit.prevent="onSubmit"
+    @reset="onReset"
     ref="formCoordinatorApplicationRef"
     data-cy="form-coordinator-application"
   >
@@ -247,5 +261,7 @@ export default defineComponent({
         />
       </div>
     </div>
+    <!-- Debug component: Show register challenge store values -->
+    <show-register-challenge-store-values :keys="['getTelephone']" />
   </q-form>
 </template>

--- a/src/components/types/Register.ts
+++ b/src/components/types/Register.ts
@@ -8,3 +8,13 @@ export interface RegisterCoordinatorRequest {
   responsibility?: boolean;
   terms?: boolean;
 }
+export interface RegisterCoordinatorResponse {
+  firstName?: string;
+  jobTitle?: string;
+  lastName?: string;
+  newsletter: string;
+  organizationId?: number;
+  phone?: string;
+  responsibility?: boolean;
+  terms?: boolean;
+}

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -836,6 +836,8 @@ apiMessageSuccess = "Registrace byla úspěšná"
 apiMessageError = "Registrace koordinátora se nezdařila. Prosím, zkuste to znovu později."
 apiMessageErrorWithMessage = "Registrace koordinátora se nezdařila. Prosím, zkuste to znovu později. Chyba: {error}"
 apiMessageSuccess = "Registrace koordinátora byla úspěšná"
+messageMissingPersonalDetails = "Formulář nemohl být odeslán. Ve vašem profilu chybějí důležité informace: jméno, příjmení."
+messageMissingOrganizationId = "Formulář nemohl být odeslán. Ve vašem profilu chybí ID vaší organizace."
 messageNoOrganizationId = "Prosím vyberte organizaci, pro kterou chcete být koordinátorem."
 
 [register.form]

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -835,6 +835,8 @@ apiMessageSuccess = "Registration was successful"
 apiMessageError = "Coordinator registration failed. Please try again later."
 apiMessageErrorWithMessage = "Coordinator registration failed. Please try again later. Error: {error}"
 apiMessageSuccess = "Coordinator registration was successful"
+messageMissingPersonalDetails = "The form could not be submitted. Your profile is missing important information: first name, last name."
+messageMissingOrganizationId = "The form could not be submitted. Your profile is missing your organization ID."
 messageNoOrganizationId = "Please select an organization you want to be a coordinator for."
 
 [register.form]

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -835,6 +835,8 @@ apiMessageSuccess = "Registrácia bola úspešná"
 apiMessageError = "Registrácia koordinátora sa nezdařila. Prosím, skúste to znovu později."
 apiMessageErrorWithMessage = "Registrácia koordinátora sa nezdařila. Prosím, skúste to znovu později. Chyba: {error}"
 apiMessageSuccess = "Registrácia koordinátora bola úspešná"
+messageMissingPersonalDetails = "Formulár nemohol byť odoslaný. Vo vašom profile chýbajú dôležité informácie: meno, priezvisko."
+messageMissingOrganizationId = "Formulár nemohol byť odoslaný. Vo vašom profile chýba ID vašej organizácie."
 messageNoOrganizationId = "Prosím vyberte organizáciu, pre ktorú chcete byť koordinátorom."
 
 [register.form]

--- a/src/pages/BecomeCoordinatorPage.vue
+++ b/src/pages/BecomeCoordinatorPage.vue
@@ -14,11 +14,13 @@
 import { defineComponent } from 'vue';
 
 // components
+import FormCoordinatorApplication from 'components/form/FormCoordinatorApplication.vue';
 import PageHeading from 'components/global/PageHeading.vue';
 
 export default defineComponent({
   name: 'BecomeCoordinatorPage',
   components: {
+    FormCoordinatorApplication,
     PageHeading,
   },
   setup() {
@@ -47,7 +49,7 @@ export default defineComponent({
             data-cy="company-coordinator-text"
           />
           <div class="q-mt-lg">
-            <!-- TODO: Form apply -->
+            <form-coordinator-application />
           </div>
         </div>
         <div class="col-lg-4">

--- a/src/stores/register.ts
+++ b/src/stores/register.ts
@@ -13,10 +13,14 @@ import { routesConf } from '../router/routes_conf';
 // stores
 import { useLoginStore } from './login';
 import { useRegisterChallengeStore } from './registerChallenge';
+
 // types
 import type { Logger } from '../components/types/Logger';
 import type { LoginResponse as RegisterResponse } from '../components/types/Login';
-import type { RegisterCoordinatorRequest } from '../components/types/Register';
+import type {
+  RegisterCoordinatorRequest,
+  RegisterCoordinatorResponse,
+} from '../components/types/Register';
 
 // utils
 import { requestDefaultHeader, requestTokenHeader } from 'src/utils';
@@ -215,7 +219,7 @@ export const useRegisterStore = defineStore('register', {
         await loginStore.getAccessTokenWithRefresh();
       // register
       this.$log?.info('Post API coordinator registration details.');
-      const { success } = await apiFetch<null>({
+      const { data, success } = await apiFetch<RegisterCoordinatorResponse>({
         endpoint: rideToWorkByBikeConfig.urlApiRegisterCoordinator,
         method: 'post',
         payload,
@@ -230,8 +234,12 @@ export const useRegisterStore = defineStore('register', {
         this.$log?.debug(
           `Register store setting isRegistrationComplete to <${true}>.`,
         );
-        // update `isUserOrganizationAdmin` state in registerChallenge store
+
+        // set values returned from API into registerChallenge store
         const registerChallengeStore = useRegisterChallengeStore();
+        registerChallengeStore.setTelephone(data?.phone || '');
+
+        // update `isUserOrganizationAdmin` state in registerChallenge store
         await registerChallengeStore.checkIsUserOrganizationAdmin();
         // redirect to home page
         if (this.$router && redirect) {

--- a/test/cypress/e2e/become_coordinator.spec.cy.js
+++ b/test/cypress/e2e/become_coordinator.spec.cy.js
@@ -70,26 +70,33 @@ describe('Become coordinator page', () => {
       });
     });
 
-    it('renders form with empty input fields and pre-filled terms when logged in', () => {
-      cy.dataCy('form-coordinator-position')
-        .find('input')
-        .should('have.value', '');
-      cy.dataCy('form-coordinator-phone')
-        .find('input')
-        .should('have.value', '');
-      cy.dataCy('form-coordinator-responsibility')
-        .find('.q-checkbox__inner')
-        .should('have.class', 'q-checkbox__inner--falsy');
-      // terms are checked based on registerChallenge data
-      cy.dataCy('form-coordinator-terms')
-        .find('.q-checkbox__inner')
-        .should('have.class', 'q-checkbox__inner--truthy');
-    });
-
     it('submits form successfully and updates coordinator status', () => {
       cy.window().should('have.property', 'i18n');
       cy.window().then((win) => {
         cy.fixture('formBecomeCoordinator').then((testData) => {
+          // check initial values in form
+          cy.dataCy('form-coordinator-position')
+            .find('input')
+            .should('have.value', '');
+          cy.dataCy('form-coordinator-phone')
+            .find('input')
+            .should('have.value', '');
+          cy.dataCy('form-coordinator-responsibility')
+            .find('.q-checkbox__inner')
+            .should('have.class', 'q-checkbox__inner--falsy');
+          // terms are checked based on registerChallenge data
+          cy.dataCy('form-coordinator-terms')
+            .find('.q-checkbox__inner')
+            .should('have.class', 'q-checkbox__inner--truthy');
+          // check initial telephone value in store
+          cy.fixture('apiGetRegisterChallengeProfile.json').then((response) => {
+            cy.dataCy('debug-register-challenge-store').within(() => {
+              cy.dataCy('debug-telephone').should(
+                'contain',
+                response.results[0].personal_details.telephone,
+              );
+            });
+          });
           cy.dataCy('form-coordinator-position')
             .find('input')
             .type(testData.input.jobTitle);
@@ -107,6 +114,27 @@ describe('Become coordinator page', () => {
           cy.contains(
             win.i18n.global.t('registerCoordinator.apiMessageSuccess'),
           ).should('be.visible');
+          // check if telephone is set in store
+          cy.dataCy('debug-register-challenge-store').within(() => {
+            cy.dataCy('debug-telephone').should(
+              'contain',
+              testData.input.phone,
+            );
+          });
+          // check that the form is reset
+          cy.dataCy('form-coordinator-position')
+            .find('input')
+            .should('have.value', '');
+          cy.dataCy('form-coordinator-phone')
+            .find('input')
+            .should('have.value', '');
+          cy.dataCy('form-coordinator-responsibility')
+            .find('.q-checkbox__inner')
+            .should('have.class', 'q-checkbox__inner--falsy');
+          // terms are checked based on registerChallenge data
+          cy.dataCy('form-coordinator-terms')
+            .find('.q-checkbox__inner')
+            .should('have.class', 'q-checkbox__inner--truthy');
         });
       });
     });

--- a/test/cypress/e2e/become_coordinator.spec.cy.js
+++ b/test/cypress/e2e/become_coordinator.spec.cy.js
@@ -1,5 +1,9 @@
 import { routesConf } from '../../../src/router/routes_conf';
-import { testDesktopSidebar, testMobileHeader } from '../support/commonTests';
+import {
+  testDesktopSidebar,
+  testMobileHeader,
+  systemTimeChallengeActive,
+} from '../support/commonTests';
 
 describe('Become coordinator page', () => {
   context('desktop', () => {
@@ -42,6 +46,166 @@ describe('Become coordinator page', () => {
 
     coreTests();
     testMobileHeader();
+  });
+
+  context('with authenticated user and API intercepts', () => {
+    beforeEach(() => {
+      // set system time to be in the correct active token window
+      cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
+        cy.task('getAppConfig', process).then((config) => {
+          cy.wrap(config).as('config');
+          // visit the login page to initialize i18n
+          cy.visit('#' + routesConf['login']['path']);
+          cy.window().should('have.property', 'i18n');
+          cy.window().then((win) => {
+            cy.wrap(win.i18n).as('i18n');
+            // setup coordinator test environment
+            cy.setupCoordinatorTest(
+              config,
+              win.i18n,
+              'apiGetRegisterChallengeProfile.json',
+            );
+          });
+        });
+      });
+    });
+
+    it('renders form with empty input fields and pre-filled terms when logged in', () => {
+      cy.dataCy('form-coordinator-position')
+        .find('input')
+        .should('have.value', '');
+      cy.dataCy('form-coordinator-phone')
+        .find('input')
+        .should('have.value', '');
+      cy.dataCy('form-coordinator-responsibility')
+        .find('.q-checkbox__inner')
+        .should('have.class', 'q-checkbox__inner--falsy');
+      // terms are checked based on registerChallenge data
+      cy.dataCy('form-coordinator-terms')
+        .find('.q-checkbox__inner')
+        .should('have.class', 'q-checkbox__inner--truthy');
+    });
+
+    it('submits form successfully and updates coordinator status', () => {
+      cy.window().should('have.property', 'i18n');
+      cy.window().then((win) => {
+        cy.fixture('formBecomeCoordinator').then((testData) => {
+          cy.dataCy('form-coordinator-position')
+            .find('input')
+            .type(testData.input.jobTitle);
+          cy.dataCy('form-coordinator-phone')
+            .find('input')
+            .type(testData.input.phone);
+          cy.dataCy('form-coordinator-responsibility')
+            .find('.q-checkbox__inner')
+            .click();
+          cy.dataCy('form-coordinator-submit').click();
+          // check if correct payload is sent
+          cy.waitForRegisterCoordinatorApi(testData.request);
+          // code re-check isUserOrganizationAdmin status
+          cy.wait('@getIsUserOrganizationAdmin');
+          cy.contains(
+            win.i18n.global.t('registerCoordinator.apiMessageSuccess'),
+          ).should('be.visible');
+        });
+      });
+    });
+  });
+
+  context('with missing personal details', () => {
+    beforeEach(() => {
+      // set system time to be in the correct active token window
+      cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
+        cy.task('getAppConfig', process).then((config) => {
+          cy.wrap(config).as('config');
+          // visit the login page to initialize i18n
+          cy.visit('#' + routesConf['login']['path']);
+          cy.window().should('have.property', 'i18n');
+          cy.window().then((win) => {
+            cy.wrap(win.i18n).as('i18n');
+            // setup coordinator test environment with missing name fixture
+            cy.setupCoordinatorTest(
+              config,
+              win.i18n,
+              'apiGetRegisterChallengeProfileMissingName.json',
+            );
+          });
+        });
+      });
+    });
+
+    it('shows error when store lacks required personal details', () => {
+      cy.window().then((win) => {
+        cy.fixture('formBecomeCoordinator').then((testData) => {
+          cy.dataCy('form-coordinator-position')
+            .find('input')
+            .type(testData.input.jobTitle);
+          cy.dataCy('form-coordinator-phone')
+            .find('input')
+            .type(testData.input.phone);
+          cy.dataCy('form-coordinator-responsibility')
+            .find('.q-checkbox__inner')
+            .click();
+          cy.dataCy('form-coordinator-submit').click();
+          // error message should be displayed
+          cy.contains(
+            win.i18n.global.t(
+              'registerCoordinator.messageMissingPersonalDetails',
+            ),
+          );
+          // no request should be sent
+          cy.get('@registerCoordinator.all').should('have.length', 0);
+        });
+      });
+    });
+  });
+
+  context('with missing organizationId', () => {
+    beforeEach(() => {
+      // set system time to be in the correct active token window
+      cy.clock(systemTimeChallengeActive, ['Date']).then(() => {
+        cy.task('getAppConfig', process).then((config) => {
+          cy.wrap(config).as('config');
+          // visit the login page to initialize i18n
+          cy.visit('#' + routesConf['login']['path']);
+          cy.window().should('have.property', 'i18n');
+          cy.window().then((win) => {
+            cy.wrap(win.i18n).as('i18n');
+            // setup coordinator test environment with missing organizationId fixture
+            cy.setupCoordinatorTest(
+              config,
+              win.i18n,
+              'apiGetRegisterChallengeProfileMissingOrganizationId.json',
+            );
+          });
+        });
+      });
+    });
+
+    it('shows error when organizationId is missing', () => {
+      cy.window().then((win) => {
+        cy.fixture('formBecomeCoordinator').then((testData) => {
+          cy.dataCy('form-coordinator-position')
+            .find('input')
+            .type(testData.input.jobTitle);
+          cy.dataCy('form-coordinator-phone')
+            .find('input')
+            .type(testData.input.phone);
+          cy.dataCy('form-coordinator-responsibility')
+            .find('.q-checkbox__inner')
+            .click();
+          cy.dataCy('form-coordinator-submit').click();
+          // error message should be displayed
+          cy.contains(
+            win.i18n.global.t(
+              'registerCoordinator.messageMissingOrganizationId',
+            ),
+          );
+          // no request should be sent
+          cy.get('@registerCoordinator.all').should('have.length', 0);
+        });
+      });
+    });
   });
 });
 

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfileMissingName.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfileMissingName.json
@@ -1,0 +1,36 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "",
+        "last_name": "",
+        "email": "foo@bar.org",
+        "id": 123,
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "done",
+        "payment_amount": 390
+      },
+      "city_slug": "praha",
+      "city_wp_slug": "praha",
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": 987,
+      "subsidiary_id": 1358,
+      "t_shirt_size_id": 133
+    }
+  ]
+}

--- a/test/cypress/fixtures/apiGetRegisterChallengeProfileMissingOrganizationId.json
+++ b/test/cypress/fixtures/apiGetRegisterChallengeProfileMissingOrganizationId.json
@@ -1,0 +1,36 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "personal_details": {
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "email": "foo@bar.org",
+        "id": 123,
+        "nickname": "FB",
+        "sex": "male",
+        "telephone": "736123456",
+        "telephone_opt_in": false,
+        "language": "cs",
+        "occupation": "",
+        "age_group": null,
+        "newsletter": "challenge",
+        "personal_data_opt_in": true,
+        "discount_coupon": "",
+        "payment_subject": "company",
+        "payment_type": "fc",
+        "payment_status": "done",
+        "payment_amount": 390
+      },
+      "city_slug": "praha",
+      "city_wp_slug": "praha",
+      "organization_type": "company",
+      "team_id": 2451,
+      "organization_id": null,
+      "subsidiary_id": null,
+      "t_shirt_size_id": null
+    }
+  ]
+}

--- a/test/cypress/fixtures/formBecomeCoordinator.json
+++ b/test/cypress/fixtures/formBecomeCoordinator.json
@@ -12,5 +12,15 @@
     "phone": "732123456",
     "responsibility": true,
     "terms": true
+  },
+  "response": {
+    "firstName": "Foo",
+    "lastName": "Bar",
+    "jobTitle": "Senior Developer",
+    "newsletter": "challenge",
+    "organizationId": 987,
+    "phone": "732123456",
+    "responsibility": true,
+    "terms": true
   }
 }

--- a/test/cypress/fixtures/formBecomeCoordinator.json
+++ b/test/cypress/fixtures/formBecomeCoordinator.json
@@ -1,0 +1,16 @@
+{
+  "input": {
+    "jobTitle": "Senior Developer",
+    "phone": "732123456"
+  },
+  "request": {
+    "firstName": "Foo",
+    "lastName": "Bar",
+    "jobTitle": "Senior Developer",
+    "newsletter": "challenge",
+    "organizationId": 987,
+    "phone": "732123456",
+    "responsibility": true,
+    "terms": true
+  }
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -44,6 +44,7 @@ import { getApiBaseUrlWithLang } from '../../../src/utils/get_api_base_url_with_
 import { bearerTokeAuth } from '../../../src/utils';
 import { OrganizationType } from '../../../src/components/types/Organization';
 import { routesConf } from '../../../src/router/routes_conf';
+import { defLocale } from '../../../src/i18n/def_locale';
 import { getRadioOption, negativeColor, positiveColor } from '../utils';
 import { PaymentSubject } from '../../../src/components/enums/Payment';
 import { useMenu } from '../../../src/composables/useMenu';
@@ -3962,5 +3963,120 @@ Cypress.Commands.add(
         }
       },
     );
+  },
+);
+
+/**
+ * Intercept register coordinator API call
+ * @param {Object} config - App configuration object
+ * @param {Object} i18n - Internationalization object
+ * @param {Object} responseBody - Expected response body (optional)
+ */
+Cypress.Commands.add(
+  'interceptRegisterCoordinatorApi',
+  (config, i18n, responseBody = null, responseStatusCode = null) => {
+    const { apiBase, apiDefaultLang, urlApiRegisterCoordinator } = config;
+    const apiBaseUrl = getApiBaseUrlWithLang(
+      null,
+      apiBase,
+      apiDefaultLang,
+      i18n,
+    );
+    const urlApiRegisterCoordinatorLocalized = `${apiBaseUrl}${urlApiRegisterCoordinator}`;
+
+    cy.intercept('POST', urlApiRegisterCoordinatorLocalized, {
+      statusCode: responseStatusCode || httpSuccessfullStatus,
+      body: responseBody,
+    }).as('registerCoordinator');
+  },
+);
+
+/**
+ * Wait for register coordinator API call and compare request/response object
+ * Wait for `@registerCoordinator` intercept
+ * @param {Object} requestBody - Expected request body to compare against
+ * @param {Object} responseBody - Expected response body to compare against (optional)
+ */
+Cypress.Commands.add(
+  'waitForRegisterCoordinatorApi',
+  (requestBody, responseBody = null) => {
+    cy.wait('@registerCoordinator').then(({ request, response }) => {
+      // verify request body
+      expect(request.body).to.deep.equal(requestBody);
+      // verify response body if provided
+      if (responseBody) {
+        expect(response.body).to.deep.equal(responseBody);
+      }
+    });
+  },
+);
+
+/**
+ * Performs authenticated login flow for E2E tests
+ *
+ * @param {Object} config - App configuration object
+ * @param {Object} i18n - Internationalization object
+ * @returns {void}
+ */
+Cypress.Commands.add('performAuthenticatedLogin', (config, i18n) => {
+  // Load required fixtures
+  cy.fixture('refreshTokensResponseChallengeActive').then(
+    (refreshTokensResponseChallengeActive) => {
+      cy.fixture('loginRegisterResponseChallengeActive').then(
+        (loginRegisterResponseChallengeActive) => {
+          // set up API intercepts
+          cy.interceptLoginRefreshAuthTokenVerifyEmailVerifyCampaignPhaseApi(
+            config,
+            i18n,
+            loginRegisterResponseChallengeActive,
+            null,
+            refreshTokensResponseChallengeActive,
+            null,
+            { has_user_verified_email_address: true },
+          );
+          // intercept APIs that get called after login
+          cy.interceptMyTeamGetApi(config, i18n);
+          // perform login
+          cy.fillAndSubmitLoginForm(config, i18n);
+          // wait for authentication flow to complete
+          cy.wait([
+            '@loginRequest',
+            '@verifyEmailRequest',
+            '@thisCampaignRequest',
+          ]);
+          // confirm we are on home page
+          cy.dataCy('index-title').should('be.visible');
+        },
+      );
+    },
+  );
+});
+
+/**
+ * Setup authenticated coordinator test environment
+ * Sets up API intercepts, performs login, and navigates to become coordinator page
+ * @param {Object} config - App configuration object
+ * @param {Object} i18n - Internationalization object
+ * @param {string} registerChallengeFixture - Fixture file name for register challenge response
+ */
+Cypress.Commands.add(
+  'setupCoordinatorTest',
+  (
+    config,
+    i18n,
+    registerChallengeFixture = 'apiGetRegisterChallengeProfile.json',
+  ) => {
+    cy.fixture(registerChallengeFixture).then((response) => {
+      cy.interceptRegisterChallengeGetApi(config, defLocale, response);
+    });
+    cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+      (response) => {
+        cy.interceptIsUserOrganizationAdminGetApi(config, defLocale, response);
+      },
+    );
+    cy.interceptRegisterCoordinatorApi(config, i18n);
+    cy.performAuthenticatedLogin(config, i18n);
+    cy.visit('#' + routesConf['become_coordinator']['path']);
+    cy.dataCy('company-coordinator-title').should('be.visible');
   },
 );

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -4074,7 +4074,9 @@ Cypress.Commands.add(
         cy.interceptIsUserOrganizationAdminGetApi(config, defLocale, response);
       },
     );
-    cy.interceptRegisterCoordinatorApi(config, i18n);
+    cy.fixture('formBecomeCoordinator').then((testData) => {
+      cy.interceptRegisterCoordinatorApi(config, i18n, testData.response);
+    });
     cy.performAuthenticatedLogin(config, i18n);
     cy.visit('#' + routesConf['become_coordinator']['path']);
     cy.dataCy('company-coordinator-title').should('be.visible');


### PR DESCRIPTION
Add ability to register logged in user as coordinator in `FormCoordinatorApplication` component.

- integrate component `FormCoordinatorApplication.vue` into `BecomeCoordinatorPage.vue`
- add submit event for form submit with API call to `register-coordinator` endpoint
- add debug component `ShowRegisterChallengeStoreValues.vue` for displaying store state
- add E2E tests (fixture for test data + fixtures for starting state - data from `register-challenge` endpoint)

[Jira task: DPNKAP-30](https://automatno.atlassian.net/browse/DPNKAP-30?atlOrigin=eyJpIjoiYTFkYTI3YTk5OWNjNGYwZGIwOTY0NTc0OTZlYzRkMGIiLCJwIjoiaiJ9)