### PR TITLE
src/components/__tests__/FooterBar: remove external URL test to prevent failing on CI

### DIFF
--- a/src/components/__tests__/FooterBar.cy.js
+++ b/src/components/__tests__/FooterBar.cy.js
@@ -96,20 +96,6 @@ describe('<FooterBar>', () => {
         );
       });
     });
-
-    it('test application info URL', () => {
-      cy.request({
-        url: rideToWorkByBikeConfig.urlFreeSoftwareDefinition,
-        failOnStatusCode: failOnStatusCode,
-        headers: { ...userAgentHeader },
-      }).then((resp) => {
-        if (resp.status === httpTooManyRequestsStatus) {
-          cy.log(httpTooManyRequestsStatusMessage);
-          return;
-        }
-        expect(resp.status).to.eq(httpSuccessfullStatus);
-      });
-    });
   });
 
   context('mobile', () => {


### PR DESCRIPTION
Issue: `FooterBar` component test often fails on CI with message:
```
  1) <FooterBar>
       desktop
         test application info URL:
     CypressError: `cy.request()` timed out waiting `30000ms` for a response from your server.
```

Cause: Issue comes with testing the [Free Software definition URL](https://www.gnu.org/philosophy/free-sw.en.html). This is likely caused by limitation on CI block or target site.

Solution: Since the issue likely originates outside our app and tests. I suggest opting out of testing the URL availability - we keep testing the correct URL in the link attribute elsewhere in the test.