### PR TITLE
src/components/__tests__/FormLogin: add function options parameter to login call to display error message

### DIFF
--- a/src/components/__tests__/FormLogin.cy.js
+++ b/src/components/__tests__/FormLogin.cy.js
@@ -443,7 +443,7 @@ describe('<FormLogin>', () => {
         expect(result).to.equal(null);
         cy.get(classSelectorQNotificationMessage)
           .should('be.visible')
-          .and('contain', i18n.global.t('login.form.messageEmailReqired'));
+          .and('contain', i18n.global.t('login.form.messagePasswordRequired'));
       });
     });
 
@@ -469,7 +469,16 @@ describe('<FormLogin>', () => {
     it('calls API and shows error if login fails', () => {
       const store = useLoginStore();
       // intercept login API call
-      cy.wrap(store.login({ username, password })).then(() => {
+      cy.wrap(
+        store.login(
+          { username, password },
+          {
+            redirectAfterLogin: false,
+            showSuccessMessage: true,
+            showErrorMessage: true,
+          },
+        ),
+      ).then(() => {
         cy.get(classSelectorQNotificationMessage)
           .should('be.visible')
           .and('contain', i18n.global.t('login.apiMessageError'));


### PR DESCRIPTION
Issue: `FormLogin` component test fails with message
```
  1) <FormLogin>
       desktop
         shows error if API call fails (error has message):
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `.q-notification__message`, but never found it.
```

Cause: Parameter `options` was added to `login()` function which contains flag to show error messages - this needs to be passed in to work properly.

Solution: Add missing options parameter with correct flags.

Additional change: Fix error translation string key.