### PR TITLE
src/components/__tests__/NewsletterFeature: update awating API requests to ensure sequential checks

### DIFF
--- a/src/components/__tests__/NewsletterFeature.cy.js
+++ b/src/components/__tests__/NewsletterFeature.cy.js
@@ -270,6 +270,7 @@ function coreTests() {
             ).then((responseUpdatedAll) => {
               // wait for register-challenge GET request
               cy.waitForRegisterChallengeGetApi(responseRegisterChallenge);
+              cy.get('@getRegisterChallenge.all').should('have.length', 1);
               // newsletter challenge is enabled
               cy.dataCy('newsletter-feature-item').each(($item) => {
                 const dataId = $item.attr('data-id');
@@ -300,8 +301,10 @@ function coreTests() {
               ).then((request) => {
                 cy.waitForRegisterChallengePutApi(request);
               });
+              cy.get('@putRegisterChallenge.all').should('have.length', 1);
               // wait for GET request
               cy.waitForRegisterChallengeGetApi(responseUpdated);
+              cy.get('@getRegisterChallenge.all').should('have.length', 2);
               // verify button state changed
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="mobility"]')
@@ -324,8 +327,10 @@ function coreTests() {
               ).then((request) => {
                 cy.waitForRegisterChallengePutApi(request);
               });
+              cy.get('@putRegisterChallenge.all').should('have.length', 2);
               // wait for GET request
               cy.waitForRegisterChallengeGetApi(responseUpdatedAll);
+              cy.get('@getRegisterChallenge.all').should('have.length', 3);
               // verify button state changed
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="events"]')

--- a/src/components/__tests__/NewsletterFeature.cy.js
+++ b/src/components/__tests__/NewsletterFeature.cy.js
@@ -269,9 +269,10 @@ function coreTests() {
               'apiGetRegisterChallengeProfileUpdatedNewsletterAll.json',
             ).then((responseUpdatedAll) => {
               // wait for register-challenge GET request
-              cy.waitForRegisterChallengeGetApi(responseRegisterChallenge);
               cy.get('@getRegisterChallenge.all').should('have.length', 1);
-              // newsletter challenge is enabled
+              // check loaded data
+              cy.waitForRegisterChallengeGetApi(responseRegisterChallenge);
+              // UI shows newsletter challenge is enabled
               cy.dataCy('newsletter-feature-item').each(($item) => {
                 const dataId = $item.attr('data-id');
                 if (dataId === 'challenge') {
@@ -284,7 +285,7 @@ function coreTests() {
                     .should('have.class', 'q-toggle__inner--falsy');
                 }
               });
-              // follow newsletter mobility
+              // set newsletter mobility to enabled
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="mobility"]')
                 .find('.q-toggle__inner')
@@ -296,21 +297,22 @@ function coreTests() {
                 responseUpdated,
               );
               // wait for PUT request
+              cy.get('@putRegisterChallenge.all').should('have.length', 1);
+              // check sent data
               cy.fixture(
                 'apiPostRegisterChallengeNewsletterChallengeMobilityRequest.json',
               ).then((request) => {
                 cy.waitForRegisterChallengePutApi(request);
               });
-              cy.get('@putRegisterChallenge.all').should('have.length', 1);
               // wait for GET request
-              cy.waitForRegisterChallengeGetApi(responseUpdated);
               cy.get('@getRegisterChallenge.all').should('have.length', 2);
-              // verify button state changed
+              cy.waitForRegisterChallengeGetApi(responseUpdated);
+              // verify that mobility state changed to enabled
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="mobility"]')
                 .find('.q-toggle__inner')
                 .should('have.class', 'q-toggle__inner--truthy');
-              // follow newsletter events
+              // set newsletter events to enabled
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="events"]')
                 .find('.q-toggle__inner')
@@ -322,16 +324,18 @@ function coreTests() {
                 responseUpdatedAll,
               );
               // wait for PUT request
+              cy.get('@putRegisterChallenge.all').should('have.length', 2);
+              // check sent data
               cy.fixture(
                 'apiPostRegisterChallengeNewsletterAllRequest.json',
               ).then((request) => {
                 cy.waitForRegisterChallengePutApi(request);
               });
-              cy.get('@putRegisterChallenge.all').should('have.length', 2);
               // wait for GET request
-              cy.waitForRegisterChallengeGetApi(responseUpdatedAll);
               cy.get('@getRegisterChallenge.all').should('have.length', 3);
-              // verify button state changed
+              // check loaded data
+              cy.waitForRegisterChallengeGetApi(responseUpdatedAll);
+              // verify that events state changed to enabled
               cy.dataCy('newsletter-feature-item')
                 .filter('[data-id="events"]')
                 .find('.q-toggle__inner')


### PR DESCRIPTION
Issue: `NewsletterFeature` component test sometimes fails with message:
```
1) loads newsletter settings from API
   
	<NewsletterFeature>
       mobile
         loads newsletter settings from API:

      AssertionError: expected { Object (count, next, ...) } to deeply equal { Object (count, next, ...) }
      + expected - actual

         next: null,
         previous: null,
         results: 
          [ { personal_details: [Object],
      -       city_slug: 'praha',
      -       city_wp_slug: 'praha',
              organization_type: 'company',
```

Cause: This is likely caused by race condition between executing an API request and overriding the intercept - the GET requests still compares the old intercepted version with the fixture data expecting new intercept.

Solution: Add check for the number of requests to wait for the correct version of data to be intercepted (GET should be intercepted while awaiting the POST request).