### PR TITLE
test/cypress/e2e: add visibility check before button presses

### DIFF
--- a/test/cypress/e2e/register_challenge.spec.cy.js
+++ b/test/cypress/e2e/register_challenge.spec.cy.js
@@ -3931,19 +3931,28 @@ describe('Register Challenge page', () => {
           .find('.q-stepper__step-content')
           .should('be.visible');
         // go to step 3
-        cy.dataCy('step-2-continue').click();
+        cy.dataCy('step-2-continue')
+          .should('be.visible')
+          .and('not.contain', 'q-spinner')
+          .click();
         // we are on step 3
         cy.dataCy('step-3')
           .find('.q-stepper__step-content')
           .should('be.visible');
         // go to step 4
-        cy.dataCy('step-3-continue').click();
+        cy.dataCy('step-3-continue')
+          .should('be.visible')
+          .and('not.contain', 'q-spinner')
+          .click();
         // we are on step 4
         cy.dataCy('step-4')
           .find('.q-stepper__step-content')
           .should('be.visible');
         // go to step 5
-        cy.dataCy('step-4-continue').click();
+        cy.dataCy('step-4-continue')
+          .should('be.visible')
+          .and('not.contain', 'q-spinner')
+          .click();
         // we are on step 5
         cy.dataCy('step-5')
           .find('.q-stepper__step-content')
@@ -3961,7 +3970,10 @@ describe('Register Challenge page', () => {
           .should('have.class', 'disabled')
           .and('contain', responseTeams.results[0].name);
         // click continue button
-        cy.dataCy('step-5-continue').click();
+        cy.dataCy('step-5-continue')
+          .should('be.visible')
+          .and('not.contain', 'q-spinner')
+          .click();
         // second teams request is to refresh availability
         cy.waitForTeamsGetApi();
         // wait for my_team GET API call
@@ -3993,19 +4005,28 @@ describe('Register Challenge page', () => {
                   .find('.q-stepper__step-content')
                   .should('be.visible');
                 // go to step 3
-                cy.dataCy('step-2-continue').click();
+                cy.dataCy('step-2-continue')
+                  .should('be.visible')
+                  .and('not.contain', 'q-spinner')
+                  .click();
                 // we are on step 3
                 cy.dataCy('step-3')
                   .find('.q-stepper__step-content')
                   .should('be.visible');
                 // go to step 4
-                cy.dataCy('step-3-continue').click();
+                cy.dataCy('step-3-continue')
+                  .should('be.visible')
+                  .and('not.contain', 'q-spinner')
+                  .click();
                 // we are on step 4
                 cy.dataCy('step-4')
                   .find('.q-stepper__step-content')
                   .should('be.visible');
                 // go to step 5
-                cy.dataCy('step-4-continue').click();
+                cy.dataCy('step-4-continue')
+                  .should('be.visible')
+                  .and('not.contain', 'q-spinner')
+                  .click();
                 // we are on step 5
                 cy.dataCy('step-5')
                   .find('.q-stepper__step-content')
@@ -4023,7 +4044,10 @@ describe('Register Challenge page', () => {
                   .should('have.class', 'disabled')
                   .and('contain', responseTeams.results[0].name);
                 // click continue button
-                cy.dataCy('step-5-continue').click();
+                cy.dataCy('step-5-continue')
+                  .should('be.visible')
+                  .and('not.contain', 'q-spinner')
+                  .click();
                 // second teams request is to refresh availability
                 cy.waitForTeamsGetApi();
                 // wait for my_team GET API call


### PR DESCRIPTION
Issue: `register_challenge` E2E test occasionally fails with error:
```
  1) Register Challenge page
       registration with selected full team
         does not allow to pass on full team if user is not a member:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `.q-stepper__step-content`, but never found it. 
```

Cause: This is likely caused by running the .click command before button it is fully visible.

Solution: Add `.should('be.visible')` check before click commands and ensure that buttons are not loading.