### PR TITLE
src/components: display date range on multi-day offer cards on prizes page

### DIFF
--- a/src/components/homepage/CardOffer.vue
+++ b/src/components/homepage/CardOffer.vue
@@ -69,22 +69,33 @@ export default defineComponent({
     const borderRadius = rideToWorkByBikeConfig.borderRadiusCard;
     const modalOpened = ref(false);
 
-    const eventDate = computed(() => {
-      // show for one-day events
-      if (
-        props.card.type !== OfferEventType.oneDayEvent ||
-        !props.card.startDate
-      ) {
+    const displayDate = computed(() => {
+      if (!props.card.startDate) {
         return null;
       }
-      // display date with removed timezone
-      const localDate = props.card.startDate.replace('Z', '');
-      return i18n.global.d(new Date(localDate), 'monthDayHourMinute');
+      // remove timezone marker
+      const localStartDate = props.card.startDate.replace('Z', '');
+      // one-day event - show date-time
+      if (props.card.type === OfferEventType.oneDayEvent) {
+        return i18n.global.d(new Date(localStartDate), 'monthDayHourMinute');
+      }
+      // multi-day offer - show date range no time
+      const startFormatted = i18n.global.d(
+        new Date(localStartDate),
+        'monthDay',
+      );
+      if (props.card.endDate) {
+        const localEndDate = props.card.endDate.replace('Z', '');
+        const endFormatted = i18n.global.d(new Date(localEndDate), 'monthDay');
+        return `${startFormatted} - ${endFormatted}`;
+      }
+      // fallback - only start date available
+      return startFormatted;
     });
 
     return {
       borderRadius,
-      eventDate,
+      displayDate,
       modalOpened,
       isOfferPast,
     };
@@ -124,14 +135,14 @@ export default defineComponent({
         ></div>
         <!-- Date chip -->
         <q-chip
-          v-if="eventDate"
+          v-if="displayDate"
           dense
           color="transparent"
           icon="svguse:icons/card_offer/icons.svg#calendar"
           class="q-mt-xs q-ml-none text-caption"
           data-cy="card-date-chip"
         >
-          {{ eventDate }}
+          {{ displayDate }}
         </q-chip>
       </q-card-section>
     </q-card-section>

--- a/test/cypress/e2e/prizes.spec.cy.js
+++ b/test/cypress/e2e/prizes.spec.cy.js
@@ -279,7 +279,7 @@ function coreTests() {
             cy.dataCy('discount-offers-item').each((item, index) => {
               cy.wrap(item).should('contain', displayedOffers[index].title);
               cy.wrap(item).within(() => {
-                cy.dataCy('card-date-chip').should('not.exist');
+                cy.dataCy('card-date-chip').should('be.visible');
               });
               cy.wrap(item).click();
               cy.dataCy('dialog-offer').should('be.visible');
@@ -345,6 +345,35 @@ function coreTests() {
         cy.dataCy('dialog-offer-link')
           .should('be.visible')
           .and('have.attr', 'href', offers[1].voucher_url);
+      });
+    });
+  });
+
+  it('displays correct date format on offer cards (date range)', () => {
+    cy.get('@i18n').then((i18n) => {
+      cy.waitForOffersApi();
+      cy.fixture('apiGetOffersResponse.json').then((offers) => {
+        // filter multi-day offers
+        cy.wrap(offers.filter(isOfferValidMoreThanOneDay)).then(
+          (displayedOffers) => {
+            // test first offer
+            const firstOffer = displayedOffers[0];
+            // format expected dates
+            const startDate = new Date(firstOffer.start_date.replace(' ', 'T'));
+            const endDate = new Date(firstOffer.end_date);
+            const expectedStart = i18n.global.d(startDate, 'monthDay');
+            const expectedEnd = i18n.global.d(endDate, 'monthDay');
+            const expectedDateRange = `${expectedStart} - ${expectedEnd}`;
+            // verify the date chip
+            cy.dataCy('discount-offers-item')
+              .first()
+              .within(() => {
+                cy.dataCy('card-date-chip')
+                  .should('be.visible')
+                  .and('contain', expectedDateRange);
+              });
+          },
+        );
       });
     });
   });
@@ -504,6 +533,35 @@ function coreTests() {
               cy.dataCy('card-date-chip').should('be.visible');
             });
           });
+        });
+      });
+    });
+  });
+
+  it('displays correct date format on event cards (date with time)', () => {
+    cy.get('@i18n').then((i18n) => {
+      cy.waitForOffersApi();
+      cy.fixture('apiGetOffersResponse.json').then((offers) => {
+        // filter one-day events
+        cy.wrap(
+          offers.filter((offer) => !isOfferValidMoreThanOneDay(offer)),
+        ).then((displayedEvents) => {
+          // test first event
+          const firstEvent = displayedEvents[0];
+          // format expected date-time
+          const startDate = new Date(firstEvent.start_date.replace(' ', 'T'));
+          const expectedDateTime = i18n.global.d(
+            startDate,
+            'monthDayHourMinute',
+          );
+          // verify the date chip
+          cy.dataCy('events-item')
+            .first()
+            .within(() => {
+              cy.dataCy('card-date-chip')
+                .should('be.visible')
+                .and('contain', expectedDateTime);
+            });
         });
       });
     });


### PR DESCRIPTION
Display date range on multi-day offer cards on prizes page.

Use the `startDate` and `endDate` to display offer validity on the prize card on top of displaying it in the dialog.

[Jira: AM-296](https://automatno.atlassian.net/browse/AM-296)