### PR TITLE
src/components: add tachometers results to Results page and Homepage

### DIFF
--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -307,7 +307,7 @@ describe('<ResultsTabs>', () => {
             resultsResponse.response,
             resultsResponse.key,
           );
-          // tachometers are shown above tabs, skip
+          // skip tachometers for tabs test loop
           if (resultsResponse.key === ResultsReportType.tachometers) {
             return;
           }

--- a/src/components/__tests__/ResultsTabs.cy.js
+++ b/src/components/__tests__/ResultsTabs.cy.js
@@ -46,6 +46,7 @@ describe('<ResultsTabs>', () => {
         'performanceOrganization',
         'regularity',
         'septemberJanuary',
+        'tachometers',
         'teamRegularityCity',
       ],
       'results.reportType',
@@ -240,6 +241,33 @@ describe('<ResultsTabs>', () => {
     });
   });
 
+  it('should show tachometers iframe above tabs', () => {
+    cy.fixture('apiGetResultsResponses').then((resultsResponses) => {
+      const tachometersResponse = resultsResponses.find(
+        (resultsResponse) =>
+          resultsResponse.key === ResultsReportType.tachometers,
+      );
+      cy.waitForGetResultsApi(
+        tachometersResponse.response,
+        tachometersResponse.key,
+      );
+      cy.dataCy('results-tachometers-section').should('be.visible');
+      // verify link
+      cy.dataCy('results-tachometers-link-open-in-new-tab')
+        .should('be.visible')
+        .and('have.class', 'text-primary')
+        .and('have.attr', 'target', '_blank')
+        .and('have.attr', 'href', tachometersResponse.response.data_report_url)
+        .and('contain', i18n.global.t('results.linkOpenResultsInNewTab'));
+      // verify iframe
+      cy.dataCy('results-tachometers-iframe').should(
+        'have.attr',
+        'src',
+        tachometersResponse.response.data_report_url,
+      );
+    });
+  });
+
   context('results page when user is organization admin and staff', () => {
     beforeEach(() => {
       cy.wrap(useRegisterChallengeStore()).then((registerChallengeStore) => {
@@ -279,6 +307,10 @@ describe('<ResultsTabs>', () => {
             resultsResponse.response,
             resultsResponse.key,
           );
+          // tachometers are shown above tabs, skip
+          if (resultsResponse.key === ResultsReportType.tachometers) {
+            return;
+          }
           cy.dataCy(`results-tab-${resultsResponse.key}`)
             .should('be.visible')
             .click({ force: true });

--- a/src/components/__tests__/ResultsTachometersReport.cy.js
+++ b/src/components/__tests__/ResultsTachometersReport.cy.js
@@ -1,8 +1,6 @@
 import ResultsTachometersReport from 'components/results/ResultsTachometersReport.vue';
 import { i18n } from '../../boot/i18n';
-
-const testSrc =
-  'https://metabase.dopracenakole.net/public/question/tachometers-placeholder';
+import { ResultsReportType } from 'src/components/enums/Results';
 
 describe('<ResultsTachometersReport>', () => {
   it('has translation for all strings', () => {
@@ -14,17 +12,27 @@ describe('<ResultsTachometersReport>', () => {
   });
 
   it('shows section with link and iframe when src is provided', () => {
-    cy.mount(ResultsTachometersReport, {
-      props: { src: testSrc },
+    cy.fixture('apiGetResultsResponses').then((resultsResponses) => {
+      const tachometersResponse = resultsResponses.find(
+        (resultsResponse) =>
+          resultsResponse.key === ResultsReportType.tachometers,
+      );
+      cy.mount(ResultsTachometersReport, {
+        props: { src: tachometersResponse.response.data_report_url },
+      });
+      cy.dataCy('results-tachometers-section').should('be.visible');
+      cy.dataCy('results-tachometers-link-open-in-new-tab')
+        .should('be.visible')
+        .and('have.class', 'text-primary')
+        .and('have.attr', 'target', '_blank')
+        .and('have.attr', 'href', tachometersResponse.response.data_report_url)
+        .and('contain', i18n.global.t('results.linkOpenResultsInNewTab'));
+      cy.dataCy('results-tachometers-iframe').should(
+        'have.attr',
+        'src',
+        tachometersResponse.response.data_report_url,
+      );
     });
-    cy.dataCy('results-tachometers-section').should('be.visible');
-    cy.dataCy('results-tachometers-link-open-in-new-tab')
-      .should('be.visible')
-      .and('have.class', 'text-primary')
-      .and('have.attr', 'target', '_blank')
-      .and('have.attr', 'href', testSrc)
-      .and('contain', i18n.global.t('results.linkOpenResultsInNewTab'));
-    cy.dataCy('results-tachometers-iframe').should('have.attr', 'src', testSrc);
   });
 
   it('hides section when src is not provided', () => {

--- a/src/components/__tests__/ResultsTachometersReport.cy.js
+++ b/src/components/__tests__/ResultsTachometersReport.cy.js
@@ -1,0 +1,36 @@
+import ResultsTachometersReport from 'components/results/ResultsTachometersReport.vue';
+import { i18n } from '../../boot/i18n';
+
+const testSrc =
+  'https://metabase.dopracenakole.net/public/question/tachometers-placeholder';
+
+describe('<ResultsTachometersReport>', () => {
+  it('has translation for all strings', () => {
+    cy.testLanguageStringsInContext(
+      ['linkOpenResultsInNewTab'],
+      'results',
+      i18n,
+    );
+  });
+
+  it('shows section with link and iframe when src is provided', () => {
+    cy.mount(ResultsTachometersReport, {
+      props: { src: testSrc },
+    });
+    cy.dataCy('results-tachometers-section').should('be.visible');
+    cy.dataCy('results-tachometers-link-open-in-new-tab')
+      .should('be.visible')
+      .and('have.class', 'text-primary')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'href', testSrc)
+      .and('contain', i18n.global.t('results.linkOpenResultsInNewTab'));
+    cy.dataCy('results-tachometers-iframe').should('have.attr', 'src', testSrc);
+  });
+
+  it('hides section when src is not provided', () => {
+    cy.mount(ResultsTachometersReport, {
+      props: { src: '' },
+    });
+    cy.dataCy('results-tachometers-section').should('not.exist');
+  });
+});

--- a/src/components/enums/Results.ts
+++ b/src/components/enums/Results.ts
@@ -1,4 +1,5 @@
 export enum ResultsReportType {
+  tachometers = 'tachometers',
   regularity = 'regularity',
   teamRegularityCity = 'team-regularity-city',
   performanceCity = 'performance-city',

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -11,6 +11,9 @@
 // libraries
 import { computed, defineComponent, onMounted, ref } from 'vue';
 
+// components
+import ResultsTachometersReport from 'src/components/results/ResultsTachometersReport.vue';
+
 // config
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
@@ -25,6 +28,9 @@ import { useResultsStore } from 'src/stores/results';
 
 export default defineComponent({
   name: 'ResultsTabs',
+  components: {
+    ResultsTachometersReport,
+  },
   setup() {
     const resultsStore = useResultsStore();
     const { challengeMonth, dataReportIframeHeight } = rideToWorkByBikeConfig;
@@ -79,29 +85,10 @@ export default defineComponent({
 <template>
   <div data-cy="results-tabs">
     <!-- Section: Tachometers report (above tabs) -->
-    <div
-      v-if="getResultsUrl(ResultsReportType.tachometers)"
-      class="q-pa-md"
-      data-cy="results-tachometers-section"
-    >
-      <div class="text-right q-mt-sm q-mb-md">
-        <a
-          :href="getResultsUrl(ResultsReportType.tachometers)"
-          target="_blank"
-          class="text-primary"
-          data-cy="results-tachometers-link-open-in-new-tab"
-        >
-          {{ $t('results.linkOpenResultsInNewTab') }}
-        </a>
-      </div>
-      <iframe
-        class="full-width"
-        style="height: 560px"
-        :src="getResultsUrl(ResultsReportType.tachometers)"
-        frameBorder="0"
-        data-cy="results-tachometers-iframe"
-      />
-    </div>
+    <results-tachometers-report
+      :src="getResultsUrl(ResultsReportType.tachometers)"
+      class="q-px-md q-mb-xl"
+    />
     <!-- Tabs: Report types -->
     <q-tabs
       inline-label

--- a/src/components/results/ResultsTabs.vue
+++ b/src/components/results/ResultsTabs.vue
@@ -39,6 +39,11 @@ export default defineComponent({
     });
 
     const resultsUrls = computed(() => resultsStore.getAvailableReportTypes);
+    const reportTypeTabs = computed(() =>
+      resultsUrls.value.filter(
+        (reportType) => reportType !== ResultsReportType.tachometers,
+      ),
+    );
 
     const activeTab = ref<ResultsReportType | ResultsReportTypeByChallenge>(
       challengeMonth === 'may'
@@ -62,6 +67,8 @@ export default defineComponent({
       activeTab,
       dataReportIframeHeight,
       resultsUrls,
+      reportTypeTabs,
+      ResultsReportType,
       getReportTypeLabel,
       getResultsUrl,
     };
@@ -71,6 +78,30 @@ export default defineComponent({
 
 <template>
   <div data-cy="results-tabs">
+    <!-- Section: Tachometers report (above tabs) -->
+    <div
+      v-if="getResultsUrl(ResultsReportType.tachometers)"
+      class="q-pa-md"
+      data-cy="results-tachometers-section"
+    >
+      <div class="text-right q-mt-sm q-mb-md">
+        <a
+          :href="getResultsUrl(ResultsReportType.tachometers)"
+          target="_blank"
+          class="text-primary"
+          data-cy="results-tachometers-link-open-in-new-tab"
+        >
+          {{ $t('results.linkOpenResultsInNewTab') }}
+        </a>
+      </div>
+      <iframe
+        class="full-width"
+        style="height: 560px"
+        :src="getResultsUrl(ResultsReportType.tachometers)"
+        frameBorder="0"
+        data-cy="results-tachometers-iframe"
+      />
+    </div>
     <!-- Tabs: Report types -->
     <q-tabs
       inline-label
@@ -82,7 +113,7 @@ export default defineComponent({
       data-cy="results-tabs-buttons"
     >
       <q-tab
-        v-for="reportType in resultsUrls"
+        v-for="reportType in reportTypeTabs"
         :key="reportType"
         :name="reportType"
         :label="getReportTypeLabel(reportType)"
@@ -94,7 +125,7 @@ export default defineComponent({
     <!-- Tab panels: Report types -->
     <q-tab-panels v-model="activeTab" animated>
       <q-tab-panel
-        v-for="reportType in resultsUrls"
+        v-for="reportType in reportTypeTabs"
         :key="reportType"
         :name="reportType"
         :data-cy="`results-tab-panel-${reportType}`"

--- a/src/components/results/ResultsTachometersReport.vue
+++ b/src/components/results/ResultsTachometersReport.vue
@@ -1,0 +1,49 @@
+<script lang="ts">
+/**
+ * ResultsTachometersReport Component
+ *
+ * @description * Use this component to display the tachometers Metabase report.
+ * The section is hidden when `src` is empty.
+ *
+ * @props
+ * - `src` (String, required): The Metabase embed URL
+ *
+ * @example
+ * <results-tachometers-report :src="tachometersUrl" />
+ */
+
+// libraries
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ResultsTachometersReport',
+  props: {
+    src: {
+      type: String,
+      required: true,
+    },
+  },
+});
+</script>
+
+<template>
+  <div v-if="src" data-cy="results-tachometers-section">
+    <div class="text-right q-mt-sm q-mb-md">
+      <a
+        :href="src"
+        target="_blank"
+        class="text-primary"
+        data-cy="results-tachometers-link-open-in-new-tab"
+      >
+        {{ $t('results.linkOpenResultsInNewTab') }}
+      </a>
+    </div>
+    <iframe
+      class="full-width"
+      style="height: 560px"
+      :src="src"
+      frameBorder="0"
+      data-cy="results-tachometers-iframe"
+    />
+  </div>
+</template>

--- a/src/i18n/cs.toml
+++ b/src/i18n/cs.toml
@@ -1161,6 +1161,7 @@ tabPerformance = "Výkonnost"
 tabReport = "Data report"
 
 [results.reportType]
+tachometers = "Tachometry"
 may = "Květnová výzva"
 cityCoordinator = "Report městského koordinátora"
 organizationCoordinator = "Datový report koordinátora"

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -1160,6 +1160,7 @@ tabPerformance = "Performance"
 tabReport = "Data report"
 
 [results.reportType]
+tachometers = "Tachometers"
 may = "May Challenge"
 cityCoordinator = "City Coordinator Report"
 organizationCoordinator = "Coordinator Data Report"

--- a/src/i18n/sk.toml
+++ b/src/i18n/sk.toml
@@ -1160,6 +1160,7 @@ tabPerformance = "Výkonnosť"
 tabReport = "Data report"
 
 [results.reportType]
+tachometers = "Tachometry"
 may = "Májová výzva"
 cityCoordinator = "Report mestského koordinátora"
 organizationCoordinator = "Dátový report koordinátora"

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -37,6 +37,7 @@
         />
         <!-- Section: Tachometers report -->
         <results-tachometers-report
+          v-if="isResultsPhase"
           :src="tachometersUrl"
           class="q-my-xl"
           data-cy="index-tachometers-report"
@@ -200,6 +201,7 @@ import { useAdminCompetitionStore } from '../stores/adminCompetition';
 
 // types
 import type { Logger } from '../components/types/Logger';
+import { PhaseType } from '../components/types/Challenge';
 
 export default defineComponent({
   name: 'IndexPage',
@@ -243,6 +245,9 @@ export default defineComponent({
 
     const challengeStore = useChallengeStore();
     const challengeStatus = challengeStore.getChallengeStatus;
+    const isResultsPhase = computed(() =>
+      challengeStore.getIsChallengeInPhase(PhaseType.results),
+    );
 
     const cardsFollow = listCardsFollow;
     const cardsPost = listCardsPost;
@@ -341,6 +346,7 @@ export default defineComponent({
       isSectionEventsEnabled,
       isSectionOffersEnabled,
       isSectionPostsEnabled,
+      isResultsPhase,
       tachometersUrl,
     };
   },

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -35,6 +35,12 @@
           class="q-my-xl"
           data-cy="banner-app"
         />
+        <!-- Section: Tachometers report -->
+        <results-tachometers-report
+          :src="tachometersUrl"
+          class="q-my-xl"
+          data-cy="index-tachometers-report"
+        />
         <list-challenges />
         <!-- Section: Future challenges -->
         <template
@@ -147,6 +153,7 @@ import { feedAdapter } from '../adapters/feedAdapter';
 
 // components
 import BannerApp from 'components/homepage/BannerApp.vue';
+import ResultsTachometersReport from 'src/components/results/ResultsTachometersReport.vue';
 import BannerImage from 'components/homepage/BannerImage.vue';
 import BannerRoutes from 'components/homepage/BannerRoutes.vue';
 import BannerTeamMemberApprove from 'components/global/BannerTeamMemberApprove.vue';
@@ -174,6 +181,7 @@ import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 
 // enums
 import { ChallengeStatus as ChallengeStatusEnum } from 'src/components/enums/Challenge';
+import { ResultsReportType } from 'src/components/enums/Results';
 
 // fixtures
 import listCardsFollow from '../../test/cypress/fixtures/listCardsFollow.json';
@@ -186,6 +194,7 @@ import * as homepage from '../mocks/homepage';
 // stores
 import { useChallengeStore } from 'src/stores/challenge';
 import { useRegisterChallengeStore } from 'src/stores/registerChallenge';
+import { useResultsStore } from 'src/stores/results';
 import { useFeedStore } from '../stores/feed';
 import { useAdminCompetitionStore } from '../stores/adminCompetition';
 
@@ -196,6 +205,7 @@ export default defineComponent({
   name: 'IndexPage',
   components: {
     BannerApp,
+    ResultsTachometersReport,
     BannerImage,
     BannerRoutes,
     BannerTeamMemberApprove,
@@ -217,6 +227,7 @@ export default defineComponent({
   setup() {
     const logger = inject('vuejs3-logger') as Logger | null;
     const registerChallengeStore = useRegisterChallengeStore();
+    const resultsStore = useResultsStore();
     const feedStore = useFeedStore();
     const isLoadingPosts = computed(() => feedStore.getIsLoading);
 
@@ -238,6 +249,11 @@ export default defineComponent({
 
     const urlCommunity = routesConf['community']['path'];
     const urlResults = routesConf['results']['path'];
+    const tachometersUrl = computed(
+      () =>
+        resultsStore.getResultsUrl(ResultsReportType.tachometers)
+          ?.data_report_url ?? '',
+    );
 
     const cardsOffer = computed(() =>
       feedAdapter.toCardOffer(feedStore.getPostsOffer),
@@ -274,6 +290,7 @@ export default defineComponent({
       if (!adminCompetitionStore.getCompetitions?.length) {
         await adminCompetitionStore.loadCompetitions();
       }
+      resultsStore.loadTachometersUrl();
     });
 
     const {
@@ -324,6 +341,7 @@ export default defineComponent({
       isSectionEventsEnabled,
       isSectionOffersEnabled,
       isSectionPostsEnabled,
+      tachometersUrl,
     };
   },
 });

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -223,6 +223,23 @@ export const useResultsStore = defineStore('results', {
     },
 
     /**
+     * Load tachometers results URL
+     * Used by homepage to only load tachometers
+     * @returns {Promise<void>}
+     */
+    async loadTachometersUrl(): Promise<void> {
+      // skip if loaded
+      if (this.resultsUrls[ResultsReportType.tachometers]) {
+        return;
+      }
+      this.isLoading = true;
+      const { load: loadResults } = useApiGetResults(this.$log);
+      const response = await loadResults(ResultsReportType.tachometers);
+      this.resultsUrls[ResultsReportType.tachometers] = response;
+      this.isLoading = false;
+    },
+
+    /**
      * Load organization coordinator results URL
      * Used by coordinator results tab to load only specific URLs needed
      * @returns {Promise<void>}

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -49,6 +49,9 @@ export const useResultsStore = defineStore('results', {
         ResultsReportType | ResultsReportTypeByChallenge,
         string
       > = {
+        [ResultsReportType.tachometers]: i18n.global.t(
+          'results.reportType.tachometers',
+        ),
         [ResultsReportType.regularity]: i18n.global.t(
           'results.reportType.regularity',
         ),
@@ -131,6 +134,7 @@ export const useResultsStore = defineStore('results', {
         const reportTypesPerRole = new Set<ResultsReportType>();
         // Basic challenge member (default)
         [
+          ResultsReportType.tachometers,
           ResultsReportType.regularity,
           ResultsReportType.teamRegularityCity,
           ResultsReportType.performanceCity,

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -1,5 +1,6 @@
 import {
   systemTimeRegistrationPhaseInactive,
+  systemTimeChallengeActive,
   systemTimeBeforeCompetitionStart,
   systemTimeBeforeEntryPhaseEnd,
   failOnStatusCode,
@@ -948,6 +949,95 @@ describe('Home page', () => {
         // verify redirect to #/routes URL
         cy.url().should('include', routesConf['routes'].children.fullPath);
       });
+    });
+  });
+
+  context('tachometers report during results phase', () => {
+    beforeEach(() => {
+      cy.clock(systemTimeChallengeActive, ['Date']);
+      cy.get('@config').then((config) => {
+        cy.interceptThisCampaignGetApi(config, defLocale);
+        cy.fixture('apiGetRegisterChallengeIndividualPaidCompleteStaff').then(
+          (responseRegisterChallenge) => {
+            cy.interceptRegisterChallengeGetApi(
+              config,
+              defLocale,
+              responseRegisterChallenge,
+            );
+          },
+        );
+        cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+          (response) => {
+            cy.interceptIsUserOrganizationAdminGetApi(
+              config,
+              defLocale,
+              response,
+            );
+          },
+        );
+        cy.fixture('apiGetResultsResponses').then((resultsResponses) => {
+          const tachometersResponse = resultsResponses.find(
+            (resultsResponse) => resultsResponse.key === 'tachometers',
+          );
+          cy.interceptGetResultsApi(
+            config,
+            defLocale,
+            tachometersResponse.key,
+            tachometersResponse.response,
+          );
+        });
+      });
+      cy.visit(Cypress.config('baseUrl'));
+      cy.waitForThisCampaignApi();
+    });
+
+    it('shows tachometers report on homepage', () => {
+      cy.waitForGetResultsApi(
+        {
+          data_report_url:
+            'https://metabase.dopracenakole.net/public/question/tachometers-placeholder',
+        },
+        'tachometers',
+      );
+      cy.dataCy('index-tachometers-report').should('be.visible');
+      cy.dataCy('results-tachometers-iframe').should(
+        'have.attr',
+        'src',
+        'https://metabase.dopracenakole.net/public/question/tachometers-placeholder',
+      );
+    });
+  });
+
+  context('tachometers report outside results phase', () => {
+    beforeEach(() => {
+      cy.clock(systemTimeRegistrationPhaseInactive, ['Date']);
+      cy.get('@config').then((config) => {
+        cy.interceptThisCampaignGetApi(config, defLocale);
+        cy.fixture('apiGetRegisterChallengeIndividualPaidCompleteStaff').then(
+          (responseRegisterChallenge) => {
+            cy.interceptRegisterChallengeGetApi(
+              config,
+              defLocale,
+              responseRegisterChallenge,
+            );
+          },
+        );
+        cy.fixture('apiGetIsUserOrganizationAdminResponseFalse').then(
+          (response) => {
+            cy.interceptIsUserOrganizationAdminGetApi(
+              config,
+              defLocale,
+              response,
+            );
+          },
+        );
+      });
+      cy.visit(Cypress.config('baseUrl'));
+      cy.waitForThisCampaignApi();
+    });
+
+    it('does not show tachometers report on homepage', () => {
+      cy.dataCy('index-tachometers-report').should('not.exist');
     });
   });
 

--- a/test/cypress/e2e/home.spec.cy.js
+++ b/test/cypress/e2e/home.spec.cy.js
@@ -992,19 +992,24 @@ describe('Home page', () => {
     });
 
     it('shows tachometers report on homepage', () => {
-      cy.waitForGetResultsApi(
-        {
-          data_report_url:
-            'https://metabase.dopracenakole.net/public/question/tachometers-placeholder',
-        },
-        'tachometers',
-      );
-      cy.dataCy('index-tachometers-report').should('be.visible');
-      cy.dataCy('results-tachometers-iframe').should(
-        'have.attr',
-        'src',
-        'https://metabase.dopracenakole.net/public/question/tachometers-placeholder',
-      );
+      cy.fixture('apiGetResultsResponses').then((resultsResponses) => {
+        const tachometersResponse = resultsResponses.find(
+          (resultsResponse) => resultsResponse.key === 'tachometers',
+        );
+
+        cy.waitForGetResultsApi(
+          {
+            data_report_url: tachometersResponse.response.data_report_url,
+          },
+          tachometersResponse.key,
+        );
+        cy.dataCy('index-tachometers-report').should('be.visible');
+        cy.dataCy('results-tachometers-iframe').should(
+          'have.attr',
+          'src',
+          tachometersResponse.response.data_report_url,
+        );
+      });
     });
   });
 

--- a/test/cypress/fixtures/apiGetResultsResponses.json
+++ b/test/cypress/fixtures/apiGetResultsResponses.json
@@ -1,5 +1,11 @@
 [
   {
+    "key": "tachometers",
+    "response": {
+      "data_report_url": "https://metabase.dopracenakole.net/public/question/tachometers-placeholder"
+    }
+  },
+  {
     "key": "regularity",
     "response": {
       "data_report_url": "https://metabase.dopracenakole.net/public/question/11d87a37-c391-45fd-8f97-dd2c52b869bc"

--- a/test/cypress/fixtures/apiGetResultsResponses.json
+++ b/test/cypress/fixtures/apiGetResultsResponses.json
@@ -2,7 +2,7 @@
   {
     "key": "tachometers",
     "response": {
-      "data_report_url": "https://metabase.dopracenakole.net/public/question/tachometers-placeholder"
+      "data_report_url": "https://metabase.dopracenakole.net/public/dashboard/7f73ee3b-215d-4dac-bb08-5ec9855b2f73"
     }
   },
   {

--- a/test/cypress/fixtures/apiGetThisCampaign.json
+++ b/test/cypress/fixtures/apiGetThisCampaign.json
@@ -29,6 +29,11 @@
           "phase_type": "invoices",
           "date_from": "2024-07-15",
           "date_to": "2024-10-07"
+        },
+        {
+          "phase_type": "results",
+          "date_from": "2024-09-16",
+          "date_to": "2024-10-07"
         }
       ],
       "price_level": [


### PR DESCRIPTION
Add tachometers results to Results page and Homepage.

* Add component `ResultsTachometersReport`.
* Show component on results page and homepage.
* Add individual load method for the tachometer results for homepage.

Note: extends default campaign fixture with results phase data.

[Jira: AM-56](https://automatno.atlassian.net/browse/AM-56)