### PR TITLE
test/cypress/support: fix TabCoordinatorInvoices test by adding event bus to support component file

### DIFF
--- a/src/boot/bus.ts
+++ b/src/boot/bus.ts
@@ -1,7 +1,8 @@
 import { EventBus } from 'quasar';
 import { boot } from 'quasar/wrappers';
 
+export const bus = new EventBus();
+
 export default boot(({ app }) => {
-  const bus = new EventBus();
   app.provide('bus', bus);
 });

--- a/test/cypress/support/component.js
+++ b/test/cypress/support/component.js
@@ -83,6 +83,7 @@ import { register } from 'swiper/element/bundle';
 
 import { options as loggerOptions } from '../../../src/boot/logger';
 import { i18n as i18nApp } from '../../../src/boot/i18n';
+import { bus } from '../../../src/boot/bus';
 // Import Vue router
 import route from '../../../src/router';
 import { initVars } from 'src/boot/global_vars';
@@ -112,6 +113,7 @@ Cypress.Commands.add('mount', (component, options = {}) => {
       app.use(VuePlugin);
       app.use(createPinia());
       app.use(OpenLayersMap);
+      app.provide('bus', bus);
     },
   });
 


### PR DESCRIPTION
Fix `TabCoordinatorInvoices` test by providing the event bus to support component file.