### PR TITLE
src/components/__tests__: fix FormFieldSelectTable by handling the different address checkbox

### DIFF
--- a/src/components/__tests__/FormFieldSelectTable.cy.js
+++ b/src/components/__tests__/FormFieldSelectTable.cy.js
@@ -289,6 +289,8 @@ describe('<FormFieldSelectTable>', () => {
             .find('input')
             .type(formFieldCompanyCreateRequest.address.zip);
           // subsidiary details
+          cy.dataCy('form-add-subsidiary-street').should('not.exist');
+          cy.dataCy('form-add-company-checkbox-different-address').click();
           cy.dataCy('form-add-subsidiary-street').find('input').type('Slezská');
           cy.dataCy('form-add-subsidiary-house-number')
             .find('input')
@@ -360,6 +362,8 @@ describe('<FormFieldSelectTable>', () => {
               cy.dataCy('form-add-company-vat-id')
                 .find('input')
                 .should('have.value', '');
+              cy.dataCy('form-add-subsidiary-street').should('not.exist');
+              cy.dataCy('form-add-company-checkbox-different-address').click();
               cy.dataCy('form-add-subsidiary-street')
                 .find('input')
                 .should('have.value', '');


### PR DESCRIPTION
Issue: `FormFieldSelectTable` does not correctly handle the checkbox that controls the visibility of subsidiary address fields (if not the same as billing address).

Solution: Check the checkbox before completing the rest of the form.