### PR TITLE
src/stores: fix user display name data for TableFeeApproval

### DIFF
--- a/src/stores/adminOrganisation.ts
+++ b/src/stores/adminOrganisation.ts
@@ -347,7 +347,7 @@ export const useAdminOrganisationStore = defineStore('adminOrganisation', {
         ): TableFeeApprovalRow => {
           return {
             id: member.id,
-            name: member.name,
+            name: member.name_for_trusted,
             reward: member.is_payment_with_reward,
             email: member.email,
             nickname: member.nickname,

--- a/test/cypress/fixtures/tableFeeApprovalTestData.json
+++ b/test/cypress/fixtures/tableFeeApprovalTestData.json
@@ -154,7 +154,7 @@
   "displayData": {
     "nonApprovedMembers": [
       {
-        "name": "Karel Dvořák",
+        "name": "Karel Dvořák (kdvorak)",
         "email": "karel.dvorak@cerny.cz",
         "nickname": "kdvorak",
         "amount": 380,
@@ -163,7 +163,7 @@
         "reward": false
       },
       {
-        "name": "Jan Novák",
+        "name": "Jan Novák (jnovak)",
         "email": "jan.novak@cerny.cz",
         "nickname": "jnovak",
         "amount": 430,
@@ -174,7 +174,7 @@
     ],
     "approvedMembers": [
       {
-        "name": "Jan Šťastný",
+        "name": "Jan Šťastný (jstastny)",
         "email": "jan.stastny@cerny.cz",
         "nickname": "jstastny",
         "amount": 380,
@@ -183,7 +183,7 @@
         "reward": false
       },
       {
-        "name": "Anna Nováková",
+        "name": "Anna Nováková (anovakova)",
         "email": "anna.novakova@cerny.cz",
         "nickname": "anovakova",
         "amount": 1000,


### PR DESCRIPTION
Update user display name data for `TableFeeApproval`.

Show `name_for_trusted` instead of `name` - this is needed because nickname overrides full name in the `name` field.

Requirement discussed on Slack.