### PR TITLE
src/components/routes: fix select option translation in route logging panel

### DIFF
--- a/src/components/__tests__/RouteInputDistance.cy.js
+++ b/src/components/__tests__/RouteInputDistance.cy.js
@@ -55,6 +55,7 @@ describe('<RouteInputDistance>', () => {
         'hintUploadFile',
         'labelDistance',
         'labelUploadFile',
+        'labelValidationDistance',
         'messageFileInvalidFormat',
         'messageFileTooLarge',
       ],

--- a/src/components/__tests__/RouteInputDistance.cy.js
+++ b/src/components/__tests__/RouteInputDistance.cy.js
@@ -3,7 +3,7 @@ import RouteInputDistance from 'components/routes/RouteInputDistance.vue';
 import { i18n } from '../../boot/i18n';
 import { rideToWorkByBikeConfig } from 'src/boot/global_vars';
 import { RouteInputType } from '../types/Route';
-import { routeFormFieldOptions } from '../routes/utils';
+import { getRouteFormFieldOptions } from '../routes/utils';
 
 // composables
 const { getPaletteColor } = colors;
@@ -32,7 +32,7 @@ const valueHalf = '0.50';
 const valueEmpty = '';
 const { defaultDistanceZero } = rideToWorkByBikeConfig;
 const optionsAction = [
-  ...routeFormFieldOptions,
+  ...getRouteFormFieldOptions(),
   {
     label: i18n.global.t('routes.actionCopyYesterday'),
     value: RouteInputType.copyYesterday,
@@ -243,7 +243,7 @@ describe('<RouteInputDistance>', () => {
         props: {
           modelAction: RouteInputType.inputNumber,
           modelValue: defaultDistanceZero,
-          optionsAction: routeFormFieldOptions,
+          optionsAction: getRouteFormFieldOptions(),
         },
       });
       cy.viewport('macbook-16');
@@ -252,7 +252,10 @@ describe('<RouteInputDistance>', () => {
     it('renders the number of action options passed in props', () => {
       cy.dataCy(selectorSelectAction).should('be.visible').click();
       cy.get('.q-menu').within(() => {
-        cy.get('.q-item').should('have.length', routeFormFieldOptions.length);
+        cy.get('.q-item').should(
+          'have.length',
+          getRouteFormFieldOptions().length,
+        );
         cy.get('.q-item').should(
           'contain',
           i18n.global.t('routes.actionInputDistance'),

--- a/src/components/__tests__/RouteItemEdit.cy.js
+++ b/src/components/__tests__/RouteItemEdit.cy.js
@@ -16,6 +16,8 @@ describe('<RouteItemEdit>', () => {
       [
         'labelDirectionFromWork',
         'labelDirectionToWork',
+        'logRouterCalendarNumberText',
+        'logRouterPlayVideoBtnLabel',
         'messageCopyNoDistance',
         'messageCopyNoRoute',
       ],

--- a/src/components/__tests__/RouteListEdit.cy.js
+++ b/src/components/__tests__/RouteListEdit.cy.js
@@ -41,7 +41,7 @@ let selectorButtonSave;
 
 describe('<RouteListEdit>', () => {
   it('has translation for all strings', () => {
-    cy.testLanguageStringsInContext([], 'routes', i18n);
+    cy.testLanguageStringsInContext(['buttonSaveChangesCount'], 'routes', i18n);
   });
 
   beforeEach(() => {

--- a/src/components/__tests__/RouteTabs.cy.js
+++ b/src/components/__tests__/RouteTabs.cy.js
@@ -10,7 +10,16 @@ import { systemTimeLoggingRoutes } from '../../../test/cypress/support/commonTes
 describe('<RouteTabs>', () => {
   it('has translation for all strings', () => {
     cy.testLanguageStringsInContext(
-      ['tabCalendar', 'tabList', 'tabMap', 'tabApp'],
+      [
+        'hintAutomaticLoggingNotApproved',
+        'hintManualLoggingNotApproved',
+        'instructionRouteCombination',
+        'instructionRouteLogTimeframe',
+        'tabCalendar',
+        'tabList',
+        'tabMap',
+        'tabApp',
+      ],
       'routes',
       i18n,
     );

--- a/src/components/__tests__/RoutesApps.cy.js
+++ b/src/components/__tests__/RoutesApps.cy.js
@@ -18,6 +18,8 @@ describe('<RoutesApps>', () => {
         'hintManualLogging',
         'titleAutomaticLogging',
         'titleManualLogging',
+        'titleRoutes',
+        'titleRoutesConnectApps',
       ],
       'routes',
       i18n,

--- a/src/components/routes/RouteCalendarPanel.vue
+++ b/src/components/routes/RouteCalendarPanel.vue
@@ -61,7 +61,7 @@ import type { Logger } from '../types/Logger';
 import type { FormOption } from '../types/Form';
 
 // utils
-import { routeFormFieldOptions } from './utils/';
+import { getRouteFormFieldOptions } from './utils/';
 
 export default defineComponent({
   name: 'RouteCalendarPanel',
@@ -98,15 +98,15 @@ export default defineComponent({
       },
     });
 
-    const optionsAction: FormOption[] = [
-      ...routeFormFieldOptions,
+    const optionsAction = computed((): FormOption[] => [
+      ...getRouteFormFieldOptions(),
       /* Disable trace to map action option menu item
       {
         label: i18n.global.t('routes.actionTraceMap'),
         value: RouteInputType.inputMap,
       },
       */
-    ];
+    ]);
 
     // Make props into computed ref so it can be passed as a reactive value.
     const routes = computed(() => props.routes);

--- a/src/components/routes/RouteItemEdit.vue
+++ b/src/components/routes/RouteItemEdit.vue
@@ -51,7 +51,7 @@ import {
 import { useTripsStore } from 'src/stores/trips';
 
 // utils
-import { routeFormFieldOptions } from './utils/';
+import { getRouteFormFieldOptions } from './utils/';
 import { localizedFloatNumStrToFloatNumber } from 'src/utils';
 
 // types
@@ -110,8 +110,8 @@ export default defineComponent({
       urlLogRouteListNumberVideo,
     } = rideToWorkByBikeConfig;
 
-    const optionsAction: FormOption[] = [
-      ...routeFormFieldOptions,
+    const optionsAction = computed((): FormOption[] => [
+      ...getRouteFormFieldOptions(),
       {
         label: i18n.global.t('routes.actionCopyYesterday'),
         value: RouteInputType.copyYesterday,
@@ -122,7 +122,7 @@ export default defineComponent({
         value: RouteInputType.inputMap,
       },
       */
-    ];
+    ]);
 
     const routes = computed<RouteItem[]>(() => [props.route]);
     // create refs from the route object

--- a/src/components/routes/utils/index.ts
+++ b/src/components/routes/utils/index.ts
@@ -3,7 +3,7 @@ import { i18n } from '../../../boot/i18n';
 import { RouteInputType } from '../../types/Route';
 import type { FormOption } from '../../types/Form';
 
-const routeFormFieldOptions: FormOption[] = [
+const getRouteFormFieldOptions = (): FormOption[] => [
   {
     label: i18n.global.t('routes.actionInputDistance'),
     value: RouteInputType.inputNumber,
@@ -14,4 +14,4 @@ const routeFormFieldOptions: FormOption[] = [
   },
 ];
 
-export { routeFormFieldOptions };
+export { getRouteFormFieldOptions };


### PR DESCRIPTION
Fix select option translation in route logging panel.

* Switch to computed array of options to update on language change.
* Add missing translation keys to tests.

[Jira: AM-395](https://automatno.atlassian.net/browse/AM-395)