### PR TITLE
src/components/coordinator: disable coordinator's with reward checkboxes when merch is not available

### DIFF
--- a/public/icons/table_fee_approval/icons.svg
+++ b/public/icons/table_fee_approval/icons.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="lucide:triangle-alert" viewBox="0 0 24 24">
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+      stroke-width="2"
+      d="m21.73 18l-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3M12 9v4m0 4h.01" />
+  </symbol>
+</svg>

--- a/src/components/__tests__/TableFeeApproval.cy.js
+++ b/src/components/__tests__/TableFeeApproval.cy.js
@@ -749,7 +749,7 @@ describe('<TableFeeApproval>', () => {
   });
 
   context('merchandise unavailable', () => {
-    it('shows banner and disables reward checkbox in non-approved table when merch is unavailable', () => {
+    it('shows banner and disables reward checkbox when merch not available', () => {
       setActivePinia(createPinia());
       cy.mount(TableFeeApproval, {
         props: { approved: false },

--- a/src/components/__tests__/TableFeeApproval.cy.js
+++ b/src/components/__tests__/TableFeeApproval.cy.js
@@ -4,6 +4,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import TableFeeApproval from 'components/coordinator/TableFeeApproval.vue';
 import { i18n } from '../../boot/i18n';
 import { useAdminOrganisationStore } from '../../stores/adminOrganisation';
+import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 import testData from '../../../test/cypress/fixtures/headerOrganizationTestData.json';
 import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { useTable } from 'src/composables/useTable';
@@ -34,6 +35,7 @@ const selectorDisapproveButton = 'table-fee-disapproval-button';
 const selectorDisapproveDialog = 'dialog-disapprove-payments';
 const selectorDisapproveCancel = 'dialog-disapprove-cancel';
 const selectorDisapproveConfirm = 'dialog-disapprove-confirm';
+const selectorMerchUnavailable = 'table-fee-approval-merch-unavailable';
 
 // variables
 const borderRadius = rideToWorkByBikeConfig.borderRadiusCardSmall;
@@ -59,6 +61,11 @@ describe('<TableFeeApproval>', () => {
       'table',
       i18n,
     );
+    cy.testLanguageStringsInContext(
+      ['tooltipMerchNotAvailable'],
+      'register.challenge',
+      i18n,
+    );
   });
 
   context('desktop non-approved variant', () => {
@@ -68,6 +75,7 @@ describe('<TableFeeApproval>', () => {
         props: { approved: false },
       });
       cy.viewport('macbook-16');
+      cy.setMerchandiseCardsStoreState(useRegisterChallengeStore);
     });
 
     testData.forEach((test) => {
@@ -737,6 +745,85 @@ describe('<TableFeeApproval>', () => {
           );
         });
       });
+    });
+  });
+
+  context('merchandise unavailable', () => {
+    it('shows banner and disables reward checkbox in non-approved table when merch is unavailable', () => {
+      setActivePinia(createPinia());
+      cy.mount(TableFeeApproval, {
+        props: { approved: false },
+      });
+      cy.viewport('macbook-16');
+      cy.fixture('tableFeeApprovalTestData').then(
+        (tableFeeApprovalTestData) => {
+          cy.wrap(useAdminOrganisationStore()).then(
+            (adminOrganisationStore) => {
+              adminOrganisationStore.setAdminOrganisations(
+                tableFeeApprovalTestData.storeData,
+              );
+            },
+          );
+          // notification chip
+          cy.dataCy(selectorMerchUnavailable)
+            .should('be.visible')
+            .and(
+              'contain',
+              i18n.global.t('register.challenge.tooltipMerchNotAvailable'),
+            );
+          // reward checkboxes disabled
+          cy.dataCy(selectorTableRewardCheckbox)
+            .should('be.visible')
+            .and('have.class', 'disabled');
+        },
+      );
+    });
+
+    it('does not show merch unavailable banner in approved table', () => {
+      setActivePinia(createPinia());
+      cy.mount(TableFeeApproval, {
+        props: { approved: true },
+      });
+      cy.viewport('macbook-16');
+      cy.fixture('tableFeeApprovalTestData').then(
+        (tableFeeApprovalTestData) => {
+          cy.wrap(useAdminOrganisationStore()).then(
+            (adminOrganisationStore) => {
+              adminOrganisationStore.setAdminOrganisations(
+                tableFeeApprovalTestData.storeData,
+              );
+            },
+          );
+          // notification chip not shown
+          cy.dataCy(selectorMerchUnavailable).should('not.exist');
+        },
+      );
+    });
+
+    it('does not show merch unavailable banner when merch is available', () => {
+      setActivePinia(createPinia());
+      cy.mount(TableFeeApproval, {
+        props: { approved: false },
+      });
+      cy.viewport('macbook-16');
+      cy.fixture('tableFeeApprovalTestData').then(
+        (tableFeeApprovalTestData) => {
+          cy.wrap(useAdminOrganisationStore()).then(
+            (adminOrganisationStore) => {
+              adminOrganisationStore.setAdminOrganisations(
+                tableFeeApprovalTestData.storeData,
+              );
+            },
+          );
+          cy.setMerchandiseCardsStoreState(useRegisterChallengeStore);
+          // notification chip not shown
+          cy.dataCy(selectorMerchUnavailable).should('not.exist');
+          // reward checkboxes enabled
+          cy.dataCy(selectorTableRewardCheckbox)
+            .should('be.visible')
+            .and('not.have.class', 'disabled');
+        },
+      );
     });
   });
 

--- a/src/components/coordinator/TableFeeApproval.vue
+++ b/src/components/coordinator/TableFeeApproval.vue
@@ -189,7 +189,7 @@ export default defineComponent({
 
 <template>
   <div data-cy="table-fee-approval">
-    <!-- Chip: Merch unavailable -->
+    <!-- Chip: Merch is unavailable -->
     <q-chip
       v-if="!approved && !isMerchandiseAvailable"
       color="amber-2"

--- a/src/components/coordinator/TableFeeApproval.vue
+++ b/src/components/coordinator/TableFeeApproval.vue
@@ -40,6 +40,7 @@ import {
 
 // stores
 import { useAdminOrganisationStore } from '../../stores/adminOrganisation';
+import { useRegisterChallengeStore } from '../../stores/registerChallenge';
 
 // types
 import type { TableFeeApprovalRow } from '../../components/types/AdminOrganisation';
@@ -61,6 +62,10 @@ export default defineComponent({
 
   setup(props) {
     const adminOrganisationStore = useAdminOrganisationStore();
+    const registerChallengeStore = useRegisterChallengeStore();
+    const isMerchandiseAvailable = computed<boolean>(
+      () => registerChallengeStore.getIsMerchandiseAvailable,
+    );
     const selected = computed<TableFeeApprovalRow[]>({
       get: () => adminOrganisationStore.getSelectedPaymentsToApprove,
       set: (value) => {
@@ -162,6 +167,7 @@ export default defineComponent({
       feeApprovalData,
       isLoading,
       isLoadingApprovePayments,
+      isMerchandiseAvailable,
       isLoadingDisapprovePayments,
       selected,
       tableRef,
@@ -183,6 +189,17 @@ export default defineComponent({
 
 <template>
   <div data-cy="table-fee-approval">
+    <!-- Chip: Merch unavailable -->
+    <q-chip
+      v-if="!approved && !isMerchandiseAvailable"
+      color="amber-2"
+      text-color="orange-10"
+      icon="svguse:icons/table_fee_approval/icons.svg#lucide:triangle-alert"
+      class="q-mb-md"
+      data-cy="table-fee-approval-merch-unavailable"
+    >
+      {{ $t('register.challenge.tooltipMerchNotAvailable') }}
+    </q-chip>
     <div>
       <!-- Table -->
       <q-table
@@ -265,6 +282,7 @@ export default defineComponent({
               <q-checkbox
                 v-else
                 :model-value="paymentRewards[props.row.id] ?? props.row.reward"
+                :disable="!isMerchandiseAvailable"
                 color="primary"
                 data-cy="table-fee-approval-reward-checkbox"
                 @update:model-value="

--- a/src/pages/CompanyCoordinatorPage.vue
+++ b/src/pages/CompanyCoordinatorPage.vue
@@ -31,6 +31,7 @@ import CoordinatorTabs from '../components/coordinator/CoordinatorTabs.vue';
 import { useAdminOrganisationStore } from '../stores/adminOrganisation';
 import { useAdminCompetitionStore } from '../stores/adminCompetition';
 import { useFeedStore } from '../stores/feed';
+import { useRegisterChallengeStore } from '../stores/registerChallenge';
 
 // utils
 import { getApiBaseUrlWithLang } from '../utils/get_api_base_url_with_lang';
@@ -50,6 +51,7 @@ export default defineComponent({
     const adminOrganisationStore = useAdminOrganisationStore();
     const adminCompetitionStore = useAdminCompetitionStore();
     const feedStore = useFeedStore();
+    const registerChallengeStore = useRegisterChallengeStore();
 
     const urlRideToWorkByBikeOldFrontendDjangoApp = computed(() => {
       return getApiBaseUrlWithLang(
@@ -74,6 +76,9 @@ export default defineComponent({
       }
       if (feedStore.getCities.length === 0) {
         promises.push(feedStore.loadCities());
+      }
+      if (registerChallengeStore.getMerchandiseItems.length === 0) {
+        promises.push(registerChallengeStore.loadMerchandiseToStore(logger));
       }
       await Promise.all(promises);
     });

--- a/test/cypress/fixtures/cardMerch.json
+++ b/test/cypress/fixtures/cardMerch.json
@@ -6,6 +6,7 @@
   "gender": "female",
   "material": "Bavlna",
   "itemIds": [133, 134, 135, 136, 137, 138],
+  "available": true,
   "sizeOptions": [
     {
       "label": "XS",

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -4213,6 +4213,8 @@ Cypress.Commands.add('setupCompanyCoordinatorTest', (config, i18n) => {
   cy.interceptCompetitionGetApi(config, 'apiGetCompetitionResponse.json');
   // commute modes API
   cy.interceptCommuteModeGetApi(config, i18n);
+  // merchandise API
+  cy.interceptMerchandiseGetApi(config, i18n);
   // login and navigate to coordinator fees page
   cy.performAuthenticatedLogin(config, i18n);
 });

--- a/test/cypress/support/commands/store_commands.js
+++ b/test/cypress/support/commands/store_commands.js
@@ -21,3 +21,25 @@ Cypress.Commands.add(
     });
   },
 );
+
+/**
+ * Set merchandise cards value in register challenge store
+ * @param {function} useRegisterChallengeStore - `useRegisterChallengeStore` function
+ *                                                to initialize register challenge store
+ */
+Cypress.Commands.add(
+  'setMerchandiseCardsStoreState',
+  (useRegisterChallengeStore) => {
+    cy.fixture('cardMerch.json').then((card) => {
+      cy.wrap(useRegisterChallengeStore()).then((registerChallengeStore) => {
+        const storedMerchandiseCards = computed(
+          () => registerChallengeStore.getMerchandiseCards,
+        );
+        registerChallengeStore.setMerchandiseCards({ [card.gender]: [card] });
+        cy.wrap(storedMerchandiseCards)
+          .its('value')
+          .should('deep.equal', { [card.gender]: [card] });
+      });
+    });
+  },
+);


### PR DESCRIPTION
* Disable coordinator's "with reward" checkboxes in `TableFeeApproval` when merchandise not available.
* Add notification chip.
* Add component tests.

[Jira: AM-400](https://automatno.atlassian.net/browse/AM-400)