### PR TITLE
src/components/form: skip calling onTrack function when merchandise size variable is null

### DIFF
--- a/src/components/form/FormFieldListMerch.vue
+++ b/src/components/form/FormFieldListMerch.vue
@@ -473,6 +473,7 @@ export default defineComponent({
     watch(selectedSizeTrack, (val) => {
       const size =
         merchandiseItems.value.find((item) => item.id === val) || null;
+      if (!size) return;
       onTrack({
         detail: {
           targetName: 'selectedSize',


### PR DESCRIPTION
Fix onTrack function call with empty variable condition.
Prevent console.log error in component `FormFieldListMerch` by returning early when `size` variable is empty.

This resulted in failing E2E tests `register_challenge`.
