### PR TITLE
src/components: add explicit keys to TableAttendance and TableResults rows

### DIFF
--- a/src/components/coordinator/TableAttendance.vue
+++ b/src/components/coordinator/TableAttendance.vue
@@ -635,6 +635,7 @@ export default defineComponent({
           <!-- Group header -->
           <q-tr
             v-if="props.row.isFirst"
+            :key="`header-${props.row.teamId}`"
             class="bg-primary text-weight-bold text-white"
             data-cy="table-attendance-team-header"
           >
@@ -694,6 +695,7 @@ export default defineComponent({
           <!-- Row -->
           <q-tr
             v-if="!props.row.isEmpty"
+            :key="`row-${props.row.memberId}`"
             :props="props"
             class="text-grey-10"
             data-cy="table-attendance-row"

--- a/src/components/coordinator/TableResults.vue
+++ b/src/components/coordinator/TableResults.vue
@@ -215,6 +215,7 @@ export default defineComponent({
           <!-- Team header row -->
           <q-tr
             v-if="props.row.isFirst"
+            :key="`header-${props.row.teamId}`"
             class="bg-primary text-weight-bold text-white"
             data-cy="table-results-team-header"
           >
@@ -249,6 +250,7 @@ export default defineComponent({
           <!-- Member data row -->
           <q-tr
             v-if="!props.row.isEmpty"
+            :key="`row-${props.row.memberId}`"
             :props="props"
             class="text-grey-10"
             data-cy="table-results-row"


### PR DESCRIPTION
Add explicit keys to `TableAttendance` and `TableResults` rows.
This resolves test issues arising with Quasar upgrade from version "2.18.1" to "2.23.1" in #1518 