### PR TITLE
src/composables: hide "prizes" item in useMenu for september challenge

### DIFF
--- a/src/components/__tests__/DrawerMenu.cy.js
+++ b/src/components/__tests__/DrawerMenu.cy.js
@@ -47,6 +47,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -87,6 +88,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -131,6 +133,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: false,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -184,6 +187,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -255,6 +259,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: false,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -289,6 +294,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {
@@ -323,6 +329,7 @@ describe('DrawerMenu', () => {
           isEntryEnabled: true,
           isResultsEnabled: false,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }),
       ).then((menuTop) => {
         cy.mount(DrawerMenu, {

--- a/src/components/global/MobileBottomPanel.vue
+++ b/src/components/global/MobileBottomPanel.vue
@@ -54,7 +54,8 @@ export default defineComponent({
     const { isEntryEnabled, isResultsEnabled } = useRoutes();
     const { getMenuTop, getMenuBottom } = useMenu();
 
-    const { mobileBottomPanelVisibleItems } = rideToWorkByBikeConfig;
+    const { challengeMonth, mobileBottomPanelVisibleItems } =
+      rideToWorkByBikeConfig;
     const logger = inject('vuejs3-logger') as Logger | null;
 
     const {
@@ -79,6 +80,7 @@ export default defineComponent({
         isEntryEnabled,
         isResultsEnabled,
         getHasOrganizationAdmin,
+        challengeMonth,
       });
     });
     const menuPanel = computed((): Link[] => {

--- a/src/composables/__tests__/useMenu.cy.js
+++ b/src/composables/__tests__/useMenu.cy.js
@@ -1,8 +1,9 @@
 import { useMenu } from '../useMenu';
 
+// composables
 const { getMenuTop } = useMenu();
 
-// test parameters for getMenuTop
+// default params
 const defaultMenuParams = {
   isUserOrganizationAdmin: false,
   isUserStaff: false,
@@ -10,12 +11,13 @@ const defaultMenuParams = {
   isEntryEnabled: true,
   isResultsEnabled: true,
   getHasOrganizationAdmin: true,
+  challengeMonth: 'may',
 };
 
-describe('useMenu composable', () => {
-  describe('getMenuTop - prizes/discounts menu item visibility', () => {
-    context('when challengeMonth is may', () => {
-      it('includes the discounts menu item', () => {
+describe('useMenu', () => {
+  describe('"prizes/discounts" item visibility', () => {
+    context('when challengeMonth is "may"', () => {
+      it('shows "discounts" menu item', () => {
         const menuTop = getMenuTop({
           ...defaultMenuParams,
           challengeMonth: 'may',
@@ -26,8 +28,8 @@ describe('useMenu composable', () => {
       });
     });
 
-    context('when challengeMonth is october', () => {
-      it('includes the discounts menu item', () => {
+    context('when challengeMonth is "october"', () => {
+      it('shows "discounts" menu item', () => {
         const menuTop = getMenuTop({
           ...defaultMenuParams,
           challengeMonth: 'october',
@@ -38,8 +40,8 @@ describe('useMenu composable', () => {
       });
     });
 
-    context('when challengeMonth is january', () => {
-      it('includes the discounts menu item', () => {
+    context('when challengeMonth is "january"', () => {
+      it('shows "discounts" menu item', () => {
         const menuTop = getMenuTop({
           ...defaultMenuParams,
           challengeMonth: 'january',
@@ -50,8 +52,8 @@ describe('useMenu composable', () => {
       });
     });
 
-    context('when challengeMonth is september', () => {
-      it('does NOT include the discounts menu item', () => {
+    context('when challengeMonth is "september"', () => {
+      it('does NOT show "discounts" menu item', () => {
         const menuTop = getMenuTop({
           ...defaultMenuParams,
           challengeMonth: 'september',
@@ -60,20 +62,5 @@ describe('useMenu composable', () => {
         expect(discountsItem).to.not.exist;
       });
     });
-
-    context(
-      'when challengeMonth is not provided (uses default from config)',
-      () => {
-        it('returns menu items (discounts visibility depends on config)', () => {
-          const menuTop = getMenuTop(defaultMenuParams);
-          // verify basic menu structure exists
-          expect(menuTop).to.be.an('array');
-          expect(menuTop.length).to.be.greaterThan(0);
-          // home item should always be present
-          const homeItem = menuTop.find((item) => item.name === 'home');
-          expect(homeItem).to.exist;
-        });
-      },
-    );
   });
 });

--- a/src/composables/__tests__/useMenu.cy.js
+++ b/src/composables/__tests__/useMenu.cy.js
@@ -1,0 +1,79 @@
+import { useMenu } from '../useMenu';
+
+const { getMenuTop } = useMenu();
+
+// test parameters for getMenuTop
+const defaultMenuParams = {
+  isUserOrganizationAdmin: false,
+  isUserStaff: false,
+  urlAdmin: 'http://example.com/admin',
+  isEntryEnabled: true,
+  isResultsEnabled: true,
+  getHasOrganizationAdmin: true,
+};
+
+describe('useMenu composable', () => {
+  describe('getMenuTop - prizes/discounts menu item visibility', () => {
+    context('when challengeMonth is may', () => {
+      it('includes the discounts menu item', () => {
+        const menuTop = getMenuTop({
+          ...defaultMenuParams,
+          challengeMonth: 'may',
+        });
+        const discountsItem = menuTop.find((item) => item.name === 'discounts');
+        expect(discountsItem).to.exist;
+        expect(discountsItem.title).to.equal('discounts');
+      });
+    });
+
+    context('when challengeMonth is october', () => {
+      it('includes the discounts menu item', () => {
+        const menuTop = getMenuTop({
+          ...defaultMenuParams,
+          challengeMonth: 'october',
+        });
+        const discountsItem = menuTop.find((item) => item.name === 'discounts');
+        expect(discountsItem).to.exist;
+        expect(discountsItem.title).to.equal('discounts');
+      });
+    });
+
+    context('when challengeMonth is january', () => {
+      it('includes the discounts menu item', () => {
+        const menuTop = getMenuTop({
+          ...defaultMenuParams,
+          challengeMonth: 'january',
+        });
+        const discountsItem = menuTop.find((item) => item.name === 'discounts');
+        expect(discountsItem).to.exist;
+        expect(discountsItem.title).to.equal('discounts');
+      });
+    });
+
+    context('when challengeMonth is september', () => {
+      it('does NOT include the discounts menu item', () => {
+        const menuTop = getMenuTop({
+          ...defaultMenuParams,
+          challengeMonth: 'september',
+        });
+        const discountsItem = menuTop.find((item) => item.name === 'discounts');
+        expect(discountsItem).to.not.exist;
+      });
+    });
+
+    context(
+      'when challengeMonth is not provided (uses default from config)',
+      () => {
+        it('returns menu items (discounts visibility depends on config)', () => {
+          const menuTop = getMenuTop(defaultMenuParams);
+          // verify basic menu structure exists
+          expect(menuTop).to.be.an('array');
+          expect(menuTop.length).to.be.greaterThan(0);
+          // home item should always be present
+          const homeItem = menuTop.find((item) => item.name === 'home');
+          expect(homeItem).to.exist;
+        });
+      },
+    );
+  });
+});

--- a/src/composables/__tests__/useMenu.cy.js
+++ b/src/composables/__tests__/useMenu.cy.js
@@ -29,14 +29,13 @@ describe('useMenu', () => {
     });
 
     context('when challengeMonth is "october"', () => {
-      it('shows "discounts" menu item', () => {
+      it('does NOT show "discounts" menu item', () => {
         const menuTop = getMenuTop({
           ...defaultMenuParams,
           challengeMonth: 'october',
         });
         const discountsItem = menuTop.find((item) => item.name === 'discounts');
-        expect(discountsItem).to.exist;
-        expect(discountsItem.title).to.equal('discounts');
+        expect(discountsItem).to.not.exist;
       });
     });
 

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -67,8 +67,8 @@ export const useMenu = () => {
       },
     ];
 
-    // prizes/discounts item is hidden for september challenge
-    if (challengeMonth !== 'september') {
+    // prizes/discounts item is hidden for september/october challenge
+    if (challengeMonth !== 'september' && challengeMonth !== 'october') {
       menuTop = [
         ...menuTop,
         {

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -3,7 +3,6 @@ import { unref } from 'vue';
 
 // config
 import { routesConf } from '../router/routes_conf';
-import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // types
 import type { ComputedRef } from 'vue';
@@ -25,7 +24,7 @@ export const useMenu = () => {
    * @param {ComputedRef<boolean | null> | boolean | null}
    *   getHasOrganizationAdmin - Whether the organization has an admin
    * @param {'may' | 'october' | 'september' | 'january'}
-   *   challengeMonth - Challenge month (defaults to config value)
+   *   challengeMonth - Challenge month
    * @returns {Link[]} - Array of top menu items
    */
   const getMenuTop = ({
@@ -35,7 +34,7 @@ export const useMenu = () => {
     isEntryEnabled,
     isResultsEnabled,
     getHasOrganizationAdmin,
-    challengeMonth = rideToWorkByBikeConfig.challengeMonth,
+    challengeMonth,
   }: {
     isUserOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
     isUserStaff: ComputedRef<boolean | null> | boolean | null;
@@ -43,7 +42,7 @@ export const useMenu = () => {
     isEntryEnabled: ComputedRef<boolean | null> | boolean | null;
     isResultsEnabled: ComputedRef<boolean | null> | boolean | null;
     getHasOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
-    challengeMonth?: 'may' | 'october' | 'september' | 'january';
+    challengeMonth: 'may' | 'october' | 'september' | 'january';
   }): Link[] => {
     let menuTop: Link[] = [
       {
@@ -68,7 +67,7 @@ export const useMenu = () => {
       },
     ];
 
-    // prizes/discounts menu item is hidden for september challenge
+    // prizes/discounts item is hidden for september challenge
     if (challengeMonth !== 'september') {
       menuTop = [
         ...menuTop,

--- a/src/composables/useMenu.ts
+++ b/src/composables/useMenu.ts
@@ -3,6 +3,7 @@ import { unref } from 'vue';
 
 // config
 import { routesConf } from '../router/routes_conf';
+import { rideToWorkByBikeConfig } from '../boot/global_vars';
 
 // types
 import type { ComputedRef } from 'vue';
@@ -23,6 +24,8 @@ export const useMenu = () => {
    *   isResultsEnabled - Whether the results are enabled
    * @param {ComputedRef<boolean | null> | boolean | null}
    *   getHasOrganizationAdmin - Whether the organization has an admin
+   * @param {'may' | 'october' | 'september' | 'january'}
+   *   challengeMonth - Challenge month (defaults to config value)
    * @returns {Link[]} - Array of top menu items
    */
   const getMenuTop = ({
@@ -32,6 +35,7 @@ export const useMenu = () => {
     isEntryEnabled,
     isResultsEnabled,
     getHasOrganizationAdmin,
+    challengeMonth = rideToWorkByBikeConfig.challengeMonth,
   }: {
     isUserOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
     isUserStaff: ComputedRef<boolean | null> | boolean | null;
@@ -39,6 +43,7 @@ export const useMenu = () => {
     isEntryEnabled: ComputedRef<boolean | null> | boolean | null;
     isResultsEnabled: ComputedRef<boolean | null> | boolean | null;
     getHasOrganizationAdmin: ComputedRef<boolean | null> | boolean | null;
+    challengeMonth?: 'may' | 'october' | 'september' | 'january';
   }): Link[] => {
     let menuTop: Link[] = [
       {
@@ -61,13 +66,20 @@ export const useMenu = () => {
         title: 'results',
         disabled: !unref(isResultsEnabled),
       },
-      {
-        url: routesConf['prizes']['children']['fullPath'],
-        icon: 'svguse:icons/drawer_menu/icons.svg#lucide-badge-percent',
-        name: 'discounts',
-        title: 'discounts',
-      },
     ];
+
+    // prizes/discounts menu item is hidden for september challenge
+    if (challengeMonth !== 'september') {
+      menuTop = [
+        ...menuTop,
+        {
+          url: routesConf['prizes']['children']['fullPath'],
+          icon: 'svguse:icons/drawer_menu/icons.svg#lucide-badge-percent',
+          name: 'discounts',
+          title: 'discounts',
+        },
+      ];
+    }
 
     const showCoordinatorMenu =
       unref(isUserOrganizationAdmin) ||

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -97,6 +97,7 @@ export default defineComponent({
     const { isEntryEnabled, isResultsEnabled } = useRoutes();
 
     const {
+      challengeMonth,
       urlRideToWorkByBikeOldFrontendDjangoApp,
       urlRideToWorkByBikeOldFrontendDjangoAppAdmin,
     } = rideToWorkByBikeConfig;
@@ -118,6 +119,7 @@ export default defineComponent({
         isEntryEnabled,
         isResultsEnabled,
         getHasOrganizationAdmin,
+        challengeMonth,
       });
     });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2925,6 +2925,7 @@ Cypress.Commands.add(
         isEntryEnabled: true,
         isResultsEnabled: true,
         getHasOrganizationAdmin: true,
+        challengeMonth: 'may',
       }),
     ).then((menuTop) => {
       cy.wrap(getMenuBottom(urlDonate, urlContact)).then((menuBottom) => {

--- a/test/cypress/support/commonTests.ts
+++ b/test/cypress/support/commonTests.ts
@@ -159,6 +159,7 @@ export const testDesktopSidebar = (): void => {
           isEntryEnabled: true,
           isResultsEnabled: true,
           getHasOrganizationAdmin: true,
+          challengeMonth: 'may',
         }).length > 0
       ) {
         cy.dataCy(selectorDrawerMenuTop).should('be.visible');


### PR DESCRIPTION
Hide "prizes" item in useMenu for september challenge.
Pass the `challengeMonth` to `useMenu` as required param. (We cannot use global config directly because it causes test errors.)

Add composable component Cypress test.

[Jira: AM-622](https://automatno.atlassian.net/browse/AM-622)