### PR TITLE
src/components: disable packages tab in coordinator view for september challenge

### DIFF
--- a/src/components/__tests__/CoordinatorTabs.cy.js
+++ b/src/components/__tests__/CoordinatorTabs.cy.js
@@ -1,5 +1,6 @@
 import CoordinatorTabs from 'components/coordinator/CoordinatorTabs.vue';
 import { i18n } from '../../boot/i18n';
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 import { routesConf } from 'src/router/routes_conf';
 
 // selectors
@@ -56,6 +57,64 @@ describe('<CoordinatorTabs>', () => {
     });
 
     coreTests();
+  });
+
+  context('packages tab disabled - september challenge', () => {
+    const originalChallengeMonth = rideToWorkByBikeConfig.challengeMonth;
+
+    beforeEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = 'september';
+      cy.mount(CoordinatorTabs, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    afterEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = originalChallengeMonth;
+    });
+
+    it('packages tab is visible but disabled', () => {
+      cy.dataCy(selectorButtonPackages)
+        .should('be.visible')
+        .and('have.class', 'disabled');
+    });
+
+    it('packages tab does not navigate when clicked', () => {
+      cy.dataCy(selectorButtonTasks).click();
+      cy.dataCy(selectorPanelTasks).should('be.visible');
+      cy.dataCy(selectorButtonPackages).click();
+      // panel should not change - tasks panel still visible
+      cy.dataCy(selectorPanelTasks).should('be.visible');
+      cy.dataCy(selectorPanelPackages).should('not.exist');
+    });
+  });
+
+  context('packages tab enabled - may challenge', () => {
+    const originalChallengeMonth = rideToWorkByBikeConfig.challengeMonth;
+
+    beforeEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = 'may';
+      cy.mount(CoordinatorTabs, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    afterEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = originalChallengeMonth;
+    });
+
+    it('packages tab is visible and enabled', () => {
+      cy.dataCy(selectorButtonPackages)
+        .should('be.visible')
+        .and('not.have.class', 'disabled');
+    });
+
+    it('packages tab navigates when clicked', () => {
+      cy.dataCy(selectorButtonPackages).click();
+      cy.dataCy(selectorPanelPackages).should('be.visible');
+    });
   });
 });
 

--- a/src/components/__tests__/CoordinatorTabs.cy.js
+++ b/src/components/__tests__/CoordinatorTabs.cy.js
@@ -90,6 +90,37 @@ describe('<CoordinatorTabs>', () => {
     });
   });
 
+  context('packages tab disabled - october challenge', () => {
+    const originalChallengeMonth = rideToWorkByBikeConfig.challengeMonth;
+
+    beforeEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = 'october';
+      cy.mount(CoordinatorTabs, {
+        props: {},
+      });
+      cy.viewport('macbook-16');
+    });
+
+    afterEach(() => {
+      rideToWorkByBikeConfig.challengeMonth = originalChallengeMonth;
+    });
+
+    it('packages tab is visible but disabled', () => {
+      cy.dataCy(selectorButtonPackages)
+        .should('be.visible')
+        .and('have.class', 'disabled');
+    });
+
+    it('packages tab does not navigate when clicked', () => {
+      cy.dataCy(selectorButtonTasks).click();
+      cy.dataCy(selectorPanelTasks).should('be.visible');
+      cy.dataCy(selectorButtonPackages).click();
+      // panel should not change - tasks panel still visible
+      cy.dataCy(selectorPanelTasks).should('be.visible');
+      cy.dataCy(selectorPanelPackages).should('not.exist');
+    });
+  });
+
   context('packages tab enabled - may challenge', () => {
     const originalChallengeMonth = rideToWorkByBikeConfig.challengeMonth;
 

--- a/src/components/coordinator/CoordinatorTabs.vue
+++ b/src/components/coordinator/CoordinatorTabs.vue
@@ -74,9 +74,11 @@ export default defineComponent({
     onBeforeUnmount(() => {
       bus.off('request-edit-organization', onEditOrganizationRequested);
     });
-    // september challenge does not have packages
+    // september/october challenge does not have packages
     const isPackagesTabDisabled = computed(
-      () => rideToWorkByBikeConfig.challengeMonth === 'september',
+      () =>
+        rideToWorkByBikeConfig.challengeMonth === 'september' ||
+        rideToWorkByBikeConfig.challengeMonth === 'october',
     );
 
     return {

--- a/src/components/coordinator/CoordinatorTabs.vue
+++ b/src/components/coordinator/CoordinatorTabs.vue
@@ -17,8 +17,11 @@
 
 // libraries
 import { EventBus } from 'quasar';
-import { defineComponent, inject, onBeforeUnmount, ref } from 'vue';
+import { computed, defineComponent, inject, onBeforeUnmount, ref } from 'vue';
 import { useRouter } from 'vue-router';
+
+// config
+import { rideToWorkByBikeConfig } from '../../boot/global_vars';
 
 // components
 import TabCoordinatorAttendance from './TabCoordinatorAttendance.vue';
@@ -71,9 +74,14 @@ export default defineComponent({
     onBeforeUnmount(() => {
       bus.off('request-edit-organization', onEditOrganizationRequested);
     });
+    // september challenge does not have packages
+    const isPackagesTabDisabled = computed(
+      () => rideToWorkByBikeConfig.challengeMonth === 'september',
+    );
 
     return {
       activeTab,
+      isPackagesTabDisabled,
       routesConf,
       tabsCoordinator,
     };
@@ -115,6 +123,7 @@ export default defineComponent({
         :to="routesConf['coordinator_packages'].path"
         :name="tabsCoordinator.packages"
         :label="$t('coordinator.tabPackages')"
+        :disable="isPackagesTabDisabled"
         data-cy="coordinator-tabs-button-packages"
       />
       <q-route-tab


### PR DESCRIPTION
Disable "packages" tab in coordinator view for september challenge.
Add component tests using modified config.

[Jira: AM-623](https://automatno.atlassian.net/browse/AM-623)